### PR TITLE
fix(parser): closure/static-int dims in mesh/split sugar + clear DimVar/bool diagnostics (task #5)

### DIFF
--- a/docs/spec/parser.md
+++ b/docs/spec/parser.md
@@ -149,14 +149,10 @@ axis is `Broadcast` (carries no mesh binding). A **split** extent
 participates in mesh-extent canonicalisation (factorisation), which a
 dynamic extent cannot. A dynamic split extent is rejected.
 
-A `static-extent` — whether a split extent (left of `@`) or a
-**mesh-shape** dim in a mesh's own layout tuple (e.g. `(WARPS, LANES)` in
-`Mesh(Topology("thread", THREADS), (WARPS, LANES), …)`) — may be written as an
-`integer-literal` or a `static-dim-ref`: a closure/global identifier bound to a
-static `int` (e.g. `WARPS = 4`). Both resolve identically. A `bool` is rejected
-even though it subclasses `int`, and a dynamic (`DimVar`) or otherwise non-int
-value in a `static-extent` position is rejected with a `must be a static int`
-diagnostic (never a raw AST or attribute error).
+A `static-extent` (a split extent or a mesh-shape dim) accepts an
+`integer-literal` or a `static-dim-ref` (a closure/global name bound to a static
+int); a `bool` or a dynamic (`DimVar`) / non-int value is rejected with a
+`must be a static int` diagnostic.
 
 A dynamic bare axis is admissible only where `Reshard` materialises strides
 in the **shared-engine** form — a same-storage reshard off a plain (non

--- a/docs/spec/parser.md
+++ b/docs/spec/parser.md
@@ -149,10 +149,9 @@ axis is `Broadcast` (carries no mesh binding). A **split** extent
 participates in mesh-extent canonicalisation (factorisation), which a
 dynamic extent cannot. A dynamic split extent is rejected.
 
-A `static-extent` (a split extent or a mesh-shape dim) accepts an
-`integer-literal` or a `static-dim-ref` (a closure/global name bound to a static
-int); a `bool` or a dynamic (`DimVar`) / non-int value is rejected with a
-`must be a static int` diagnostic.
+Closure/global int resolution applies to mesh-shape dims too; a `bool` or
+dynamic value in a `static-extent` is rejected with a `must be a static int`
+diagnostic.
 
 A dynamic bare axis is admissible only where `Reshard` materialises strides
 in the **shared-engine** form — a same-storage reshard off a plain (non

--- a/docs/spec/parser.md
+++ b/docs/spec/parser.md
@@ -130,9 +130,10 @@ axis-tuple    ::= '(' axis-spec (',' axis-spec)* ','? ')'
 axis-spec     ::= axis-extent                    ; a cute dim, not split (axis placement only)
                 | static-extent '@' mesh-axis    ; Split(axis_index) on mesh-axis
                 | static-extent '@' '(' mesh-axis (',' mesh-axis)* ')'  ; sequential decomposition
-axis-extent   ::= static-extent | dim-ref        ; a bare axis may be dynamic
-static-extent ::= integer-literal                ; split axes must be a static int
-dim-ref       ::= identifier                     ; closure-resolved DimVar (or int); bare axes only
+axis-extent    ::= static-extent | dim-ref        ; a bare axis may be dynamic
+static-extent  ::= integer-literal | static-dim-ref  ; split axes & mesh dims: a static int
+dim-ref        ::= identifier                     ; closure-resolved DimVar (or int); bare axes only
+static-dim-ref ::= identifier                     ; closure/global name bound to a static int (bool rejected)
 stride-tuple  ::= '(' integer-literal (',' integer-literal)* ','? ')'
 value-state   ::= '{' partial-spec (',' partial-spec)* ','? '}'  ; a set; only the last outer item
 partial-spec  ::= mesh-axis '@' 'P(' '"' reduction '"' ')'       ; Partial(reduction) on mesh-axis
@@ -147,6 +148,15 @@ axis is `Broadcast` (carries no mesh binding). A **split** extent
 (`static-extent` on the left of `@`) MUST resolve to a static int: it
 participates in mesh-extent canonicalisation (factorisation), which a
 dynamic extent cannot. A dynamic split extent is rejected.
+
+A `static-extent` — whether a split extent (left of `@`) or a
+**mesh-shape** dim in a mesh's own layout tuple (e.g. `(WARPS, LANES)` in
+`Mesh(Topology("thread", THREADS), (WARPS, LANES), …)`) — may be written as an
+`integer-literal` or a `static-dim-ref`: a closure/global identifier bound to a
+static `int` (e.g. `WARPS = 4`). Both resolve identically. A `bool` is rejected
+even though it subclasses `int`, and a dynamic (`DimVar`) or otherwise non-int
+value in a `static-extent` position is rejected with a `must be a static int`
+diagnostic (never a raw AST or attribute error).
 
 A dynamic bare axis is admissible only where `Reshard` materialises strides
 in the **shared-engine** form — a same-storage reshard off a plain (non

--- a/src/tilefoundry/parser/base.py
+++ b/src/tilefoundry/parser/base.py
@@ -29,6 +29,7 @@ from .dispatch import (
 )
 from .range_slice import RangeSlice
 from .sugar import (
+    LayoutSugarError,
     _is_tuple_sugar,
     parse_layout_sugar,
     parse_shard_layout_sugar,
@@ -688,6 +689,10 @@ class BaseExprVisitor:
             if sugar is not None:
                 try:
                     return sugar(node)
+                except LayoutSugarError:
+                    # Node is recognized layout sugar but malformed — surface the
+                    # real diagnostic instead of masking it with _eval_static.
+                    raise
                 except ValueError:
                     pass
         elif annotation is None and attr_name == "layout" and _is_tuple_sugar(node):
@@ -698,6 +703,8 @@ class BaseExprVisitor:
                     default_mesh=self._current_default_mesh(),
                     closure=self.closure,
                 )
+            except LayoutSugarError:
+                raise
             except ValueError:
                 pass
         value = self._eval_static(node)

--- a/src/tilefoundry/parser/hir_parser.py
+++ b/src/tilefoundry/parser/hir_parser.py
@@ -802,7 +802,7 @@ class _HirBodyVisitor(BaseExprVisitor):
         # kwargs like ``names=("x", "y")`` are plain static tuples.
         def _eval_mesh_arg(arg_node: ast.AST, *, is_layout_slot: bool = True):
             if is_layout_slot and _is_tuple_sugar(arg_node):
-                return parse_mesh_layout_sugar(arg_node)
+                return parse_mesh_layout_sugar(arg_node, closure=self.closure)
             return self._eval_static(arg_node)
 
         def _resolve_string_topology(name: str) -> object:

--- a/src/tilefoundry/parser/sugar.py
+++ b/src/tilefoundry/parser/sugar.py
@@ -203,7 +203,9 @@ def _resolve_mesh_axis(mesh: Mesh, axis_name: str) -> MeshAxis:
 # ── layout literal parser (shared bottom layer) ────────────────────────────
 
 
-def _parse_layout_literal(node: ast.AST) -> tuple[tuple[int, ...], tuple[int, ...] | None]:
+def _parse_layout_literal(
+    node: ast.AST, *, closure: dict[str, Any] | None = None
+) -> tuple[tuple[int, ...], tuple[int, ...] | None]:
     """Parse a tuple AST node into (shape, strides_or_none).
 
     This is the shared bottom layer.  It does NOT choose a final type.
@@ -217,18 +219,21 @@ def _parse_layout_literal(node: ast.AST) -> tuple[tuple[int, ...], tuple[int, ..
     When dim elements contain ``@`` sugar operators, only the left-hand
     int constant is extracted for the shape; axis binding is handled by
     the target-specific lowering (e.g. ``parse_shard_layout_sugar``).
+
+    ``closure`` lets a dim that is a closure/global ``Name`` (e.g. ``WARPS``)
+    resolve to its static int value.
     """
     if isinstance(node, ast.Tuple):
         if len(node.elts) == 2 and isinstance(node.elts[0], ast.Tuple) and isinstance(node.elts[1], ast.Tuple):
             # Full form: ((dims), (strides))
             dim_nodes = list(node.elts[0].elts)
-            strides = _eval_ast(node.elts[1])
-            shape = tuple(_extract_dim_int(dn) for dn in dim_nodes)
+            strides = _eval_ast(node.elts[1], closure)
+            shape = tuple(_extract_dim_int(dn, closure=closure) for dn in dim_nodes)
         else:
             # Short form: (dims)
             dim_nodes = list(node.elts)
             strides = None
-            shape = tuple(_extract_dim_int(dn) for dn in dim_nodes)
+            shape = tuple(_extract_dim_int(dn, closure=closure) for dn in dim_nodes)
     elif _is_constant(node):
         shape = (node.value,)
         strides = None
@@ -249,17 +254,26 @@ def _parse_layout_literal(node: ast.AST) -> tuple[tuple[int, ...], tuple[int, ..
     return shape, strides
 
 
-def _extract_dim_int(node: ast.AST) -> int:
-    """Extract the integer from a layout dim node.
+def _extract_dim_int(node: ast.AST, *, closure: dict[str, Any] | None = None) -> int:
+    """Extract the static-int dimension from a layout dim node.
 
-    Handles: plain ``Constant(32)``, and ``BinOp(Constant(32), MatMult, ...)``
-    sugar forms where only the left operand is the dimension.
+    Handles: plain ``Constant(32)``, closure/global ``Name`` references bound to
+    an ``int`` (e.g. ``WARPS = 4``), and ``BinOp(<dim>, MatMult, ...)`` sugar
+    forms where only the left operand is the dimension. The resolved value MUST
+    be a static ``int``; ``bool`` and dynamic (``DimVar``) extents are rejected
+    with a clear diagnostic rather than a raw AST / attribute error.
     """
-    if _is_constant(node):
-        return node.value
-    if _is_matmul(node) and _is_constant(node.left):
-        return node.left.value
-    raise ValueError(f"expected int dim, got {ast.dump(node)}")
+    dim_node = node.left if _is_matmul(node) else node
+    if _is_constant(dim_node):
+        val = dim_node.value
+    else:
+        try:
+            val = _eval_ast(dim_node, closure)
+        except ValueError:
+            raise ValueError(f"expected int dim, got {ast.dump(node)}") from None
+    if isinstance(val, bool) or not isinstance(val, int):
+        raise ValueError(f"layout dim must be a static int, got {val!r}")
+    return val
 
 
 # ── target-specific sugar parsers ──────────────────────────────────────────
@@ -277,13 +291,18 @@ def parse_layout_sugar(node: ast.AST) -> Layout:
     return Layout(shape=shape, strides=strides)
 
 
-def parse_mesh_layout_sugar(node: ast.AST) -> Layout:
+def parse_mesh_layout_sugar(
+    node: ast.AST, *, closure: dict[str, Any] | None = None
+) -> Layout:
     """Parse a mesh's layout tuple sugar as a ``Layout``.
+
+    ``closure`` lets mesh dims be closure/global ``int`` names (e.g. a
+    ``WARPS = 4`` constant used as ``(WARPS, LANES)``).
 
     >>> parse_mesh_layout_sugar(ast.parse("(128,)", mode="eval").body)
     Layout(shape=(128,), strides=(1,))
     """
-    shape, strides = _parse_layout_literal(node)
+    shape, strides = _parse_layout_literal(node, closure=closure)
     if strides is None:
         strides = _auto_strides(shape)
     return Layout(shape=shape, strides=strides)

--- a/src/tilefoundry/parser/sugar.py
+++ b/src/tilefoundry/parser/sugar.py
@@ -29,6 +29,18 @@ from tilefoundry.ir.types.shard.shard_layout import (
     Split,
 )
 
+
+class LayoutSugarError(ValueError):
+    """A layout-sugar node was recognized structurally but is malformed
+    (e.g. a dynamic ``DimVar`` / ``bool`` static extent).
+
+    It subclasses ``ValueError`` so existing ``except ValueError`` handlers
+    still catch it, but callers that speculatively try sugar parsing (and fall
+    back to generic static evaluation on a plain ``ValueError``) MUST let this
+    propagate so the real diagnostic is not masked by a downstream error.
+    """
+
+
 # ── AST helpers ─────────────────────────────────────────────────────────────
 
 
@@ -272,7 +284,7 @@ def _extract_dim_int(node: ast.AST, *, closure: dict[str, Any] | None = None) ->
         except ValueError:
             raise ValueError(f"expected int dim, got {ast.dump(node)}") from None
     if isinstance(val, bool) or not isinstance(val, int):
-        raise ValueError(f"layout dim must be a static int, got {val!r}")
+        raise LayoutSugarError(f"layout dim must be a static int, got {val!r}")
     return val
 
 
@@ -549,7 +561,7 @@ def _parse_layout_item(
             # canonicalisation (factorisation against the mesh extent), so it
             # must resolve to a static int. A dynamic (DimVar) split axis is
             # not expressible in v1 sugar — only bare axes may be dynamic.
-            raise ValueError(
+            raise LayoutSugarError(
                 f"split layout dim `dim @ mesh.axis` must be a static int, got {dim!r}"
             )
 

--- a/tests/parser/hir/test_parse_shard_sugar.py
+++ b/tests/parser/hir/test_parse_shard_sugar.py
@@ -440,3 +440,82 @@ def test_reshard_sugar_rejects_dynamic_split_axis() -> None:
         parse_shard_layout_sugar(
             node, lambda n: cta if n == "cta" else None, closure={"S": _S_DYN}
         )
+
+
+# ── closure / static-int dims in a mesh-shape sugar (task #5 P1/P2) ───────────
+# These exercise the ``with Mesh(Topology(...), (dims), names)`` body path
+# (`parse_mesh_layout_sugar`), which — unlike the shard/split path above — did
+# not thread the closure and rejected any ``ast.Name`` dim.
+
+
+def _mesh_body_fn(threads, warps, lanes):
+    """Build a nested ``@func`` whose mesh-shape sugar reads its dims from the
+    enclosing closure (``threads``/``warps``/``lanes``)."""
+
+    @func(topologies=(Topology("thread", threads),))
+    def _f(x: Tensor[(1, 128), "bf16"]) -> Tensor[(1, 128), "bf16"]:
+        with Mesh(Topology("thread", threads), (warps, lanes), ("w", "t")) as m:
+            xr = reshard(x, (1, 128 @ (m.w, m.t)), "rmem")  # noqa: F821
+            return reshard(xr, (1, 128), "gmem")  # noqa: F821
+
+    return _f
+
+
+def _mesh_body_literal():
+    """The all-literal equivalent of :func:`_mesh_body_fn` (128, 4, 32)."""
+
+    @func(topologies=(Topology("thread", 128),))
+    def _f(x: Tensor[(1, 128), "bf16"]) -> Tensor[(1, 128), "bf16"]:
+        with Mesh(Topology("thread", 128), (4, 32), ("w", "t")) as m:
+            xr = reshard(x, (1, 128 @ (m.w, m.t)), "rmem")  # noqa: F821
+            return reshard(xr, (1, 128), "gmem")  # noqa: F821
+
+    return _f
+
+
+def test_closure_int_mesh_dims_resolve_like_literals() -> None:
+    """E1: closure/global ints in a mesh-shape sugar (``(WARPS, LANES)`` and the
+    topology extent ``THREADS``) resolve identically to integer literals — the
+    parser must not reject the ``ast.Name``."""
+    assert as_script(_mesh_body_fn(128, 4, 32)) == as_script(_mesh_body_literal())
+
+
+def test_closure_int_split_extent_still_parses() -> None:
+    """E2 (regression lock): a closure int as a split extent already works and
+    must keep working."""
+    k_tile = 128
+
+    @func(topologies=(Topology("thread", 128),))
+    def _f(x: Tensor[(1, 128), "bf16"]) -> Tensor[(1, 128), "bf16"]:
+        with Mesh(Topology("thread", 128), (4, 32), ("w", "t")) as m:
+            xr = reshard(x, (1, k_tile @ (m.w, m.t)), "rmem")  # noqa: F821
+            return reshard(xr, (1, 128), "gmem")  # noqa: F821
+
+    assert _f.name == "_f"
+
+
+def test_dimvar_mesh_dim_reports_static_int() -> None:
+    """E4: a ``DimVar`` in a mesh-shape position is rejected with a clear
+    static-int diagnostic (not a raw ``expected int dim`` / attribute error)."""
+    w = DimVar("W", 1, 8)
+
+    with pytest.raises(ValueError, match="static int"):
+
+        @func(topologies=(Topology("thread", 128),))
+        def _bad(x: Tensor[(1, 128), "bf16"]) -> Tensor[(1, 128), "bf16"]:
+            with Mesh(Topology("thread", 128), (w, 32), ("w", "t")) as m:
+                xr = reshard(x, (1, 128 @ (m.w, m.t)), "rmem")  # noqa: F821
+                return reshard(xr, (1, 128), "gmem")  # noqa: F821
+
+
+def test_bool_mesh_dim_rejected() -> None:
+    """E5: ``bool`` is rejected as a mesh dim even though it subclasses ``int``."""
+    warps = True
+
+    with pytest.raises(ValueError, match="static int"):
+
+        @func(topologies=(Topology("thread", 128),))
+        def _bad(x: Tensor[(1, 128), "bf16"]) -> Tensor[(1, 128), "bf16"]:
+            with Mesh(Topology("thread", 128), (warps, 32), ("w", "t")) as m:
+                xr = reshard(x, (1, 128 @ (m.w, m.t)), "rmem")  # noqa: F821
+                return reshard(xr, (1, 128), "gmem")  # noqa: F821

--- a/tests/parser/hir/test_parse_shard_sugar.py
+++ b/tests/parser/hir/test_parse_shard_sugar.py
@@ -442,123 +442,142 @@ def test_reshard_sugar_rejects_dynamic_split_axis() -> None:
         )
 
 
-# ── closure / static-int dims in a mesh-shape sugar ──────────────────────────
-# These exercise the ``with Mesh(Topology(...), (dims), names)`` body path
-# (`parse_mesh_layout_sugar`): a closure/global int dim resolves like a literal,
-# and a dynamic or bool dim is rejected with a static-int diagnostic.
+# ── static-int dims in mesh / split sugar: closure resolution + diagnostics ───
+# A static-extent (mesh-shape dim or split extent) accepts an int literal or a
+# closure/global int; a bool or dynamic (DimVar) value is rejected with a
+# static-int diagnostic (and the sugar error must surface, not be swallowed into
+# ``'Mesh' object has no attribute ...``). All cases below use the string-
+# topology sugar `Mesh(topology="thread", ...)` referencing the @func-declared
+# topology rather than reconstructing a ``Topology(...)`` in the body.
+
+_MESH_DIM_W = DimVar("W", 1, 8)
+_SPLIT_EXTENT_K = DimVar("K", 32, 256)
 
 
-def _mesh_body_fn(threads, warps, lanes):
-    """Build a nested ``@func`` whose mesh-shape sugar reads its dims from the
-    enclosing closure (``threads``/``warps``/``lanes``)."""
+def _closure_mesh_dims_fn(warps, lanes):
+    """A mesh-shape sugar (`layout=(warps, lanes)`) whose dims come from the
+    enclosing closure."""
 
-    @func(topologies=(Topology("thread", threads),))
+    @func(topologies=(Topology("thread", 128),))
     def _f(x: Tensor[(1, 128), "bf16"]) -> Tensor[(1, 128), "bf16"]:
-        with Mesh(Topology("thread", threads), (warps, lanes), ("w", "t")) as m:
+        with Mesh(topology="thread", layout=(warps, lanes), names=("w", "t")) as m:
             xr = reshard(x, (1, 128 @ (m.w, m.t)), "rmem")  # noqa: F821
             return reshard(xr, (1, 128), "gmem")  # noqa: F821
 
     return _f
 
 
-def _mesh_body_literal():
-    """The all-literal equivalent of :func:`_mesh_body_fn` (128, 4, 32)."""
+def _closure_split_extent_fn(k_tile):
+    """A split extent (`k_tile @ (m.w, m.t)`) taken from the enclosing closure."""
 
     @func(topologies=(Topology("thread", 128),))
     def _f(x: Tensor[(1, 128), "bf16"]) -> Tensor[(1, 128), "bf16"]:
-        with Mesh(Topology("thread", 128), (4, 32), ("w", "t")) as m:
-            xr = reshard(x, (1, 128 @ (m.w, m.t)), "rmem")  # noqa: F821
-            return reshard(xr, (1, 128), "gmem")  # noqa: F821
-
-    return _f
-
-
-def test_closure_int_mesh_dims_resolve_like_literals() -> None:
-    """Closure/global ints in a mesh-shape sugar (``(WARPS, LANES)`` and the
-    topology extent ``THREADS``) resolve identically to integer literals; the
-    parser must not reject the ``ast.Name``."""
-    assert as_script(_mesh_body_fn(128, 4, 32)) == as_script(_mesh_body_literal())
-
-
-def test_closure_int_split_extent_still_parses() -> None:
-    """A closure int used as a split extent resolves and parses."""
-    k_tile = 128
-
-    @func(topologies=(Topology("thread", 128),))
-    def _f(x: Tensor[(1, 128), "bf16"]) -> Tensor[(1, 128), "bf16"]:
-        with Mesh(Topology("thread", 128), (4, 32), ("w", "t")) as m:
+        with Mesh(topology="thread", layout=(4, 32), names=("w", "t")) as m:
             xr = reshard(x, (1, k_tile @ (m.w, m.t)), "rmem")  # noqa: F821
             return reshard(xr, (1, 128), "gmem")  # noqa: F821
 
-    assert _f.name == "_f"
+    return _f
 
 
-def test_dimvar_mesh_dim_reports_static_int() -> None:
-    """A ``DimVar`` in a mesh-shape position is rejected with a clear static-int
-    diagnostic (not a raw AST / attribute error)."""
-    w = DimVar("W", 1, 8)
+def _literal_reshard_fn():
+    """All-literal reference form: `layout=(4, 32)` mesh dims and a `128 @
+    (m.w, m.t)` split extent. Both closure builders above must print to this."""
 
+    @func(topologies=(Topology("thread", 128),))
+    def _f(x: Tensor[(1, 128), "bf16"]) -> Tensor[(1, 128), "bf16"]:
+        with Mesh(topology="thread", layout=(4, 32), names=("w", "t")) as m:
+            xr = reshard(x, (1, 128 @ (m.w, m.t)), "rmem")  # noqa: F821
+            return reshard(xr, (1, 128), "gmem")  # noqa: F821
+
+    return _f
+
+
+@pytest.mark.parametrize(
+    "closure_call",
+    [
+        lambda: _closure_mesh_dims_fn(4, 32),
+        lambda: _closure_split_extent_fn(128),
+    ],
+    ids=["mesh-dims", "split-extent"],
+)
+def test_closure_int_resolves_like_literal(closure_call) -> None:
+    """A closure/global int in a static-extent position (mesh dim or split
+    extent) resolves identically to the integer literal — the parser must not
+    reject the ``ast.Name``; the closure form prints back to the literal form."""
+    assert as_script(closure_call()) == as_script(_literal_reshard_fn())
+
+
+def _dimvar_mesh_dim_fn():
+    @func(topologies=(Topology("thread", 128),))
+    def _f(x: Tensor[(1, 128), "bf16"]) -> Tensor[(1, 128), "bf16"]:
+        with Mesh(topology="thread", layout=(_MESH_DIM_W, 32), names=("w", "t")) as m:
+            xr = reshard(x, (1, 128 @ (m.w, m.t)), "rmem")  # noqa: F821
+            return reshard(xr, (1, 128), "gmem")  # noqa: F821
+
+    return _f
+
+
+def _bool_mesh_dim_fn():
+    @func(topologies=(Topology("thread", 128),))
+    def _f(x: Tensor[(1, 128), "bf16"]) -> Tensor[(1, 128), "bf16"]:
+        with Mesh(topology="thread", layout=(True, 32), names=("w", "t")) as m:
+            xr = reshard(x, (1, 128 @ (m.w, m.t)), "rmem")  # noqa: F821
+            return reshard(xr, (1, 128), "gmem")  # noqa: F821
+
+    return _f
+
+
+def _dimvar_split_extent_fn():
+    @func(topologies=(Topology("cta", 8), Topology("thread", 128)))
+    def _f(x: Tensor[(8, _SPLIT_EXTENT_K), "bf16"]) -> Tensor[(8, 1), "bf16"]:
+        with Mesh(topology="thread", layout=(4, 32), names=("w", "t")) as m:
+            xr = reshard(x, (8, _SPLIT_EXTENT_K @ (m.w, m.t)), "rmem")  # noqa: F821
+            return reshard(xr, (8, 1), "gmem")  # noqa: F821
+
+    return _f
+
+
+def _bool_split_extent_single_axis_fn():
+    @func(topologies=(Topology("thread", 128),))
+    def _f(x: Tensor[(1, 128), "bf16"]) -> Tensor[(1, 128), "bf16"]:
+        with Mesh(topology="thread", layout=(4, 32), names=("w", "t")) as m:
+            xr = reshard(x, (1, True @ m.w), "rmem")  # noqa: F821
+            return reshard(xr, (1, 128), "gmem")  # noqa: F821
+
+    return _f
+
+
+def _bool_split_extent_multi_axis_fn():
+    @func(topologies=(Topology("thread", 128),))
+    def _f(x: Tensor[(1, 128), "bf16"]) -> Tensor[(1, 128), "bf16"]:
+        with Mesh(topology="thread", layout=(4, 32), names=("w", "t")) as m:
+            xr = reshard(x, (1, True @ (m.w, m.t)), "rmem")  # noqa: F821
+            return reshard(xr, (1, 128), "gmem")  # noqa: F821
+
+    return _f
+
+
+@pytest.mark.parametrize(
+    "build",
+    [
+        _dimvar_mesh_dim_fn,
+        _bool_mesh_dim_fn,
+        _dimvar_split_extent_fn,
+        _bool_split_extent_single_axis_fn,
+        _bool_split_extent_multi_axis_fn,
+    ],
+    ids=[
+        "dimvar-mesh-dim",
+        "bool-mesh-dim",
+        "dimvar-split-extent",
+        "bool-split-single-axis",
+        "bool-split-multi-axis",
+    ],
+)
+def test_static_extent_position_rejects_non_static_int(build) -> None:
+    """A dynamic (``DimVar``) or ``bool`` value in a static-extent position (mesh
+    dim or split extent) is rejected with a clear static-int diagnostic; the
+    sugar error must surface rather than be swallowed into a generic
+    ``'Mesh' object has no attribute ...`` attribute error."""
     with pytest.raises(ValueError, match="static int"):
-
-        @func(topologies=(Topology("thread", 128),))
-        def _bad(x: Tensor[(1, 128), "bf16"]) -> Tensor[(1, 128), "bf16"]:
-            with Mesh(Topology("thread", 128), (w, 32), ("w", "t")) as m:
-                xr = reshard(x, (1, 128 @ (m.w, m.t)), "rmem")  # noqa: F821
-                return reshard(xr, (1, 128), "gmem")  # noqa: F821
-
-
-def test_bool_mesh_dim_rejected() -> None:
-    """``bool`` is rejected as a mesh dim even though it subclasses ``int``."""
-    warps = True
-
-    with pytest.raises(ValueError, match="static int"):
-
-        @func(topologies=(Topology("thread", 128),))
-        def _bad(x: Tensor[(1, 128), "bf16"]) -> Tensor[(1, 128), "bf16"]:
-            with Mesh(Topology("thread", 128), (warps, 32), ("w", "t")) as m:
-                xr = reshard(x, (1, 128 @ (m.w, m.t)), "rmem")  # noqa: F821
-                return reshard(xr, (1, 128), "gmem")  # noqa: F821
-
-
-# ── malformed layout sugar surfaces (not swallowed → AttributeError) ──────────
-# A sugar ValueError raised once the node is recognized as layout sugar must not
-# be swallowed into generic static eval (which turned the real "static int"
-# diagnostic into `'Mesh' object has no attribute 'w'`).
-
-
-def test_dimvar_split_extent_full_pipeline_reports_static_int() -> None:
-    """A ``DimVar`` split extent through the full ``@func`` op-arg path reports a
-    clear static-int error, not ``'Mesh' object has no attribute 'w'``."""
-    k = DimVar("K", 32, 256)
-
-    with pytest.raises(ValueError, match="static int"):
-
-        @func(topologies=(Topology("cta", 8), Topology("thread", 128)))
-        def _bad(x: Tensor[(8, k), "bf16"]) -> Tensor[(8, 1), "bf16"]:
-            with Mesh(Topology("thread", 128), (4, 32), ("w", "t")) as m:
-                xr = reshard(x, (8, k @ (m.w, m.t)), "rmem")  # noqa: F821
-                return reshard(xr, (8, 1), "gmem")  # noqa: F821
-
-
-def test_bool_split_extent_single_axis_rejected() -> None:
-    """A ``bool`` split extent (``True @ m.w``) is rejected with a static-int
-    error rather than being swallowed."""
-    with pytest.raises(ValueError, match="static int"):
-
-        @func(topologies=(Topology("thread", 128),))
-        def _bad(x: Tensor[(1, 128), "bf16"]) -> Tensor[(1, 128), "bf16"]:
-            with Mesh(Topology("thread", 128), (4, 32), ("w", "t")) as m:
-                xr = reshard(x, (1, True @ m.w), "rmem")  # noqa: F821
-                return reshard(xr, (1, 128), "gmem")  # noqa: F821
-
-
-def test_bool_split_extent_multi_axis_rejected() -> None:
-    """A ``bool`` split extent in the multi-axis form (``True @ (m.w, m.t)``) is
-    rejected with a static-int error."""
-    with pytest.raises(ValueError, match="static int"):
-
-        @func(topologies=(Topology("thread", 128),))
-        def _bad(x: Tensor[(1, 128), "bf16"]) -> Tensor[(1, 128), "bf16"]:
-            with Mesh(Topology("thread", 128), (4, 32), ("w", "t")) as m:
-                xr = reshard(x, (1, True @ (m.w, m.t)), "rmem")  # noqa: F821
-                return reshard(xr, (1, 128), "gmem")  # noqa: F821
+        build()

--- a/tests/parser/hir/test_parse_shard_sugar.py
+++ b/tests/parser/hir/test_parse_shard_sugar.py
@@ -1,16 +1,18 @@
 """Shard-layout sugar parse tests.
 
-Each test owns its mesh, writes the compact ``ShardLayout`` sugar in a nested
-``@func`` param annotation, and asserts the parsed ``TensorType`` equals a
-hand-written expected value (or that an invalid form raises). Covers inline
-``Split``, the ``{...}`` ``Partial`` value-state set, default ``Broadcast``,
-multi-mesh-axis split, explicit strides, the single-axis ``int @ mesh``
-shorthand, and that sugar source prints to valid Python.
+Unified model: each scenario is a named ``build_*_func`` / ``build_*_case``
+builder carrying a docstring that describes the DSL scene, and a ``test_*`` that
+runs it through a shared assertion helper (parsed ``TensorType`` equality, or a
+raised diagnostic). Covers inline ``Split``, the ``{...}`` ``Partial``
+value-state set, default ``Broadcast``, multi-mesh-axis split, explicit strides,
+the single-axis ``int @ mesh`` shorthand, closure/static-int dim resolution, and
+that sugar source prints to valid Python.
 """
 
 from __future__ import annotations
 
 import ast
+from typing import Any, Callable
 
 import pytest
 
@@ -34,6 +36,31 @@ from tilefoundry.ir.types.shard.shard_layout import Broadcast, Partial, Split
 from tilefoundry.parser.sugar import parse_shard_layout_sugar
 from tests.fixtures.demo_ir import build_demo
 
+
+# ── shared assertion helpers ─────────────────────────────────────────────────
+
+
+def assert_param_type(build_func: Callable[[], Any], expected: TensorType) -> None:
+    """Build the DSL ``@func`` and assert its first parameter's parsed type."""
+    fn = build_func()
+    assert fn.params[0].type == expected
+
+
+def assert_build_raises(build_func: Callable[[], Any], match: str) -> None:
+    """Assert that building the DSL ``@func`` raises a ``ValueError`` (parse
+    happens at ``@func`` decoration, so calling the builder triggers it)."""
+    with pytest.raises(ValueError, match=match):
+        build_func()
+
+
+def assert_parse_raises(build_case: Callable[[], Callable[[], Any]], match: str) -> None:
+    """Assert that running a direct ``parse_shard_layout_sugar`` case (returned as
+    a zero-arg thunk by *build_case*) raises a ``ValueError``."""
+    do_parse = build_case()
+    with pytest.raises(ValueError, match=match):
+        do_parse()
+
+
 # ── inline Split + default Broadcast ────────────────────────────────────────
 
 _M_SPLIT = Mesh(
@@ -43,7 +70,7 @@ _M_SPLIT = Mesh(
 )
 
 
-def test_split_inline_and_default_broadcast() -> None:
+def build_split_inline_and_default_broadcast_func():
     """``dim @ mesh.axis`` binds a Split on that cute axis; mesh axes named in
     no Split default to Broadcast; cute strides auto-fill C-order."""
 
@@ -53,14 +80,21 @@ def test_split_inline_and_default_broadcast() -> None:
     ) -> Tensor[(32, 128), "f32"]:
         return a
 
-    assert _f.params[0].type == TensorType(
-        shape=(32, 128),
-        dtype=DType.bf16,
-        storage=StorageKind.SMEM,
-        layout=ShardLayout(
-            layout=Layout((32, 2, 64), (128, 64, 1)),
-            attrs=(Split(0), Split(1), Broadcast(), Broadcast()),
-            mesh=_M_SPLIT,
+    return _f
+
+
+def test_split_inline_and_default_broadcast() -> None:
+    assert_param_type(
+        build_split_inline_and_default_broadcast_func,
+        TensorType(
+            shape=(32, 128),
+            dtype=DType.bf16,
+            storage=StorageKind.SMEM,
+            layout=ShardLayout(
+                layout=Layout((32, 2, 64), (128, 64, 1)),
+                attrs=(Split(0), Split(1), Broadcast(), Broadcast()),
+                mesh=_M_SPLIT,
+            ),
         ),
     )
 
@@ -74,7 +108,7 @@ _M_PARTIAL = Mesh(
 )
 
 
-def test_partial_brace_value_state() -> None:
+def build_partial_brace_value_state_func():
     """The optional final ``{mesh.axis @ P("reduction")}`` set carries a
     mesh-axis Partial value state; the layout tuple holds only Split placement,
     and unnamed axes stay Broadcast."""
@@ -87,14 +121,21 @@ def test_partial_brace_value_state() -> None:
     ) -> Tensor[(64, 128), "f32"]:
         return a
 
-    assert _f.params[0].type == TensorType(
-        shape=(64, 128),
-        dtype=DType.bf16,
-        storage=StorageKind.SMEM,
-        layout=ShardLayout(
-            layout=Layout((32, 64), (64, 1)),
-            attrs=(Split(0), Broadcast(), Partial("sum"), Broadcast()),
-            mesh=_M_PARTIAL,
+    return _f
+
+
+def test_partial_brace_value_state() -> None:
+    assert_param_type(
+        build_partial_brace_value_state_func,
+        TensorType(
+            shape=(64, 128),
+            dtype=DType.bf16,
+            storage=StorageKind.SMEM,
+            layout=ShardLayout(
+                layout=Layout((32, 64), (64, 1)),
+                attrs=(Split(0), Broadcast(), Partial("sum"), Broadcast()),
+                mesh=_M_PARTIAL,
+            ),
         ),
     )
 
@@ -106,7 +147,7 @@ _M_MIXED = Mesh(
 )
 
 
-def test_mixed_split_partial_and_default_broadcast() -> None:
+def build_mixed_split_partial_and_default_broadcast_func():
     """``l`` splits dim 0, ``t`` is a Partial value state, and the unnamed ``g``
     defaults to Broadcast."""
 
@@ -116,14 +157,21 @@ def test_mixed_split_partial_and_default_broadcast() -> None:
     ) -> Tensor[(4, 64), "f32"]:
         return a
 
-    assert _f.params[0].type == TensorType(
-        shape=(4, 64),
-        dtype=DType.f32,
-        storage=StorageKind.SMEM,
-        layout=ShardLayout(
-            layout=Layout((4, 64), (64, 1)),
-            attrs=(Split(0), Broadcast(), Partial("sum")),
-            mesh=_M_MIXED,
+    return _f
+
+
+def test_mixed_split_partial_and_default_broadcast() -> None:
+    assert_param_type(
+        build_mixed_split_partial_and_default_broadcast_func,
+        TensorType(
+            shape=(4, 64),
+            dtype=DType.f32,
+            storage=StorageKind.SMEM,
+            layout=ShardLayout(
+                layout=Layout((4, 64), (64, 1)),
+                attrs=(Split(0), Broadcast(), Partial("sum")),
+                mesh=_M_MIXED,
+            ),
         ),
     )
 
@@ -133,7 +181,7 @@ def test_mixed_split_partial_and_default_broadcast() -> None:
 _M_MULTI = Mesh(Topology("thread", 6 * 32), Layout((6, 32), (32, 1)), names=("w", "t"))
 
 
-def test_multi_axis_split_factorises_with_remainder() -> None:
+def build_multi_axis_split_with_remainder_func():
     """``1536 @ (w, t)`` factorises the dim into the mesh extents (6, 32) plus a
     remainder (8), each extent bound as a Split; the leading unit axis is kept."""
 
@@ -143,19 +191,26 @@ def test_multi_axis_split_factorises_with_remainder() -> None:
     ) -> Tensor[(1, 1536), "f32"]:
         return a
 
-    assert _f.params[0].type == TensorType(
-        shape=(1, 1536),
-        dtype=DType.f32,
-        storage=StorageKind.SMEM,
-        layout=ShardLayout(
-            layout=Layout((1, 6, 32, 8), (1536, 256, 8, 1)),
-            attrs=(Split(1), Split(2)),
-            mesh=_M_MULTI,
+    return _f
+
+
+def test_multi_axis_split_factorises_with_remainder() -> None:
+    assert_param_type(
+        build_multi_axis_split_with_remainder_func,
+        TensorType(
+            shape=(1, 1536),
+            dtype=DType.f32,
+            storage=StorageKind.SMEM,
+            layout=ShardLayout(
+                layout=Layout((1, 6, 32, 8), (1536, 256, 8, 1)),
+                attrs=(Split(1), Split(2)),
+                mesh=_M_MULTI,
+            ),
         ),
     )
 
 
-def test_multi_axis_split_factorises_exact_plus_remainder() -> None:
+def build_multi_axis_split_exact_plus_remainder_func():
     """``384 @ (w, t)`` factorises into (6, 32) plus the remainder 2; the
     single-axis canonicalization path does not apply to a multi-axis split."""
 
@@ -165,28 +220,40 @@ def test_multi_axis_split_factorises_exact_plus_remainder() -> None:
     ) -> Tensor[(384,), "f32"]:
         return a
 
-    assert _f.params[0].type == TensorType(
-        shape=(384,),
-        dtype=DType.f32,
-        storage=StorageKind.SMEM,
-        layout=ShardLayout(
-            layout=Layout((6, 32, 2), (64, 2, 1)),
-            attrs=(Split(0), Split(1)),
-            mesh=_M_MULTI,
+    return _f
+
+
+def test_multi_axis_split_factorises_exact_plus_remainder() -> None:
+    assert_param_type(
+        build_multi_axis_split_exact_plus_remainder_func,
+        TensorType(
+            shape=(384,),
+            dtype=DType.f32,
+            storage=StorageKind.SMEM,
+            layout=ShardLayout(
+                layout=Layout((6, 32, 2), (64, 2, 1)),
+                attrs=(Split(0), Split(1)),
+                mesh=_M_MULTI,
+            ),
         ),
     )
 
 
+def build_multi_axis_split_not_divisible_func():
+    """A dim must be divisible by the product of the mesh extents; ``100 @
+    (w, t)`` (product 192) is rejected."""
+
+    @func
+    def _bad(
+        a: Tensor[(1, 100), "f32", (1, 100 @ (_M_MULTI.w, _M_MULTI.t)), "smem"],
+    ) -> Tensor[(1, 100), "f32"]:
+        return a
+
+    return _bad
+
+
 def test_multi_axis_split_not_divisible_raises() -> None:
-    """A dim must be divisible by the product of the mesh extents."""
-
-    with pytest.raises(ValueError, match="not divisible"):
-
-        @func
-        def _bad(
-            a: Tensor[(1, 100), "f32", (1, 100 @ (_M_MULTI.w, _M_MULTI.t)), "smem"],
-        ) -> Tensor[(1, 100), "f32"]:
-            return a
+    assert_build_raises(build_multi_axis_split_not_divisible_func, match="not divisible")
 
 
 # ── explicit strides: ``((dims), (strides))`` ────────────────────────────────
@@ -194,10 +261,9 @@ def test_multi_axis_split_not_divisible_raises() -> None:
 _M_STRIDED = Mesh(Topology("thread", 4 * 32), Layout((4, 32), (32, 1)), names=("y", "t"))
 
 
-def test_explicit_strides_skip_single_axis_canonicalization() -> None:
-    """The ``((dims), (strides))`` form preserves user-supplied dims and
-    strides; the explicit-strides path does not trigger single-axis
-    canonicalization."""
+def build_explicit_strides_func():
+    """The ``((dims), (strides))`` form preserves user-supplied dims and strides;
+    the explicit-strides path does not trigger single-axis canonicalization."""
 
     @func
     def _f(
@@ -205,14 +271,21 @@ def test_explicit_strides_skip_single_axis_canonicalization() -> None:
     ) -> Tensor[(12, 4), "f32"]:
         return a
 
-    assert _f.params[0].type == TensorType(
-        shape=(12, 4),
-        dtype=DType.f32,
-        storage=StorageKind.SMEM,
-        layout=ShardLayout(
-            layout=Layout((12, 4), (4, 1)),
-            attrs=(Split(0), Broadcast()),
-            mesh=_M_STRIDED,
+    return _f
+
+
+def test_explicit_strides_skip_single_axis_canonicalization() -> None:
+    assert_param_type(
+        build_explicit_strides_func,
+        TensorType(
+            shape=(12, 4),
+            dtype=DType.f32,
+            storage=StorageKind.SMEM,
+            layout=ShardLayout(
+                layout=Layout((12, 4), (4, 1)),
+                attrs=(Split(0), Broadcast()),
+                mesh=_M_STRIDED,
+            ),
         ),
     )
 
@@ -222,7 +295,7 @@ def test_explicit_strides_skip_single_axis_canonicalization() -> None:
 _M_CTA = Mesh(Topology("cta", 128), Layout((128,), (1,)), names=("cta",))
 
 
-def test_int_at_single_axis_mesh_canonicalises() -> None:
+def build_int_at_single_axis_mesh_func():
     """On a single-axis mesh, ``8192 @ cta`` (extent 128) canonicalises into
     ``(128, 64)`` with the mesh axis bound as a Split on the new cute axis."""
 
@@ -232,14 +305,21 @@ def test_int_at_single_axis_mesh_canonicalises() -> None:
     ) -> Tensor[(1, 8192), "f32"]:
         return a
 
-    assert _f.params[0].type == TensorType(
-        shape=(1, 8192),
-        dtype=DType.f32,
-        storage=StorageKind.SMEM,
-        layout=ShardLayout(
-            layout=Layout((1, 128, 64), (8192, 64, 1)),
-            attrs=(Split(1),),
-            mesh=_M_CTA,
+    return _f
+
+
+def test_int_at_single_axis_mesh_canonicalises() -> None:
+    assert_param_type(
+        build_int_at_single_axis_mesh_func,
+        TensorType(
+            shape=(1, 8192),
+            dtype=DType.f32,
+            storage=StorageKind.SMEM,
+            layout=ShardLayout(
+                layout=Layout((1, 128, 64), (8192, 64, 1)),
+                attrs=(Split(1),),
+                mesh=_M_CTA,
+            ),
         ),
     )
 
@@ -249,17 +329,21 @@ _M_MULTI_REJECT = Mesh(
 )
 
 
-def test_int_at_mesh_rejects_multi_axis_mesh() -> None:
+def build_int_at_multi_axis_mesh_func():
     """The bare ``int @ mesh`` shorthand requires a single-axis mesh; a
     multi-axis mesh still needs an explicit ``mesh.axis`` reference."""
 
-    with pytest.raises(ValueError, match="single-axis mesh"):
+    @func
+    def _bad(
+        a: Tensor[(64,), "f32", (64 @ _M_MULTI_REJECT,), "smem"],
+    ) -> Tensor[(64,), "f32"]:
+        return a
 
-        @func
-        def _bad(
-            a: Tensor[(64,), "f32", (64 @ _M_MULTI_REJECT,), "smem"],
-        ) -> Tensor[(64,), "f32"]:
-            return a
+    return _bad
+
+
+def test_int_at_mesh_rejects_multi_axis_mesh() -> None:
+    assert_build_raises(build_int_at_multi_axis_mesh_func, match="single-axis mesh")
 
 
 # ── invalid value-state forms ────────────────────────────────────────────────
@@ -269,35 +353,43 @@ _M_VALUE_STATE = Mesh(
 )
 
 
-def test_value_state_set_must_be_final_outer_item() -> None:
+def build_value_state_not_final_func():
     """The ``{...}`` value-state set is valid only as the last outer item; a
     stride tuple after it is rejected."""
 
-    with pytest.raises(ValueError, match="last outer item"):
+    @func
+    def _bad(
+        a: Tensor[
+            (4, 64),
+            "f32",
+            ((4 @ _M_VALUE_STATE.l, 64), {_M_VALUE_STATE.t @ P("sum")}, (64, 1)),
+            "smem",
+        ],
+    ) -> Tensor[(4, 64), "f32"]:
+        return a
 
-        @func
-        def _bad(
-            a: Tensor[
-                (4, 64),
-                "f32",
-                ((4 @ _M_VALUE_STATE.l, 64), {_M_VALUE_STATE.t @ P("sum")}, (64, 1)),
-                "smem",
-            ],
-        ) -> Tensor[(4, 64), "f32"]:
-            return a
+    return _bad
 
 
-def test_value_state_p_requires_reduction_arg() -> None:
+def test_value_state_set_must_be_final_outer_item() -> None:
+    assert_build_raises(build_value_state_not_final_func, match="last outer item")
+
+
+def build_value_state_bare_p_func():
     """``P(...)`` in the value-state set requires its reduction argument; bare
     ``P()`` is rejected (the surface is ``mesh.axis @ P("reduction")``)."""
 
-    with pytest.raises(ValueError, match="reduction argument"):
+    @func
+    def _bad(
+        a: Tensor[(4, 64), "f32", ((4 @ _M_VALUE_STATE.l, 64), {_M_VALUE_STATE.t @ P()}), "smem"],
+    ) -> Tensor[(4, 64), "f32"]:
+        return a
 
-        @func
-        def _bad(
-            a: Tensor[(4, 64), "f32", ((4 @ _M_VALUE_STATE.l, 64), {_M_VALUE_STATE.t @ P()}), "smem"],
-        ) -> Tensor[(4, 64), "f32"]:
-            return a
+    return _bad
+
+
+def test_value_state_p_requires_reduction_arg() -> None:
+    assert_build_raises(build_value_state_bare_p_func, match="reduction argument")
 
 
 # ── undefined mesh / unknown axis ────────────────────────────────────────────
@@ -307,28 +399,36 @@ _M_KNOWN = Mesh(
 )
 
 
+def build_undefined_mesh_func():
+    """Sugar that references a name bound to no mesh is rejected."""
+
+    @func
+    def _bad(
+        a: Tensor[(32, 128), bf16, (32 @ undefined.cluster, 64), "smem"],  # noqa: F821
+    ) -> Tensor[(32, 128), "f32"]:
+        return a
+
+    return _bad
+
+
 def test_sugar_undefined_mesh_raises() -> None:
-    """Sugar that references a name bound to no mesh raises."""
+    assert_build_raises(build_undefined_mesh_func, match="undefined mesh")
 
-    with pytest.raises(ValueError, match="undefined mesh"):
 
-        @func
-        def _bad(
-            a: Tensor[(32, 128), bf16, (32 @ undefined.cluster, 64), "smem"],  # noqa: F821
-        ) -> Tensor[(32, 128), "f32"]:
-            return a
+def build_unknown_axis_func():
+    """Sugar that references an axis the mesh does not have is rejected."""
+
+    @func
+    def _bad(
+        a: Tensor[(32, 128), bf16, (32 @ _M_KNOWN.nonexistent, 64), "smem"],
+    ) -> Tensor[(32, 128), "f32"]:
+        return a
+
+    return _bad
 
 
 def test_sugar_unknown_axis_raises() -> None:
-    """Sugar that references an axis the mesh does not have raises."""
-
-    with pytest.raises(ValueError, match="has no axis named"):
-
-        @func
-        def _bad(
-            a: Tensor[(32, 128), bf16, (32 @ _M_KNOWN.nonexistent, 64), "smem"],
-        ) -> Tensor[(32, 128), "f32"]:
-            return a
+    assert_build_raises(build_unknown_axis_func, match="has no axis named")
 
 
 # ── ``@func`` body with a sugar param + printing valid Python ────────────────
@@ -340,7 +440,7 @@ _M_BODY = Mesh(
 )
 
 
-def test_func_body_with_sugar_param_parses_and_reshards() -> None:
+def build_body_sugar_param_reshard_func():
     """A ``@func`` whose param carries sugar parses to the hand-written type and
     its ``reshard`` body op fires."""
 
@@ -348,7 +448,7 @@ def test_func_body_with_sugar_param_parses_and_reshards() -> None:
     def _demo(
         a: Tensor[(32, 1536), "f32", (32 @ _M_BODY.cluster, 1536), "smem"],
     ) -> Tensor[(32, 1536), "f32"]:
-        return reshard(
+        return reshard(  # noqa: F821
             a,
             layout=ShardLayout(
                 layout=Layout((32, 1536), (1536, 1)),
@@ -357,7 +457,11 @@ def test_func_body_with_sugar_param_parses_and_reshards() -> None:
             ),
         )
 
-    fn = _demo
+    return _demo
+
+
+def test_func_body_with_sugar_param_parses_and_reshards() -> None:
+    fn = build_body_sugar_param_reshard_func()
     assert fn.name == "_demo"
     assert fn.params[0].type == TensorType(
         shape=(32, 1536),
@@ -372,9 +476,8 @@ def test_func_body_with_sugar_param_parses_and_reshards() -> None:
     assert isinstance(fn.body, Call) and isinstance(fn.body.target, Reshard)
 
 
-def test_sugar_source_prints_to_valid_python() -> None:
-    """A function with a sugar param annotation prints to valid Python source,
-    and the parsed param keeps its shape/dtype/storage."""
+def build_sugar_param_print_func():
+    """A function with a sugar param annotation prints to valid Python source."""
 
     @func
     def _demo(
@@ -382,7 +485,11 @@ def test_sugar_source_prints_to_valid_python() -> None:
     ) -> Tensor[(32, 1536), "f32"]:
         return a
 
-    fn = _demo
+    return _demo
+
+
+def test_sugar_source_prints_to_valid_python() -> None:
+    fn = build_sugar_param_print_func()
     src = as_script(fn, module="M")
     compile(src, "<test>", "exec")  # printed output is valid Python
     p = fn.params[0]
@@ -391,10 +498,15 @@ def test_sugar_source_prints_to_valid_python() -> None:
     assert p.type.storage == StorageKind.SMEM
 
 
-def test_printer_falls_back_to_verbose_when_mesh_has_no_names() -> None:
-    """A mesh without ``names=`` cannot use ``@`` sugar; the printer emits the
+def build_no_names_mesh_demo_func():
+    """A mesh without ``names=`` cannot use ``@`` sugar; the printer must emit the
     verbose ``ShardLayout(...)`` form instead."""
     fn, _, _ = build_demo()
+    return fn
+
+
+def test_printer_falls_back_to_verbose_when_mesh_has_no_names() -> None:
+    fn = build_no_names_mesh_demo_func()
     src = as_script(fn)
     assert "@" not in src.split("@func")[1].split("def ")[0]
     assert "ShardLayout(" in src
@@ -405,12 +517,12 @@ def test_printer_falls_back_to_verbose_when_mesh_has_no_names() -> None:
 _S_DYN = DimVar("seq_len", 1, 4)
 
 
-def test_reshard_sugar_accepts_dynamic_bare_and_closure_name_axis() -> None:
+def build_dynamic_bare_and_closure_split_func():
     """A reshard layout sugar may carry a dynamic ``DimVar`` bare axis (``S``)
     and a closure-resolved Name split extent (``_HQ``). The split axis is
     canonicalised against the mesh extent; the dynamic axis rides through as a
-    Broadcast dim. The reshard's logical result keeps the un-factorised shape
-    and strides defer to typeinfer."""
+    Broadcast dim. The reshard's logical result keeps the un-factorised shape and
+    strides defer to typeinfer."""
     _HQ, _D = 32, 128
 
     @func(topologies=(Topology("cta", 8),))
@@ -420,43 +532,55 @@ def test_reshard_sugar_accepts_dynamic_bare_and_closure_name_axis() -> None:
         with Mesh(topology="cta", layout=Layout((8,), (1,))) as cta:
             return reshard(q, layout=(1, _S_DYN, _HQ @ cta, _D))  # noqa: F821
 
-    body = _f.body
+    return _f
+
+
+def test_reshard_sugar_accepts_dynamic_bare_and_closure_name_axis() -> None:
+    fn = build_dynamic_bare_and_closure_split_func()
+    body = fn.body
     assert isinstance(body, Call) and isinstance(body.target, Reshard)
     # logical result shape is the un-factorised (1, S, 32, 128)
-    assert body.type.shape == (1, _S_DYN, _HQ, _D)
+    assert body.type.shape == (1, _S_DYN, 32, 128)
     # the head axis is Split across the cta mesh
     assert any(isinstance(a, Split) for a in body.target.layout.attrs)
     # the authored sugar leaves strides un-materialised (deferred to typeinfer)
     assert body.target.layout.layout.strides is None
 
 
-def test_reshard_sugar_rejects_dynamic_split_axis() -> None:
+def build_dynamic_split_axis_parse_case():
     """A bare axis may be dynamic, but a *split* axis (``dim @ mesh.axis``)
-    participates in canonicalisation and must resolve to a static int — a
-    dynamic ``DimVar`` split extent is rejected."""
+    participates in canonicalisation and must resolve to a static int — a dynamic
+    ``DimVar`` split extent is rejected. Direct ``parse_shard_layout_sugar``
+    case (returned as a parse thunk)."""
     cta = Mesh(Topology("cta", 8), Layout((8,), (1,)), names=("cta",))
     node = ast.parse("(1, S @ cta, 32, 128)", mode="eval").body
-    with pytest.raises(ValueError, match="static int"):
-        parse_shard_layout_sugar(
+
+    def do_parse():
+        return parse_shard_layout_sugar(
             node, lambda n: cta if n == "cta" else None, closure={"S": _S_DYN}
         )
+
+    return do_parse
+
+
+def test_reshard_sugar_rejects_dynamic_split_axis() -> None:
+    assert_parse_raises(build_dynamic_split_axis_parse_case, match="static int")
 
 
 # ── static-int dims in mesh / split sugar: closure resolution + diagnostics ───
 # A static-extent (mesh-shape dim or split extent) accepts an int literal or a
 # closure/global int; a bool or dynamic (DimVar) value is rejected with a
 # static-int diagnostic (and the sugar error must surface, not be swallowed into
-# ``'Mesh' object has no attribute ...``). All cases below use the string-
-# topology sugar `Mesh(topology="thread", ...)` referencing the @func-declared
-# topology rather than reconstructing a ``Topology(...)`` in the body.
+# ``'Mesh' object has no attribute ...``). All cases use the string-topology
+# sugar ``Mesh(topology="thread", ...)`` referencing the @func-declared topology.
 
 _MESH_DIM_W = DimVar("W", 1, 8)
 _SPLIT_EXTENT_K = DimVar("K", 32, 256)
 
 
-def _closure_mesh_dims_fn(warps, lanes):
-    """A mesh-shape sugar (`layout=(warps, lanes)`) whose dims come from the
-    enclosing closure."""
+def build_closure_mesh_dims_func(warps, lanes):
+    """A mesh-shape sugar (``layout=(warps, lanes)``) whose dims come from the
+    enclosing closure — must resolve like the integer literals."""
 
     @func(topologies=(Topology("thread", 128),))
     def _f(x: Tensor[(1, 128), "bf16"]) -> Tensor[(1, 128), "bf16"]:
@@ -467,8 +591,9 @@ def _closure_mesh_dims_fn(warps, lanes):
     return _f
 
 
-def _closure_split_extent_fn(k_tile):
-    """A split extent (`k_tile @ (m.w, m.t)`) taken from the enclosing closure."""
+def build_closure_split_extent_func(k_tile):
+    """A split extent (``k_tile @ (m.w, m.t)``) taken from the enclosing closure
+    — must resolve like the integer literal."""
 
     @func(topologies=(Topology("thread", 128),))
     def _f(x: Tensor[(1, 128), "bf16"]) -> Tensor[(1, 128), "bf16"]:
@@ -479,9 +604,9 @@ def _closure_split_extent_fn(k_tile):
     return _f
 
 
-def _literal_reshard_fn():
-    """All-literal reference form: `layout=(4, 32)` mesh dims and a `128 @
-    (m.w, m.t)` split extent. Both closure builders above must print to this."""
+def build_literal_reshard_func():
+    """All-literal reference form: ``layout=(4, 32)`` mesh dims and a
+    ``128 @ (m.w, m.t)`` split extent; both closure builders above print to it."""
 
     @func(topologies=(Topology("thread", 128),))
     def _f(x: Tensor[(1, 128), "bf16"]) -> Tensor[(1, 128), "bf16"]:
@@ -492,22 +617,26 @@ def _literal_reshard_fn():
     return _f
 
 
-@pytest.mark.parametrize(
-    "closure_call",
-    [
-        lambda: _closure_mesh_dims_fn(4, 32),
-        lambda: _closure_split_extent_fn(128),
-    ],
-    ids=["mesh-dims", "split-extent"],
-)
-def test_closure_int_resolves_like_literal(closure_call) -> None:
-    """A closure/global int in a static-extent position (mesh dim or split
-    extent) resolves identically to the integer literal — the parser must not
-    reject the ``ast.Name``; the closure form prints back to the literal form."""
-    assert as_script(closure_call()) == as_script(_literal_reshard_fn())
+def test_closure_int_mesh_dims_resolve_like_literal() -> None:
+    """A closure/global int in a mesh-shape sugar prints back to the literal
+    form — the parser must not reject the ``ast.Name``."""
+    assert as_script(build_closure_mesh_dims_func(4, 32)) == as_script(
+        build_literal_reshard_func()
+    )
 
 
-def _dimvar_mesh_dim_fn():
+def test_closure_int_split_extent_resolves_like_literal() -> None:
+    """A closure/global int used as a split extent prints back to the literal
+    form."""
+    assert as_script(build_closure_split_extent_func(128)) == as_script(
+        build_literal_reshard_func()
+    )
+
+
+def build_dimvar_mesh_dim_func():
+    """A dynamic ``DimVar`` in a mesh-shape position is a static-extent
+    violation and must be rejected with a static-int diagnostic."""
+
     @func(topologies=(Topology("thread", 128),))
     def _f(x: Tensor[(1, 128), "bf16"]) -> Tensor[(1, 128), "bf16"]:
         with Mesh(topology="thread", layout=(_MESH_DIM_W, 32), names=("w", "t")) as m:
@@ -517,7 +646,9 @@ def _dimvar_mesh_dim_fn():
     return _f
 
 
-def _bool_mesh_dim_fn():
+def build_bool_mesh_dim_func():
+    """A ``bool`` mesh dim is rejected even though ``bool`` subclasses ``int``."""
+
     @func(topologies=(Topology("thread", 128),))
     def _f(x: Tensor[(1, 128), "bf16"]) -> Tensor[(1, 128), "bf16"]:
         with Mesh(topology="thread", layout=(True, 32), names=("w", "t")) as m:
@@ -527,7 +658,11 @@ def _bool_mesh_dim_fn():
     return _f
 
 
-def _dimvar_split_extent_fn():
+def build_dimvar_split_extent_func():
+    """A dynamic ``DimVar`` split extent through the full ``@func`` op-arg path
+    must report the static-int diagnostic, not ``'Mesh' object has no attribute
+    'w'`` (the sugar error must not be swallowed)."""
+
     @func(topologies=(Topology("cta", 8), Topology("thread", 128)))
     def _f(x: Tensor[(8, _SPLIT_EXTENT_K), "bf16"]) -> Tensor[(8, 1), "bf16"]:
         with Mesh(topology="thread", layout=(4, 32), names=("w", "t")) as m:
@@ -537,7 +672,10 @@ def _dimvar_split_extent_fn():
     return _f
 
 
-def _bool_split_extent_single_axis_fn():
+def build_bool_split_extent_single_axis_func():
+    """A ``bool`` split extent in the single-axis form (``True @ m.w``) is
+    rejected with a static-int diagnostic."""
+
     @func(topologies=(Topology("thread", 128),))
     def _f(x: Tensor[(1, 128), "bf16"]) -> Tensor[(1, 128), "bf16"]:
         with Mesh(topology="thread", layout=(4, 32), names=("w", "t")) as m:
@@ -547,7 +685,10 @@ def _bool_split_extent_single_axis_fn():
     return _f
 
 
-def _bool_split_extent_multi_axis_fn():
+def build_bool_split_extent_multi_axis_func():
+    """A ``bool`` split extent in the multi-axis form (``True @ (m.w, m.t)``) is
+    rejected with a static-int diagnostic."""
+
     @func(topologies=(Topology("thread", 128),))
     def _f(x: Tensor[(1, 128), "bf16"]) -> Tensor[(1, 128), "bf16"]:
         with Mesh(topology="thread", layout=(4, 32), names=("w", "t")) as m:
@@ -558,13 +699,13 @@ def _bool_split_extent_multi_axis_fn():
 
 
 @pytest.mark.parametrize(
-    "build",
+    "build_func",
     [
-        _dimvar_mesh_dim_fn,
-        _bool_mesh_dim_fn,
-        _dimvar_split_extent_fn,
-        _bool_split_extent_single_axis_fn,
-        _bool_split_extent_multi_axis_fn,
+        build_dimvar_mesh_dim_func,
+        build_bool_mesh_dim_func,
+        build_dimvar_split_extent_func,
+        build_bool_split_extent_single_axis_func,
+        build_bool_split_extent_multi_axis_func,
     ],
     ids=[
         "dimvar-mesh-dim",
@@ -574,10 +715,8 @@ def _bool_split_extent_multi_axis_fn():
         "bool-split-multi-axis",
     ],
 )
-def test_static_extent_position_rejects_non_static_int(build) -> None:
-    """A dynamic (``DimVar``) or ``bool`` value in a static-extent position (mesh
-    dim or split extent) is rejected with a clear static-int diagnostic; the
-    sugar error must surface rather than be swallowed into a generic
-    ``'Mesh' object has no attribute ...`` attribute error."""
-    with pytest.raises(ValueError, match="static int"):
-        build()
+def test_static_extent_position_rejects_non_static_int(build_func) -> None:
+    """A dynamic (``DimVar``) or ``bool`` value in a static-extent position is
+    rejected with a clear static-int diagnostic; the sugar error must surface
+    rather than be swallowed into a generic attribute error."""
+    assert_build_raises(build_func, match="static int")

--- a/tests/parser/hir/test_parse_shard_sugar.py
+++ b/tests/parser/hir/test_parse_shard_sugar.py
@@ -442,10 +442,10 @@ def test_reshard_sugar_rejects_dynamic_split_axis() -> None:
         )
 
 
-# ── closure / static-int dims in a mesh-shape sugar (task #5 P1/P2) ───────────
+# ── closure / static-int dims in a mesh-shape sugar ──────────────────────────
 # These exercise the ``with Mesh(Topology(...), (dims), names)`` body path
-# (`parse_mesh_layout_sugar`), which — unlike the shard/split path above — did
-# not thread the closure and rejected any ``ast.Name`` dim.
+# (`parse_mesh_layout_sugar`): a closure/global int dim resolves like a literal,
+# and a dynamic or bool dim is rejected with a static-int diagnostic.
 
 
 def _mesh_body_fn(threads, warps, lanes):
@@ -474,15 +474,14 @@ def _mesh_body_literal():
 
 
 def test_closure_int_mesh_dims_resolve_like_literals() -> None:
-    """E1: closure/global ints in a mesh-shape sugar (``(WARPS, LANES)`` and the
-    topology extent ``THREADS``) resolve identically to integer literals — the
+    """Closure/global ints in a mesh-shape sugar (``(WARPS, LANES)`` and the
+    topology extent ``THREADS``) resolve identically to integer literals; the
     parser must not reject the ``ast.Name``."""
     assert as_script(_mesh_body_fn(128, 4, 32)) == as_script(_mesh_body_literal())
 
 
 def test_closure_int_split_extent_still_parses() -> None:
-    """E2 (regression lock): a closure int as a split extent already works and
-    must keep working."""
+    """A closure int used as a split extent resolves and parses."""
     k_tile = 128
 
     @func(topologies=(Topology("thread", 128),))
@@ -495,8 +494,8 @@ def test_closure_int_split_extent_still_parses() -> None:
 
 
 def test_dimvar_mesh_dim_reports_static_int() -> None:
-    """E4: a ``DimVar`` in a mesh-shape position is rejected with a clear
-    static-int diagnostic (not a raw ``expected int dim`` / attribute error)."""
+    """A ``DimVar`` in a mesh-shape position is rejected with a clear static-int
+    diagnostic (not a raw AST / attribute error)."""
     w = DimVar("W", 1, 8)
 
     with pytest.raises(ValueError, match="static int"):
@@ -509,7 +508,7 @@ def test_dimvar_mesh_dim_reports_static_int() -> None:
 
 
 def test_bool_mesh_dim_rejected() -> None:
-    """E5: ``bool`` is rejected as a mesh dim even though it subclasses ``int``."""
+    """``bool`` is rejected as a mesh dim even though it subclasses ``int``."""
     warps = True
 
     with pytest.raises(ValueError, match="static int"):
@@ -518,4 +517,48 @@ def test_bool_mesh_dim_rejected() -> None:
         def _bad(x: Tensor[(1, 128), "bf16"]) -> Tensor[(1, 128), "bf16"]:
             with Mesh(Topology("thread", 128), (warps, 32), ("w", "t")) as m:
                 xr = reshard(x, (1, 128 @ (m.w, m.t)), "rmem")  # noqa: F821
+                return reshard(xr, (1, 128), "gmem")  # noqa: F821
+
+
+# ── malformed layout sugar surfaces (not swallowed → AttributeError) ──────────
+# A sugar ValueError raised once the node is recognized as layout sugar must not
+# be swallowed into generic static eval (which turned the real "static int"
+# diagnostic into `'Mesh' object has no attribute 'w'`).
+
+
+def test_dimvar_split_extent_full_pipeline_reports_static_int() -> None:
+    """A ``DimVar`` split extent through the full ``@func`` op-arg path reports a
+    clear static-int error, not ``'Mesh' object has no attribute 'w'``."""
+    k = DimVar("K", 32, 256)
+
+    with pytest.raises(ValueError, match="static int"):
+
+        @func(topologies=(Topology("cta", 8), Topology("thread", 128)))
+        def _bad(x: Tensor[(8, k), "bf16"]) -> Tensor[(8, 1), "bf16"]:
+            with Mesh(Topology("thread", 128), (4, 32), ("w", "t")) as m:
+                xr = reshard(x, (8, k @ (m.w, m.t)), "rmem")  # noqa: F821
+                return reshard(xr, (8, 1), "gmem")  # noqa: F821
+
+
+def test_bool_split_extent_single_axis_rejected() -> None:
+    """A ``bool`` split extent (``True @ m.w``) is rejected with a static-int
+    error rather than being swallowed."""
+    with pytest.raises(ValueError, match="static int"):
+
+        @func(topologies=(Topology("thread", 128),))
+        def _bad(x: Tensor[(1, 128), "bf16"]) -> Tensor[(1, 128), "bf16"]:
+            with Mesh(Topology("thread", 128), (4, 32), ("w", "t")) as m:
+                xr = reshard(x, (1, True @ m.w), "rmem")  # noqa: F821
+                return reshard(xr, (1, 128), "gmem")  # noqa: F821
+
+
+def test_bool_split_extent_multi_axis_rejected() -> None:
+    """A ``bool`` split extent in the multi-axis form (``True @ (m.w, m.t)``) is
+    rejected with a static-int error."""
+    with pytest.raises(ValueError, match="static int"):
+
+        @func(topologies=(Topology("thread", 128),))
+        def _bad(x: Tensor[(1, 128), "bf16"]) -> Tensor[(1, 128), "bf16"]:
+            with Mesh(Topology("thread", 128), (4, 32), ("w", "t")) as m:
+                xr = reshard(x, (1, True @ (m.w, m.t)), "rmem")  # noqa: F821
                 return reshard(xr, (1, 128), "gmem")  # noqa: F821


### PR DESCRIPTION
## Summary

Narrow parser fix (task #5). Two rough edges forced Qwen3-Omni kernels onto
f-string source templating and produced a misleading diagnostic; this fixes both
without adding any dynamic-layout feature.

**M1 (P1) — closure/static-int dims in mesh & split positions** (`8d85c59`)
- `_extract_dim_int` resolves a closure/global `Name` (e.g. `WARPS = 4`) to a
  static int via `_eval_ast`; rejects `bool` and non-int (`DimVar`) with a clear
  `layout dim must be a static int` diagnostic.
- Threaded `closure` through `_parse_layout_literal` / `parse_mesh_layout_sugar`
  and passed it at the `with Mesh(...)` body call site (`hir_parser`).
- Spec `docs/spec/parser.md` §1.5 updated (static-extent accepts closure/global
  int; bool/dynamic rejected).

**M2 (P2) — surface malformed layout-sugar errors** (`0ec4b28`)
- Added `LayoutSugarError(ValueError)`; the static-int violations raise it.
- `base.py` re-raises `LayoutSugarError` from the speculative sugar-parse paths
  instead of swallowing it into `_eval_static` (which turned the real "static
  int" diagnostic into `'Mesh' object has no attribute 'w'`). A genuine
  not-sugar `ValueError` still falls back as before.

## Tests

`tests/parser/hir/test_parse_shard_sugar.py`: closure mesh dims equal the
literal form, closure split-extent lock, `DimVar`/`bool` mesh rejection, `DimVar`
split-extent full-pipeline diagnostic, and split-bool single/multi-axis.

- `tests/parser/` → 124 passed.
- Broader non-GPU regression → 613 passed (one env-only `nvcc not on PATH`
  failure, passes with CUDA on PATH — unrelated to this change).

## Non-goals

No dynamic-outer tiled-layout feature; no de-templating; `DimVar` remains
rejected as a static extent (M2 only makes the error clear).

## Plan

Requirements/plan doc is kept local (the `docs/plans/` dir is gitignored per repo
convention): `docs/plans/dsl-shape-parser-fix.md`.
