### PR TITLE
docs(spec): unified-entry-format + ownership reorg (analysis owner, spec restructure)

### DIFF
--- a/docs/SPEC-RULES.md
+++ b/docs/SPEC-RULES.md
@@ -16,28 +16,50 @@ solely because a specific spec rule requires it.
 
 ## Unified Entry Format
 
-Spec entries for ops, runtime functions, public classes, and pass/helper classes
-use one outer shell:
+Spec entries for ops, runtime functions, public classes, enums, and
+pass/helper classes render the construct as a **source-code interface** in its
+own language, followed by its constraints:
 
 ````md
 #### Name
-```text
-signature / ClassName<...>
+```python
+class Name:
+    field_a: TypeA                        # role of field_a
+    field_b: TypeB                        # role of field_b
+    def method(self, arg: T) -> R: ...    # role of method
 ```
-- kind: HIR op | TIR op | runtime func | C++ class | Python class/pass
-- fields:
-  - name: role or argument/member/effect description
 - constraints:
+  - contract rule
   - contract rule
 ````
 
-The `fields` content adapts to `kind`: class entries describe members/type
-fields; function entries describe arguments, returns, effects, or runtime state.
-Do not paste a full dataclass or re-list code-identical fields when a compact
-signature and a few stable keys carry the contract.
+Rules:
+
+- Show the **interface only** — the class / enum / struct surface, field
+  annotations, and method / function signatures. Never include a method body,
+  traversal loop, registry / decorator implementation, or any other executable
+  detail; a signature ends in `...`.
+- Write the construct in its real language: `python` for Python classes /
+  functions / decorators / enums, `cpp` for C++ / CUDA enums / classes /
+  structs / types / functions.
+- Describe each field's and method's role with a **short inline comment** on the
+  same line (`# ...` in Python, `// ...` in C++). A longer note goes in a
+  docstring / block comment that explains role only, never mechanics.
+- An op-catalog entry renders as a callable signature
+  (e.g. `Binary(kind, lhs, rhs) -> Tensor`) with inline comments; its owning
+  dialect is conveyed by the file / namespace, not a separate label.
+- A `- constraints:` bullet list follows the code block and carries the contract
+  rules — including every normative MUST / SHALL / SHOULD sentence.
+- One code block MAY list several signatures of the same family when that reads
+  clearly.
+- Do not re-list code-identical fields twice or paste a full implementation; the
+  interface surface plus constraints carries the contract.
+- Example code appears only to pin an otherwise-ambiguous contract corner (an
+  edge case). It never replaces an entry's interface surface and never repeats a
+  full implementation.
 
 Consensus ops may be grouped when one external reference defines their behavior.
-Custom TileFoundry ops and public runtime entries need their own compact entry.
+Custom TileFoundry ops and public runtime entries need their own entry.
 
 ## Constraints
 

--- a/docs/SPEC-RULES.md
+++ b/docs/SPEC-RULES.md
@@ -16,47 +16,26 @@ solely because a specific spec rule requires it.
 
 ## Unified Entry Format
 
-Spec entries for ops, runtime functions, public classes, enums, and
-pass/helper classes render the construct as a **source-code interface** in its
-own language, followed by its constraints:
+A spec entry shows the construct's **source-code interface** — the
+class / enum / struct / function / op-callable surface with field annotations
+and method signatures (ending in `...`, no bodies), each field or method given a
+short inline comment for its role — followed by a `- constraints:` list:
 
 ````md
 #### Name
 ```python
 class Name:
     field_a: TypeA                        # role of field_a
-    field_b: TypeB                        # role of field_b
     def method(self, arg: T) -> R: ...    # role of method
 ```
 - constraints:
-  - contract rule
-  - contract rule
+  - contract rule (every normative MUST / SHALL / SHOULD sentence lives here)
 ````
 
-Rules:
-
-- Show the **interface only** — the class / enum / struct surface, field
-  annotations, and method / function signatures. Never include a method body,
-  traversal loop, registry / decorator implementation, or any other executable
-  detail; a signature ends in `...`.
-- Write the construct in its real language: `python` for Python classes /
-  functions / decorators / enums, `cpp` for C++ / CUDA enums / classes /
-  structs / types / functions.
-- Describe each field's and method's role with a **short inline comment** on the
-  same line (`# ...` in Python, `// ...` in C++). A longer note goes in a
-  docstring / block comment that explains role only, never mechanics.
-- An op-catalog entry renders as a callable signature
-  (e.g. `Binary(kind, lhs, rhs) -> Tensor`) with inline comments; its owning
-  dialect is conveyed by the file / namespace, not a separate label.
-- A `- constraints:` bullet list follows the code block and carries the contract
-  rules — including every normative MUST / SHALL / SHOULD sentence.
-- One code block MAY list several signatures of the same family when that reads
-  clearly.
-- Do not re-list code-identical fields twice or paste a full implementation; the
-  interface surface plus constraints carries the contract.
-- Example code appears only to pin an otherwise-ambiguous contract corner (an
-  edge case). It never replaces an entry's interface surface and never repeats a
-  full implementation.
+Interface only: no method body, traversal, or registry / decorator
+implementation. Write the construct in its own language (`python` / `cpp`). One
+block may group a family of related signatures. Example code appears only to pin
+an ambiguous contract corner, never to repeat an implementation.
 
 Consensus ops may be grouped when one external reference defines their behavior.
 Custom TileFoundry ops and public runtime entries need their own entry.

--- a/docs/spec/analysis.md
+++ b/docs/spec/analysis.md
@@ -1,0 +1,164 @@
+# TileFoundry Spec — analysis (static analysis services)
+
+This spec owns TileFoundry's concrete static analysis services — the semantic
+contracts that derive types, access relations, and shard layouts over the IR.
+Each service is a registry-backed derived visitor: the common registration and
+dispatch mechanism is owned by [visitor-registry](./visitor-registry.md); this
+file owns each service's requirements, handler shape, required context, and the
+semantic rules it enforces. TileGraph relation vocabulary is owned by
+[tilegraph](./tilegraph.md); this file links to it rather than redefining it.
+
+## 1. Type propagation
+
+Type inference is registered per Op through
+`@register_typeinfer(<OpClass>)` and enforces its constraints via `ctx.error(...)`
+([visitor-registry §4](./visitor-registry.md)). A handler receives the op and a
+typeinfer context, derives the output `IRType`, and reports violations through
+`ctx.error`.
+
+### 1.1 Relation-derived type behavior
+
+An op's typeinfer MAY derive the output type from a forward access
+relation ([visitor-registry §4.1](./visitor-registry.md#41-forward-relation-service--type_relation))
+rather than from a hand-written rule. The relation describes one
+shared iteration domain and, per boundary, an access map from that
+domain to the tensor's index space. The relation carries **no tensor
+shape**: the output shape is typeinfer-side data, derived from the
+op's shape rule or (where implemented) from the relation by composing
+the output access map over the domain.
+
+Within the relation:
+
+- A domain dim that appears in an input access map but **not** in the
+  output access map is a **reduction** dim (it is eliminated in the
+  output).
+- A tensor axis whose access maps to a constant (rather than a domain
+  dim) is a **broadcast** axis.
+- A symbolic size is an isl parameter of the domain; the relation's
+  rank is fixed and is read from the input types.
+
+The shard consequences of these structural facts (how `Split` /
+`Broadcast` / `Partial` propagate, and the reduction effect) are
+defined in [§3.2](#32-relation-driven-shard-propagation).
+
+### 1.2 Domain construction and output shape derivation
+
+The relation describes one shared iteration domain; a symbolic size is an isl
+parameter of that domain, and the relation's rank is fixed and read from the
+input types. Output shape is not carried by the relation — it is typeinfer-side
+data, derived from the op's shape rule or, where implemented, by composing the
+output access map over the domain. Output access-map arity is validated by the
+relation service ([visitor-registry §4.1](./visitor-registry.md#41-forward-relation-service--type_relation)).
+
+## 2. Access relation analysis
+
+The forward access relation is the boundary model shared by relation-derived
+type behavior and shard propagation: one iteration domain plus, per boundary, an
+affine access map from that domain to a tensor's index space. The relation
+vocabulary — access relations, opaque relations, and the access-relation result
+carrier — is defined in [tilegraph §3.4](./tilegraph.md#34-accessrelation); the
+relation service that produces it is registered as described in
+[visitor-registry §4.1](./visitor-registry.md#41-forward-relation-service--type_relation).
+The rule reads only the access maps' affine structure (which domain dim each
+axis uses), never the domain bounds, so it is size-agnostic and identical for
+static and dynamic shapes.
+
+## 3. Shard propagation
+
+### 3.1 Logical shape to layout domain
+
+- `TensorType.shape` is the logical shape.
+- `layout` has its own domain shape.
+- The current interpretation is canonical regroup: linearize first
+  along the logical shape's row-major order, then reinterpret along
+  the layout domain's row-major order.
+
+### 3.2 Relation-driven shard propagation
+
+When an op's output `ShardLayout` is derived from a forward access
+relation ([§1.1](#11-relation-derived-type-behavior)), the
+output `ShardAttr`s are determined from the input shards and the
+relation's access maps by a single rule, shared across ops.
+
+**Reduction effect.** A reduction dim (a domain dim absent from the
+output access map) carries one of two effects, declared by the
+op/relation:
+
+- `partial` — the per-shard result is a partial that still needs a
+  cross-shard reduction (e.g. a contraction dim split across the mesh);
+- `complete` — the reduction is already complete within each shard
+  (e.g. an explicit reduce over a sharded axis).
+
+**Propagation.** Per input mesh axis, by its attr:
+
+1. `Split(k)` — map cute axis `k` to the input's logical tensor axis,
+   then to a domain dim via the input access map.
+2. If that domain dim appears in the output access map, the output
+   carries `Split` on the **output layout axis** the domain dim maps to.
+3. If that domain dim is a reduction dim, the output mesh axis becomes
+   `Partial(reduction)` when the effect is `partial`, or `Broadcast`
+   when the effect is `complete`. The resulting `Partial` carries no
+   cute axis — it is a value state on that mesh axis.
+4. `Partial(reduction)` input — propagates on the **same mesh axis**:
+   propagate unchanged when the dataflow is homogeneous in `reduction`;
+   resolve to `Broadcast` via an explicit reduction / allreduce over that
+   axis; error on a non-homogeneous use or an unreduced function
+   output / return. There is no cute-axis mapping for a `Partial`.
+5. A `Broadcast` (size-1) input axis contributes no `Split`.
+6. Two inputs binding the same domain dim to incompatible mesh axes is
+   an error.
+
+A `Partial` MUST NOT be silently eliminated by an ordinary op
+(no silent loss); only an explicit `Reshard` / allreduce from `Partial`
+to `Broadcast` completes it.
+
+A fully-`Broadcast` input `ShardLayout` (every attr `Broadcast`) is
+**replicated**: it carries no real sharding, so it contributes no
+`Split` / `Partial` and does not pin a mesh — it MAY combine with an
+input sharded on a different mesh. When no input carries real sharding
+the output carries none.
+
+An input `Split` that accesses a non-projection domain dim, or an
+output-surviving dim reachable only through a non-projection output
+access, MUST **fail closed** rather than guess a mapping. The rule
+reads only the access maps' affine structure (which domain dim each
+axis uses), never the domain bounds, so it is size-agnostic and
+identical for static and dynamic shapes.
+
+**Owner axis.** `Split(axis)` indexes an **output layout (cute) axis**,
+not the logical tensor axis. A reduction-induced `Partial` attaches to no
+cute axis — it is a value state on the mesh axis that was reduced.
+
+### 3.3 Output storage and mesh/layout compatibility
+
+A symmetric multi-input op (`Binary`, `MatMul`, `Concat`, `Stack`,
+`Mma`) resolves its output `storage` by **anchoring** on the concrete
+residency among its operands ([types §2](./types.md)). The rule does not
+appeal to any ordering of storage kinds and is independent of operand order:
+
+- An **unmaterialized** operand (`storage=umat`) does not constrain the
+  output — it abstains.
+- One concrete operand storage (alongside any unmaterialized operands) is
+  the **anchor**; the output takes that storage.
+- Several concrete operands that agree on a storage → the output takes that
+  storage.
+- Several concrete operands that disagree on storage → typeinfer MUST
+  `ctx.error`, unless the op defines its own destination/mixed-storage
+  resolution. There is no operand-order tie-break.
+- All operands unmaterialized → the output is unmaterialized (`umat`).
+
+This resolution uses no memory-level lattice; output residency is a function
+of the concrete anchor(s) alone. (The `rmem < smem < gmem` hierarchy is
+a `Reshard`-*direction* notion and is unrelated to output-storage anchoring.)
+
+A tensor value's mesh / layout is carried by its `TensorType.layout`
+(`ShardLayout.mesh` names the mesh instance) — that type is the source of
+truth, and the IR places no scope-based restriction on values from
+different meshes coexisting. Each op's registered typeinfer **owns** the
+operand layout / mesh compatibility it requires and its result layout;
+there is no uniform cross-op rule imposed from outside typeinfer.
+`Reshard` is the explicit op that changes a value's layout / mesh.
+
+Per-op typeinfer owns layout compatibility and result layout. For example,
+`Gather` owns whether an indexed access is a pure slice or a layout-preserving
+data-dependent gather.

--- a/docs/spec/architecture.md
+++ b/docs/spec/architecture.md
@@ -195,6 +195,7 @@ This table is the authoritative spec-to-box map. Each row lists the
 | **[inspection](./inspection.md)** | Developer-facing IR presentation: DOT, Python DSL pretty-printer, viewer detail rules, dump integration |
 | **[evaluator](./evaluator.md)** | HIR reference interpreter: `evaluate` entry, `Value` family (`TensorValue` / `TupleValue`), `register_eval` op registry, node-evaluation + `GridRegionExpr` + layout-domain rules. Logical reference oracle, no codegen / runtime |
 | **[visitor-registry](./visitor-registry.md)** | Derived-visitor dispatch pattern: `AnalysisRegistry`, per-class handler registration, four instances (`typeinfer` / `verify` / `codegen_<target>` / `cost`) with their Context / Visitor derivations |
+| **[analysis](./analysis.md)** | Static analysis service semantics: type propagation (relation-derived type behavior), access relation analysis, shard propagation (logical shape → layout domain, relation-driven propagation, output storage + mesh/layout compatibility). The registration mechanism itself is owned by visitor-registry |
 | **[visitor-mutator](./visitor-mutator.md)** | IR traversal / rewrite infrastructure: expr / stmt visitors, mutators, identity-preserving rewrite invariants, mixed stmt-expr traversal |
 | **[passes](./passes.md)** | Pass framework + implemented passes: `Pass` / `PassManager`, three pass granularities, per-pass subsections (lowering / optimization rules) |
 | **[tilegraph](./tilegraph.md)** | TileGraph — pass-internal IR for polyhedral / tile-search passes |

--- a/docs/spec/code-organization.md
+++ b/docs/spec/code-organization.md
@@ -136,7 +136,7 @@ else.
 - User imports go through the `tilefoundry.dsl.tf` /
   `tilefoundry.dsl.T` namespaces' `__getattr__`, not through the
   per-category `__init__.py`
-  ([parser §2](./parser.md#2-dsl-namespace-package)).
+  ([parser §2](./parser.md#2-dsl-namespace-surface)).
 
 **Rule 6 — one pass = one file.** A pass class lives in
 `passes/transforms/<pass_name>.py` (snake_case file name = pass

--- a/docs/spec/code-organization.md
+++ b/docs/spec/code-organization.md
@@ -69,7 +69,7 @@ snake_case of the Op class CamelCase (`MatMul` → `matmul.py`,
 follow the same rule.
 
 **Rule 1a — surface-alias schemas have no per-name file.** A surface
-alias ([core-ir §4.1](./core-ir.md#41-surface-aliases-register_alias))
+alias ([core-ir §2.3](./core-ir.md#surface-aliases-register_alias))
 has no IR class — its builder routes to a kinded target Op. All
 aliases for a category live together in `aliases.py` (e.g. the 19
 HIR math sugar names `add` / `sub` / `cmp_eq` / `neg` / … all

--- a/docs/spec/codegen.md
+++ b/docs/spec/codegen.md
@@ -36,6 +36,7 @@ flowchart LR
 
 ## 2. Emitter
 
+
 An emitter walks a verified `tir.PrimFunction` and produces source plus the
 metadata the link step needs.
 
@@ -116,6 +117,7 @@ contract lives in [runtime.md §3](runtime.md#3-runtime-ops).
 ## 4. Codegen products
 
 ### 4.1 `LinkableFunction`
+
 
 One lowered function's pre-link source.
 
@@ -204,8 +206,9 @@ commands are an implementation detail and not part of the contract.
 
 ## 5. Dispatch and shape-scalar ABI
 
+
 A `tir.PrimFunction` produced by HIR→TIR lowering for a dispatch prototype
-([hir §5](./hir.md#5-dispatch-specializations)) emits as a host dispatch entry
+([hir §1.1](./hir.md#11-function)) emits as a host dispatch entry
 plus its variant kernels:
 
 - **Dispatch entry** (PrimFunction whose body is a single `tir.DispatchCall`):

--- a/docs/spec/codegen.md
+++ b/docs/spec/codegen.md
@@ -232,7 +232,7 @@ TVM_FFI_DLL_EXPORT_TYPED_FUNC(<name>, __tilefoundry_<sanitized>_host);
 ```
 
 **Shape-scalar parameter ABI.** Each `tir.ShapeOf(param, axis)`
-([tir §7](./tir.md#7-shapeof)) reachable from a PrimFunction body adds a hidden
+([tir §2.2](./tir.md#22-shapeof)) reachable from a PrimFunction body adds a hidden
 kernel-scalar parameter named `f"{param.name}_shape_<axis>"` — a rank-0 `i32`
 shape-scalar `TensorType` with `storage=None`. The host wrapper extracts the
 value from the

--- a/docs/spec/codegen.md
+++ b/docs/spec/codegen.md
@@ -34,6 +34,10 @@ flowchart LR
   C-ABI launch shims. The host module invokes device code only through that
   C-ABI shim.
 
+The target-specific emitter behavior — how a `cpu` vs `cuda` function emits, the
+dispatch and shape-scalar ABI, program-shape / dynamic-CTA accessors, and the
+`ShardLayout` runtime mapping — is owned by [target](./target.md).
+
 ## 2. Emitter
 
 
@@ -89,22 +93,7 @@ walker matches `Evaluate` and dispatches on `type(callable)` through
 the handler registry. Handlers stay small; the runtime function they
 call carries the semantic load.
 
-## 3. Target-driven emission
-
-Emission is split by function `target`; one `LinkableModule` is produced per
-target group.
-
-- A `cpu`-target entry function emits the **host translation unit**: a host
-  wrapper that marshals `tvm::ffi::Tensor` arguments and invokes the device
-  entry through its C-ABI launch shim. For a dispatch prototype the wrapper
-  also performs the `DispatchCall` selection (§5).
-- A `cuda`-target function emits the **device translation unit**: a
-  `__global__` kernel plus its C-ABI launch shim. An operand's layout selects
-  how it is viewed inside the kernel — `cute::` for a plain `Layout`,
-  `tilefoundry::` shard tensor for a `ShardLayout` (§7) — it does not change the
-  function into a `__device__`-parameter function.
-
-### 3.1 Runtime-owned op dispatch
+## 3. Runtime-owned op dispatch
 
 Where more than one runtime template implements an op, codegen emits **one
 uniform runtime op call**, passing the operand `ShardLayout`s (and any
@@ -112,7 +101,9 @@ codegen-static participant geometry) as compile-time template parameters. The
 runtime template dispatches on those layouts at compile time; codegen does not
 select a tier, compute a per-tier parameter, or carry the selection on the TIR
 op. This is the codegen side of the runtime-owned dispatch principle, whose
-contract lives in [runtime.md §3](runtime.md#3-runtime-ops).
+contract lives in [runtime.md §3](runtime.md#3-runtime-ops). The target-side
+emission that produces these calls is owned by
+[target §5](./target.md#5-target-driven-emission).
 
 ## 4. Codegen products
 
@@ -121,44 +112,38 @@ contract lives in [runtime.md §3](runtime.md#3-runtime-ops).
 
 One lowered function's pre-link source.
 
-```python
-@dataclass(frozen=True)
-class LinkableFunction:
-    name: str
-    source: str
+```text
+LinkableFunction(name: str, source: str)
 ```
 
-#### `name`
-- MUST be the function / kernel symbol.
-
-#### `source`
-- MUST be that function's emitted text.
+- kind: Python class
+- fields:
+  - name: the function / kernel symbol
+  - source: that function's emitted text
+- constraints:
+  - MUST be the function / kernel symbol.
+  - MUST be that function's emitted text.
 
 ### 4.2 `LinkableModule`
 
 One target's pre-link translation unit.
 
-```python
-@dataclass(frozen=True)
-class LinkableModule:
-    target: str
-    language: str
-    source: str
-    functions: tuple[LinkableFunction, ...]
+```text
+LinkableModule(target: str, language: str, source: str, functions: tuple[LinkableFunction, ...])
 ```
 
-#### `target`
-- MUST be the function target name (`cuda` / `cpu`).
-
-#### `language`
-- MUST be the source language: `cu` for a CUDA translation unit, `cpp` for a
-  host translation unit.
-
-#### `source`
-- MUST be the assembled translation-unit text the link step compiles.
-
-#### `functions`
-- MUST list the module's constituent `LinkableFunction`s, in emission order.
+- kind: Python class
+- fields:
+  - target: the function target name (`cuda` / `cpu`)
+  - language: the source language (`cu` / `cpp`)
+  - source: the assembled translation-unit text
+  - functions: the module's constituent `LinkableFunction`s
+- constraints:
+  - MUST be the function target name (`cuda` / `cpu`).
+  - MUST be the source language: `cu` for a CUDA translation unit, `cpp` for a
+    host translation unit.
+  - MUST be the assembled translation-unit text the link step compiles.
+  - MUST list the module's constituent `LinkableFunction`s, in emission order.
 
 A `LinkableModule` is a build artifact, not a runtime object and not a
 user-callable.
@@ -168,31 +153,24 @@ user-callable.
 The link output: a loadable artifact plus the host-visible metadata the loader
 needs.
 
-```python
-@dataclass(frozen=True)
-class LinkedModule:
-    library_path: Path
-    source: str
-    entry: CallableType
-    launch_config: LaunchConfig
-    kernels: tuple[KernelInfo, ...]
+```text
+LinkedModule(library_path: Path, source: str, entry: CallableType, launch_config: LaunchConfig, kernels: tuple[KernelInfo, ...])
 ```
 
-#### `library_path`
-- MUST point at the produced shared library.
-
-#### `source`
-- MUST carry the assembled host + device source — the diagnostic source the
-  runtime exposes as `RuntimeModule.source` ([runtime](./runtime.md)).
-
-#### `entry`
-- MUST be the host-visible callable type of the module entry.
-
-#### `launch_config`
-- MUST carry the entry's launch geometry (grid / block extents).
-
-#### `kernels`
-- MUST list the ABI of the module's `__global__` kernels.
+- kind: Python class
+- fields:
+  - library_path: the produced shared library
+  - source: the assembled host + device source
+  - entry: the host-visible callable type of the module entry
+  - launch_config: the entry's launch geometry (grid / block extents)
+  - kernels: the ABI of the module's `__global__` kernels
+- constraints:
+  - MUST point at the produced shared library.
+  - MUST carry the assembled host + device source — the diagnostic source the
+    runtime exposes as `RuntimeModule.source` ([runtime](./runtime.md)).
+  - MUST be the host-visible callable type of the module entry.
+  - MUST carry the entry's launch geometry (grid / block extents).
+  - MUST list the ABI of the module's `__global__` kernels.
 
 The `entry` `CallableType`, `launch_config` `LaunchConfig`, and `kernels`
 `KernelInfo` are host-visible ABI metadata types owned by
@@ -203,70 +181,3 @@ The link step consumes the per-target `LinkableModule`s, compiles each with its
 own toolchain, and links them into one `LinkedModule`. `LinkedModule` is
 consumed by the runtime loader ([runtime](./runtime.md)); the concrete compiler
 commands are an implementation detail and not part of the contract.
-
-## 5. Dispatch and shape-scalar ABI
-
-
-A `tir.PrimFunction` produced by HIR→TIR lowering for a dispatch prototype
-([hir §1.1](./hir.md#11-function)) emits as a host dispatch entry
-plus its variant kernels:
-
-- **Dispatch entry** (PrimFunction whose body is a single `tir.DispatchCall`):
-  the host module emits a host-only entry — no kernel. It reads the dispatch
-  subject from the host-visible tensor shape, evaluates the case predicates in
-  source order, and invokes the matching variant's C-ABI launch shim. The
-  `fallback` MUST fail the host call with a host-side error.
-- **Variant**: a `cuda`-target function (§3) — a `__global__` kernel plus its
-  C-ABI launch shim in the CUDA module, carrying the hidden shape-scalar
-  parameters below. A variant has no host wrapper of its own; the dispatch entry
-  calls its shim.
-
-**Host-visible entry symbol.** The host-visible entry wrapper (the CPU entry) is
-emitted under an internal symbol `__tilefoundry_<sanitized>_host`, where
-`<sanitized>` is the user-facing name with `$` replaced by `__` (`$` is a GCC
-extension, not portable C++). The user-facing name is republished via the
-runtime ABI macro:
-
-```cpp
-TVM_FFI_DLL_EXPORT_TYPED_FUNC(<name>, __tilefoundry_<sanitized>_host);
-```
-
-**Shape-scalar parameter ABI.** Each `tir.ShapeOf(param, axis)`
-([tir §2.2](./tir.md#22-shapeof)) reachable from a PrimFunction body adds a hidden
-kernel-scalar parameter named `f"{param.name}_shape_<axis>"` — a rank-0 `i32`
-shape-scalar `TensorType` with `storage=None`. The host wrapper extracts the
-value from the
-corresponding `tvm::ffi::Tensor.shape()[axis]` and forwards it. These hidden
-parameters are filtered out of the exported `CallableType.params` so they remain
-invisible at the user FFI surface. A user-declared rank-0 `i32` parameter is
-*not* filtered — the filter is keyed on the canonical `<name>_shape_<axis>` form
-synthesised by lowering.
-
-## 6. Program shape and dynamic CTA
-
-The emitted device source reads its program geometry through two accessors:
-
-- `program_shape<T>()` MUST be the shape composed of a topology level's program
-  dims.
-- `program_dim<T>()` MUST be the size of one topology level `T`.
-
-For a static CTA count, `program_dim<cta>()` is a compile-time constant and a
-constexpr `program_shape<cta>` is emitted. For a launch-provided (dynamic) CTA
-count, the emitter MUST NOT emit a constexpr `program_shape<cta>`; device code
-MUST read the count through `program_dim<cta>()`, which resolves to the
-launch-provided grid extent. The topology level set a target admits is owned by
-[target §topology](./target.md).
-
-## 7. `ShardLayout` / `ShardTensor` mapping
-
-A `ShardLayout` ([shard §7](./shard.md)) on a TIR tensor type is materialised
-through `tilefoundry::make_shard_tensor(buffer, global_layout, shard_layout)`
-([runtime](./runtime.md)). A handler that consumes a sharded operand emits the
-shard-tensor view; effect Ops then route through `tilefoundry::` runtime helpers
-(for example `tilefoundry::copy`) instead of plain `cute::` primitives. A plain
-`Layout` operand goes through `cute::` directly. The selection is handler-local,
-based on `arg.type.layout`.
-
-Codegen consumes the `ShardLayout` already present on the TIR tensor type; the
-cute MMA fragment → `ShardLayout` recipe that produces it is owned by the
-lowering pass ([passes.md §7.1](./passes.md#71-hirtotirpass)).

--- a/docs/spec/codegen.md
+++ b/docs/spec/codegen.md
@@ -46,11 +46,13 @@ metadata the link step needs.
 
 ### 2.1 Emitter registry
 
-Each target registers an emitter, resolved by target name:
-
 ```python
-emit = get_emitter("cuda")    # tuple[PrimFunction, ...] -> LinkableModule
+def get_emitter(target: str) -> Emitter: ...    # resolve the emitter registered for a target
+# Emitter: Callable[[tuple[PrimFunction, ...]], LinkableModule]
 ```
+
+- constraints:
+  - each target registers one emitter, resolved by target name.
 
 An emitter MUST consume only TIR and MUST return a `LinkableModule` for its
 target. The emitter file layout mirrors the IR file layout
@@ -59,13 +61,13 @@ by [code-organization](./code-organization.md).
 
 ### 2.2 Per-Op handler registry
 
-Within a target, per-Op handlers are registered for the emitter:
-
 ```python
-@register_codegen_cuda(Copy)
-def _(call: Call, ctx: CodegenContext) -> None:
-    ctx.emit(f"tilefoundry::copy({ctx.expr(call.args[0])}, {ctx.expr(call.args[1])});")
+@register_codegen_<target>(Op)                              # decorator: register a per-Op handler on a target's emitter
+def handler(call: Call, ctx: CodegenContext) -> None: ...   # Call (wrapped Op inside Evaluate) + CodegenContext
 ```
+
+- constraints:
+  - dispatch (matching `Evaluate` and selecting the handler) is owned by visitor-registry.
 
 Dispatch is owned by [visitor-registry §6](./visitor-registry.md). A handler
 receives the `Call` (the wrapped Op inside `Evaluate`) plus a `CodegenContext`,
@@ -74,13 +76,17 @@ prohibited.
 
 ### 2.3 `CodegenContext`
 
-`CodegenContext` is the per-walk state object passed to handlers. It exposes the
-helpers a handler is allowed to use:
+```python
+class CodegenContext:
+    def emit(self, line: str) -> None: ...               # append a target source line
+    def expr(self, node: Expr) -> str: ...               # render an Expr as a target expression string
+    def dtype_to_cpp(self, dtype_name: str) -> str: ...  # backend dtype mapping
+    def make_var_name(self, ...) -> str: ...             # allocate fresh target-side identifiers
+```
 
-- `emit(line: str)` — append a target source line.
-- `expr(node: Expr) -> str` — render an `Expr` as a target expression string.
-- `dtype_to_cpp(dtype_name: str) -> str` — backend dtype mapping.
-- `make_var_name(...)` — allocate fresh target-side identifiers.
+- constraints:
+  - the per-walk state object passed to handlers; the single source of truth for
+    target-side type strings, so handlers do not read the IR for them directly.
 
 A handler MUST NOT reach into the IR for type strings on its own; the context is
 the single source of truth. Other helpers MAY be added per target.
@@ -112,14 +118,12 @@ emission that produces these calls is owned by
 
 One lowered function's pre-link source.
 
-```text
-LinkableFunction(name: str, source: str)
+```python
+class LinkableFunction:
+    name: str      # the function / kernel symbol
+    source: str    # that function's emitted text
 ```
 
-- kind: Python class
-- fields:
-  - name: the function / kernel symbol
-  - source: that function's emitted text
 - constraints:
   - MUST be the function / kernel symbol.
   - MUST be that function's emitted text.
@@ -128,16 +132,14 @@ LinkableFunction(name: str, source: str)
 
 One target's pre-link translation unit.
 
-```text
-LinkableModule(target: str, language: str, source: str, functions: tuple[LinkableFunction, ...])
+```python
+class LinkableModule:
+    target: str                              # the function target name (cuda / cpu)
+    language: str                            # the source language (cu / cpp)
+    source: str                              # the assembled translation-unit text
+    functions: tuple[LinkableFunction, ...]  # the module's constituent LinkableFunctions
 ```
 
-- kind: Python class
-- fields:
-  - target: the function target name (`cuda` / `cpu`)
-  - language: the source language (`cu` / `cpp`)
-  - source: the assembled translation-unit text
-  - functions: the module's constituent `LinkableFunction`s
 - constraints:
   - MUST be the function target name (`cuda` / `cpu`).
   - MUST be the source language: `cu` for a CUDA translation unit, `cpp` for a
@@ -153,17 +155,15 @@ user-callable.
 The link output: a loadable artifact plus the host-visible metadata the loader
 needs.
 
-```text
-LinkedModule(library_path: Path, source: str, entry: CallableType, launch_config: LaunchConfig, kernels: tuple[KernelInfo, ...])
+```python
+class LinkedModule:
+    library_path: Path                  # the produced shared library
+    source: str                         # the assembled host + device source
+    entry: CallableType                 # the host-visible callable type of the module entry
+    launch_config: LaunchConfig         # the entry's launch geometry (grid / block extents)
+    kernels: tuple[KernelInfo, ...]     # the ABI of the module's __global__ kernels
 ```
 
-- kind: Python class
-- fields:
-  - library_path: the produced shared library
-  - source: the assembled host + device source
-  - entry: the host-visible callable type of the module entry
-  - launch_config: the entry's launch geometry (grid / block extents)
-  - kernels: the ABI of the module's `__global__` kernels
 - constraints:
   - MUST point at the produced shared library.
   - MUST carry the assembled host + device source — the diagnostic source the

--- a/docs/spec/core-ir.md
+++ b/docs/spec/core-ir.md
@@ -1,20 +1,12 @@
 # TileFoundry Spec — core_ir
 
 Defines the shared node algebra — `Module` / `Expr` / `Op` / `Call` /
-`Var` / `Constant` / `Tuple` — that both HIR and TIR consume. Types
-carried by `Expr.type` are defined in [types](./types.md). `Stmt` is
-not here; it lives only in [tir §1](./tir.md) as a TIR-only base
-class.
-
----
-
-## 1. Role
-
-`core_ir` is the shared node algebra layer, not a standalone IR. HIR
-and TIR both extend it with their own `Function` container and their
-own `Op` / `Stmt` subclasses; the type system lives in
-[types](./types.md), the distributed layout layer in
-[shard](./shard.md), and the `Stmt` base class in [tir](./tir.md).
+`Var` / `Constant` / `Tuple` — that both HIR and TIR consume. `core_ir` is the
+shared node algebra layer, not a standalone IR: HIR and TIR each extend it with
+their own `Function` container and their own `Op` / `Stmt` subclasses. Types
+carried by `Expr.type` are defined in [types](./types.md); the distributed
+layout layer is [shard](./shard.md); `Stmt` is not here — it lives only in
+[tir §1](./tir.md) as a TIR-only base class.
 
 ```mermaid
 flowchart TB
@@ -33,15 +25,13 @@ flowchart TB
 ```
 
 `Module.functions` is `hir.Function | tir.PrimFunction`; the
-heterogeneous container is described in [§2](#2-module). HIR
+heterogeneous container is described in [§1](#1-module). HIR
 `Function` is an `Expr` subclass, TIR `PrimFunction` is a `Stmt`
 subclass — the diagram above intentionally does not draw an edge
 from `Module` to `Expr` to avoid implying that all functions are
 Exprs.
 
----
-
-## 2. `Module`
+## 1. `Module`
 
 ```python
 @dataclass(frozen=True)
@@ -75,15 +65,15 @@ class Module:
   its specialization variants are finalized. Variants may be added to a
   base only during authoring, before the base enters a `Module`; once
   sealed, adding a variant is an error
-  ([hir.md §5](./hir.md#5-dispatch-specializations)).
+  ([hir.md §1.1](./hir.md#11-function)).
 
-### 2.1 Function access
+### 1.1 Function access
 
 A `Module` mirrors the model it describes: a caller reaches a kernel by name.
 
 Each `name` maps to at most one `Module.functions` entry. Shape-specialization
 variants of a function live inside that entry's `Function.variants`
-([hir.md §5](./hir.md#5-dispatch-specializations)), never as separate same-name
+([hir.md §1.1](./hir.md#11-function)), never as separate same-name
 entries — so name resolution is always single-valued.
 
 - `mod.lookup(name)` returns the function named `name`; it raises when no
@@ -98,9 +88,7 @@ entries — so name resolution is always single-valued.
   attribute rules. This lets a module read like the model it mirrors —
   `decoder.self_attention`.
 
----
-
-## 3. `Expr`
+## 2. `Expr`
 
 ```python
 class Expr:
@@ -119,13 +107,66 @@ single `Call` whose `type` is `TupleType`; consumers project a single
 field through the `tuple_get_item` Op (a regular registered Op; no
 dedicated `Expr` subclass).
 
----
+Dialect-specific `Expr` subclasses are owned by their dialect specs, not
+here: HIR owns `Function` and `GridRegionExpr` ([hir §1](./hir.md#1-hir-expr-constructs)),
+and TIR owns `SymbolRef` and other TIR-specific `Expr` constructs
+([tir](./tir.md)).
 
-## 4. `Op`
+### 2.1 `Call`
+
+```python
+@dataclass(frozen=True)
+class Call(Expr):
+    """A call to an Op. The HIR body is a tree of value-form Calls; in
+    TIR a value-form Call is anchored by LetStmt, while a Stmt-position
+    effect invocation is Evaluate(op, args) (tir §2.2). A Call MUST NOT
+    appear as a top-level Stmt directly."""
+    target: Op
+    args: tuple[Expr, ...]
+    # type is computed by typeinfer(target, args); it is one of
+    # TensorType / TupleType / UnitType depending on the Op's form.
+```
+
+Constraints:
+
+- `len(args)` MUST equal the number of `kind="input"` ParamDefs on
+  `target`.
+- Each `args[i].type` MUST satisfy the i-th input ParamDef's pattern
+  / typeinfer rule.
+
+### 2.2 `Var` / `Constant` / `Tuple`
+
+```python
+@dataclass(frozen=True)
+class Var(Expr):
+    """A named value. HIR uses Var for function parameters; TIR uses Var
+    for LetStmt / For / MeshScope bindings."""
+    name: str
+    type: IRType                  # declaration-side type; the binding stmt does not override it
+
+@dataclass(frozen=True)
+class Constant(Expr):
+    """Literal constant. A scalar is a rank-0 TensorType."""
+    value: object       # int / float / tuple / ...
+
+@dataclass(frozen=True)
+class Tuple(Expr):
+    """Value-level multi-output aggregate. type is TupleType
+    ([types §4](./types.md))."""
+    fields: tuple[Expr, ...]
+```
+
+`Tuple` is the value-level aggregate node; it pairs with `TupleType`
+([types §4](./types.md)) but is not the same — `Tuple` is an `Expr`
+in the IR graph, `TupleType` is the type carried by `Expr.type`.
+
+### 2.3 `Op`
 
 `Op` is a value class (it describes an op's signature and attributes)
 — not an `Expr` subclass. A `Call` carries an `Op` instance in its
-`target` field.
+`target` field. The custom-op mechanism is declared here: parameters are
+`ParamDef` class attributes discovered through reflection, and a class is
+registered with `@register_op`.
 
 ```python
 class Op:
@@ -178,7 +219,7 @@ class ReduceSum(Op):
   attribute values on the instance: `Binary(kind=BinaryKind.ADD)` /
   `ReduceSum(axis=1, keepdims=True)`.
 
-### 4.1 Surface aliases (`@register_alias`)
+#### Surface aliases (`@register_alias`)
 
 A **surface alias** is a registry entry that has no IR class of its
 own; instead, its `OpSchema.builder` callback constructs a *target*
@@ -209,9 +250,9 @@ Properties:
 
 HIR `math` uses aliases for kinded sugar names (`add` / `sub` /
 ... / `cmp_eq` / ... / `neg` / ...); the IR core has just `Binary`
-/ `Unary` (see [hir §2.1](./hir.md#21-irhirmath)).
+/ `Unary` (see [hir math ops](./hir.md#irhirmath)).
 
-### 4.2 Input position and form
+#### Input position and form
 
 The order of `kind="input"` ParamDefs determines `Call.args`
 position: `call.args[i]` corresponds to the `i`-th input ParamDef
@@ -225,61 +266,7 @@ readable value (`UnitType`, [types §6](./types.md)); in Stmt position
 it appears as `Evaluate(op, args)`
 ([tir §2.2](./tir.md#22-evaluate)).
 
----
-
-## 5. `Call`
-
-```python
-@dataclass(frozen=True)
-class Call(Expr):
-    """A call to an Op. The HIR body is a tree of value-form Calls; in
-    TIR a value-form Call is anchored by LetStmt, while a Stmt-position
-    effect invocation is Evaluate(op, args) (tir §2.2). A Call MUST NOT
-    appear as a top-level Stmt directly."""
-    target: Op
-    args: tuple[Expr, ...]
-    # type is computed by typeinfer(target, args); it is one of
-    # TensorType / TupleType / UnitType depending on the Op's form.
-```
-
-Constraints:
-
-- `len(args)` MUST equal the number of `kind="input"` ParamDefs on
-  `target`.
-- Each `args[i].type` MUST satisfy the i-th input ParamDef's pattern
-  / typeinfer rule.
-
----
-
-## 6. `Var` / `Constant` / `Tuple`
-
-```python
-@dataclass(frozen=True)
-class Var(Expr):
-    """A named value. HIR uses Var for function parameters; TIR uses Var
-    for LetStmt / For / MeshScope bindings."""
-    name: str
-    type: IRType                  # declaration-side type; the binding stmt does not override it
-
-@dataclass(frozen=True)
-class Constant(Expr):
-    """Literal constant. A scalar is a rank-0 TensorType."""
-    value: object       # int / float / tuple / ...
-
-@dataclass(frozen=True)
-class Tuple(Expr):
-    """Value-level multi-output aggregate. type is TupleType
-    ([types §4](./types.md))."""
-    fields: tuple[Expr, ...]
-```
-
-`Tuple` is the value-level aggregate node; it pairs with `TupleType`
-([types §4](./types.md)) but is not the same — `Tuple` is an `Expr`
-in the IR graph, `TupleType` is the type carried by `Expr.type`.
-
----
-
-## 7. `Pattern`
+## 3. `Pattern`
 
 `Pattern` is the reusable predicate carrier shared by parser dispatch
 and specialization dispatch.
@@ -294,19 +281,19 @@ class Pattern:
 
 Two consumer surfaces:
 
-- **Parser dispatch** — `ParamDef.pattern` (§4) is matched against an
+- **Parser dispatch** — `ParamDef.pattern` (§2.3) is matched against an
   argument's `Expr.type` during overload resolution. Subclasses used:
   `ScalarPat` (rank-0), `TensorPat(rank?, dtype?)` (non-scalar), and
   `AndPat(parts)` (conjunction). Two singletons are exported as
   convenience: `Scalar = ScalarPat()` and `Tensor = TensorPat()`.
 - **Specialization dispatch** — patterns appearing in
-  `hir.Function.specializations` ([hir.md §5](./hir.md#5-dispatch-specializations))
+  `hir.Function.specializations` ([hir.md §1.1](./hir.md#11-function))
   and the parallel `tir.DispatchCall.case_patterns`
   ([tir.md §6](./tir.md#6-dispatchcall)) describe which runtime
   shape range a variant covers. The HIR→TIR lowering inspects each
   pattern's fields directly; it does not call `match`.
 
-### 7.1 `DimVarRangePat`
+### 3.1 `DimVarRangePat`
 
 ```python
 @dataclass(frozen=True)
@@ -333,4 +320,3 @@ class DimVarRangePat(Pattern):
   containment (`pattern ⊆ DimVar envelope`) is checked in
   signature context — by the `@tilefoundry.func` validator and the
   HIR→TIR lowering — not by `DimVarRangePat.__post_init__`.
-

--- a/docs/spec/core-ir.md
+++ b/docs/spec/core-ir.md
@@ -34,15 +34,17 @@ Exprs.
 ## 1. `Module`
 
 ```python
-@dataclass(frozen=True)
 class Module:
-    """The top-level compilation unit. Parser output; pass input/output."""
-    name: str
-    functions: tuple["hir.Function | tir.PrimFunction", ...]
-    entry: str                         # required: a name in `functions`
-    topologies: tuple[Topology, ...]   # module-level program topology namespace
-    metadata: dict[str, object]        # target / option metadata, never semantic mesh bindings
+    name: str                                               # the module name
+    functions: tuple[hir.Function | tir.PrimFunction, ...]  # the heterogeneous hir.Function | tir.PrimFunction container
+    entry: str                                              # name of the public entry function (a name present in functions)
+    topologies: tuple[Topology, ...]                        # module-level program topology namespace
+    metadata: dict[str, object]                             # target / option metadata, never semantic mesh bindings
 ```
+
+- constraints:
+  - the top-level compilation unit (parser output; pass input/output);
+    constructing a `Module` seals its functions.
 
 - `parse_module` (see [parser §1](./parser.md)) returns a `Module`.
 - `entry` is the public entry point — `tilefoundry.lower(...)` and the
@@ -92,11 +94,13 @@ entries — so name resolution is always single-valued.
 
 ```python
 class Expr:
-    """Every expression node. In HIR, an Expr is the SSA value; in TIR,
-    Stmts embed Exprs in their Expr-typed sub-fields."""
-    type: IRType                  # see [types §1](./types.md)
-    source: str | None            # optional: original source slice for debug / error location
+    type: IRType        # the node's IRType; always present
+    source: str | None  # optional original source slice for debug / error location
 ```
+
+- constraints:
+  - base of every expression node; concrete subclasses are dialect-owned, not
+    introduced per Op (value-producing Ops appear as `Call` nodes).
 
 `Expr` always carries a `type`. The runtime class of `Expr.type` is
 one of `TensorType` / `TupleType` / `UnitType`
@@ -113,6 +117,17 @@ and TIR owns `SymbolRef` and other TIR-specific `Expr` constructs
 ([tir](./tir.md)).
 
 ### 2.1 `Call`
+
+```python
+class Call(Expr):
+    target: Op              # the Op being called
+    args: tuple[Expr, ...]  # the input Exprs
+    # type: computed by typeinfer(target, args); one of TensorType / TupleType / UnitType
+```
+
+- constraints:
+  - a value-form `Call` is anchored by `LetStmt` in TIR; a Stmt-position effect
+    invocation is `Evaluate(op, args)`.
 
 ```python
 @dataclass(frozen=True)
@@ -137,24 +152,19 @@ Constraints:
 ### 2.2 `Var` / `Constant` / `Tuple`
 
 ```python
-@dataclass(frozen=True)
 class Var(Expr):
-    """A named value. HIR uses Var for function parameters; TIR uses Var
-    for LetStmt / For / MeshScope bindings."""
-    name: str
-    type: IRType                  # declaration-side type; the binding stmt does not override it
+    name: str     # a named value (HIR params, TIR bindings)
+    type: IRType  # declaration-side type
 
-@dataclass(frozen=True)
 class Constant(Expr):
-    """Literal constant. A scalar is a rank-0 TensorType."""
-    value: object       # int / float / tuple / ...
+    value: object  # a literal; a scalar is a rank-0 TensorType
 
-@dataclass(frozen=True)
 class Tuple(Expr):
-    """Value-level multi-output aggregate. type is TupleType
-    ([types §4](./types.md))."""
-    fields: tuple[Expr, ...]
+    fields: tuple[Expr, ...]  # value-level multi-output aggregate; type is TupleType
 ```
+
+- constraints:
+  - `Tuple` is an `Expr` in the IR graph, distinct from the `TupleType` it carries.
 
 `Tuple` is the value-level aggregate node; it pairs with `TupleType`
 ([types §4](./types.md)) but is not the same — `Tuple` is an `Expr`
@@ -167,6 +177,17 @@ in the IR graph, `TupleType` is the type carried by `Expr.type`.
 `target` field. The custom-op mechanism is declared here: parameters are
 `ParamDef` class attributes discovered through reflection, and a class is
 registered with `@register_op`.
+
+```python
+class Op:                                     # @register_op registers a class
+    @classmethod
+    def params(cls) -> list[ParamDef]: ...    # reflectively scans class-level ParamDef attributes and returns them ordered
+    def __init__(self, **attrs): ...          # instantiates with attribute values (a no-attribute Op is a singleton)
+```
+
+- constraints:
+  - a value class describing an op's signature/attributes, not an `Expr` subclass;
+    a `Call` carries an `Op` instance in `target`.
 
 ```python
 class Op:
@@ -185,15 +206,16 @@ class Op:
 ```
 
 ```python
-@dataclass(frozen=True)
 class ParamDef:
-    """Single Op parameter descriptor."""
-    kind: Literal["input", "attribute"]
-    annotation: type | None = None     # Python type (Expr / int / bool / tuple / ...)
-    pattern: Pattern | None = None     # input-kind only: pattern matched against arg.type
-    default: object = MISSING          # attribute-kind only: omitted-call default
-    optional: bool = False             # attribute-kind only: nullable
+    kind: Literal["input", "attribute"]  # "input" (flows into Call.args) or "attribute" (carried on the Op instance)
+    annotation: type | None              # the Python type of the parameter
+    pattern: Pattern | None              # input-kind only — the Pattern matched against arg.type
+    default: object                      # attribute-kind only — omitted-call default
+    optional: bool                       # attribute-kind only — nullability
 ```
+
+- constraints:
+  - a single Op parameter descriptor; the order of input-kind ParamDefs fixes `Call.args` position.
 
 Example:
 
@@ -226,6 +248,15 @@ own; instead, its `OpSchema.builder` callback constructs a *target*
 Op with some attributes pre-fixed. Aliases let several user-callable
 surface names share a single kinded IR class without exposing the
 `kind=...` attribute at the call site.
+
+```python
+@register_alias(dialect: str, category: str, name: str, params: list[ParamDef])  # surface-registry coordinates; params reuses the target Op's static ParamDef references
+def builder() -> Op: ...    # returns a target Op with attributes pre-fixed; takes attribute kwargs only
+```
+
+- constraints:
+  - alias schemas have no IR class (`OpSchema.op_class is None`) and prepend to the
+    schema bucket so they win first-match resolution.
 
 ```python
 @register_alias(dialect="tf", category="math", name="add",
@@ -272,12 +303,13 @@ it appears as `Evaluate(op, args)`
 and specialization dispatch.
 
 ```python
-@dataclass(frozen=True)
 class Pattern:
-    """Base predicate. Subclasses override match(subject) -> bool."""
-
-    def match(self, subject) -> bool: ...
+    def match(self, subject) -> bool: ...    # base predicate returning bool; subclasses override it
 ```
+
+- constraints:
+  - shared by parser dispatch (`ParamDef.pattern`) and specialization dispatch
+    (`Function.specializations` / `DispatchCall.case_patterns`).
 
 Two consumer surfaces:
 
@@ -296,12 +328,15 @@ Two consumer surfaces:
 ### 3.1 `DimVarRangePat`
 
 ```python
-@dataclass(frozen=True)
 class DimVarRangePat(Pattern):
-    dim_var: str
-    lo: int
-    hi: int
+    dim_var: str  # name of the DimVar the range applies to
+    lo: int       # the half-open interval [lo, hi) lower bound
+    hi: int       # the half-open interval [lo, hi) upper bound
 ```
+
+- constraints:
+  - the per-variant sub-range for a named `DimVar`; `match(v)` is `lo <= v < hi`
+    and ignores `dim_var`.
 
 - `dim_var` MUST be a non-empty `str` — the name of the `DimVar` the
   range applies to. The lowering resolves it to a runtime

--- a/docs/spec/core-ir.md
+++ b/docs/spec/core-ir.md
@@ -128,26 +128,11 @@ class Call(Expr):
 - constraints:
   - a value-form `Call` is anchored by `LetStmt` in TIR; a Stmt-position effect
     invocation is `Evaluate(op, args)`.
-
-```python
-@dataclass(frozen=True)
-class Call(Expr):
-    """A call to an Op. The HIR body is a tree of value-form Calls; in
-    TIR a value-form Call is anchored by LetStmt, while a Stmt-position
-    effect invocation is Evaluate(op, args) (tir §1.4). A Call MUST NOT
-    appear as a top-level Stmt directly."""
-    target: Op
-    args: tuple[Expr, ...]
-    # type is computed by typeinfer(target, args); it is one of
-    # TensorType / TupleType / UnitType depending on the Op's form.
-```
-
-Constraints:
-
-- `len(args)` MUST equal the number of `kind="input"` ParamDefs on
-  `target`.
-- Each `args[i].type` MUST satisfy the i-th input ParamDef's pattern
-  / typeinfer rule.
+  - A `Call` MUST NOT appear as a top-level Stmt directly.
+  - `len(args)` MUST equal the number of `kind="input"` ParamDefs on
+    `target`.
+  - Each `args[i].type` MUST satisfy the i-th input ParamDef's pattern
+    / typeinfer rule.
 
 ### 2.2 `Var` / `Constant` / `Tuple`
 
@@ -187,23 +172,10 @@ class Op:                                     # @register_op registers a class
 
 - constraints:
   - a value class describing an op's signature/attributes, not an `Expr` subclass;
-    a `Call` carries an `Op` instance in `target`.
-
-```python
-class Op:
-    """Base of every Op. Ops are value-producing through Call. Most are
-    pure; TIR has resource-introducing Ops (e.g. tir.memory.AllocTensor)
-    with positional-identity requirements that MUST be anchored by a
-    LetStmt — see [tir §2.3](./tir.md#23-tir-ops). Parameters are declared as
-    ParamDef class attributes and discovered through reflection."""
-
-    @classmethod
-    def params(cls) -> list[ParamDef]:
-        """Reflectively scan class-level ParamDef attributes and return
-        the ordered ParamDef list."""
-
-    def __init__(self, **attrs): ...
-```
+    a `Call` carries an `Op` instance in `target`; most Ops are pure.
+  - resource-introducing Ops (e.g. `tir.memory.AllocTensor`) with
+    positional-identity requirements MUST be anchored by a `LetStmt`
+    (see [tir §2.3](./tir.md#23-tir-ops)).
 
 ```python
 class ParamDef:

--- a/docs/spec/core-ir.md
+++ b/docs/spec/core-ir.md
@@ -119,7 +119,7 @@ and TIR owns `SymbolRef` and other TIR-specific `Expr` constructs
 class Call(Expr):
     """A call to an Op. The HIR body is a tree of value-form Calls; in
     TIR a value-form Call is anchored by LetStmt, while a Stmt-position
-    effect invocation is Evaluate(op, args) (tir §2.2). A Call MUST NOT
+    effect invocation is Evaluate(op, args) (tir §1.4). A Call MUST NOT
     appear as a top-level Stmt directly."""
     target: Op
     args: tuple[Expr, ...]
@@ -173,7 +173,7 @@ class Op:
     """Base of every Op. Ops are value-producing through Call. Most are
     pure; TIR has resource-introducing Ops (e.g. tir.memory.AllocTensor)
     with positional-identity requirements that MUST be anchored by a
-    LetStmt — see [tir §5.1](./tir.md). Parameters are declared as
+    LetStmt — see [tir §2.3](./tir.md#23-tir-ops). Parameters are declared as
     ParamDef class attributes and discovered through reflection."""
 
     @classmethod
@@ -264,7 +264,7 @@ result the IR consumes — `Call.type` is then `TensorType` or
 effect (e.g. `tir.memory.Copy` / `tir.cuda.nn.Mma`) and produces no
 readable value (`UnitType`, [types §6](./types.md)); in Stmt position
 it appears as `Evaluate(op, args)`
-([tir §2.2](./tir.md#22-evaluate)).
+([tir §1.4](./tir.md#14-evaluate)).
 
 ## 3. `Pattern`
 
@@ -289,7 +289,7 @@ Two consumer surfaces:
 - **Specialization dispatch** — patterns appearing in
   `hir.Function.specializations` ([hir.md §1.1](./hir.md#11-function))
   and the parallel `tir.DispatchCall.case_patterns`
-  ([tir.md §6](./tir.md#6-dispatchcall)) describe which runtime
+  ([tir.md §1.6](./tir.md#16-dispatchcall)) describe which runtime
   shape range a variant covers. The HIR→TIR lowering inspects each
   pattern's fields directly; it does not call `match`.
 

--- a/docs/spec/evaluator.md
+++ b/docs/spec/evaluator.md
@@ -119,7 +119,7 @@ rules; a handler MUST NOT depend on type inference having run.
 
 Evaluation is an `ExprVisitor[Value]`
 ([visitor-mutator §1](./visitor-mutator.md)) memoized on `id(expr)`, so
-a shared sub-DAG ([hir §1](./hir.md)) is evaluated once:
+a shared sub-DAG ([hir §1.1](./hir.md)) is evaluated once:
 
 ```python
 def visit(expr):                      # memoized: id(expr) -> Value
@@ -142,19 +142,19 @@ def visit(expr):                      # memoized: id(expr) -> Value
 ```
 
 - A `Var` resolves to its binding in the current environment; a
-  `Constant` ([core-ir §3](./core-ir.md)) materialises to a backend
+  `Constant` ([core-ir §2](./core-ir.md)) materialises to a backend
   tensor of its `TensorType` (a scalar becomes a rank-0 tensor).
 - A `Call` whose `target` is an `Op` evaluates its operands, then
   dispatches through `eval_registry`
   ([§3](#3-register_eval-and-the-eval-context)).
-- A `Call` whose `target` is a `Function` ([hir §1](./hir.md)) binds the
+- A `Call` whose `target` is a `Function` ([hir §1.1](./hir.md)) binds the
   evaluated arguments to the callee's parameters in a fresh environment
   and evaluates the callee `body` — the same value semantics a call site
   has under type inference.
 
 ## 5. `GridRegionExpr`
 
-A `GridRegionExpr` ([hir §4](./hir.md)) is a loop over its iteration
+A `GridRegionExpr` ([hir §1.2](./hir.md)) is a loop over its iteration
 domain whose carry chain starts from `init_args`:
 
 ```python
@@ -191,7 +191,7 @@ values:
   `axes` in the operand's **logical** `TensorType.shape`, regardless of
   `type.layout`. A computation that must group a logical axis differently
   (e.g. per-head normalisation) is expressed by a logical `Reshape`
-  ([hir §2.2](./hir.md)) to the target logical shape *before* the op; the
+  ([hir §1.3](./hir.md)) to the target logical shape *before* the op; the
   op's axis then indexes that reshaped logical shape. `Reshard` only
   changes distribution / layout and never changes which values an op
   reduces or indexes.
@@ -202,8 +202,8 @@ values:
   inverse. These are provided for an op explicitly defined to compute in
   the layout domain; no op in the current set is layout-domain, so none
   of them call these helpers.
-- `Reshard` ([hir §2.5](./hir.md)) preserves the logical value and MAY
+- `Reshard` ([hir §1.3](./hir.md)) preserves the logical value and MAY
   reshape it into the target layout's shape; it performs no
   cross-participant data movement.
-- `Local` ([hir §2.5](./hir.md)) returns its operand's value for the
+- `Local` ([hir §1.3](./hir.md)) returns its operand's value for the
   single modelled participant.

--- a/docs/spec/evaluator.md
+++ b/docs/spec/evaluator.md
@@ -45,32 +45,43 @@ single-output node produces a `TensorValue`; a multi-output node (a
 `Tuple`, a `TupleType` `Call`, or a multi-carry `GridRegionExpr`)
 produces a `TupleValue`.
 
-```python
-class Value:
-    """Base of every evaluated value."""
-
-@dataclass(frozen=True)
-class TensorValue(Value):
-    data: "torch.Tensor"     # logical tensor value
-    type: TensorType         # HIR type of this value (carries layout)
-
-@dataclass(frozen=True)
-class TupleValue(Value):
-    elements: tuple[Value, ...]
+```text
+Value()
 ```
+
+- kind: Python class
+- fields: none — base of every evaluated value
+- constraints: none — abstract base; concrete values are `TensorValue` / `TupleValue`
 
 ### `TensorValue`
 
-- `data` holds the value in its **logical shape** — the shape of
-  `type` ([types §2](./types.md)), not a layout-domain shape.
-- `type.layout`, when a `ShardLayout` or `Layout`, drives the
-  layout-domain projection of [§6](#6-layout-domain).
-- A scalar value is a rank-0 `data` with a rank-0 `TensorType`.
+```text
+TensorValue(data: torch.Tensor, type: TensorType)
+```
+
+- kind: Python class
+- fields:
+  - data: the logical tensor value
+  - type: the HIR type of this value (carries layout)
+- constraints:
+  - `data` holds the value in its **logical shape** — the shape of
+    `type` ([types §2](./types.md)), not a layout-domain shape.
+  - `type.layout`, when a `ShardLayout` or `Layout`, drives the
+    layout-domain projection of [§6](#6-layout-domain).
+  - A scalar value is a rank-0 `data` with a rank-0 `TensorType`.
 
 ### `TupleValue`
 
-- `elements` are the per-field `Value`s; `tuple_get_item` projects one
-  by static index.
+```text
+TupleValue(elements: tuple[Value, ...])
+```
+
+- kind: Python class
+- fields:
+  - elements: the per-field `Value`s
+- constraints:
+  - `elements` are the per-field `Value`s; `tuple_get_item` projects one
+    by static index.
 
 ## 2. Parameters and inputs
 

--- a/docs/spec/evaluator.md
+++ b/docs/spec/evaluator.md
@@ -45,24 +45,20 @@ single-output node produces a `TensorValue`; a multi-output node (a
 `Tuple`, a `TupleType` `Call`, or a multi-carry `GridRegionExpr`)
 produces a `TupleValue`.
 
-```text
-Value()
+```python
+class Value: ...    # base of every evaluated value
 ```
 
-- kind: Python class
-- fields: none — base of every evaluated value
 - constraints: none — abstract base; concrete values are `TensorValue` / `TupleValue`
 
 ### `TensorValue`
 
-```text
-TensorValue(data: torch.Tensor, type: TensorType)
+```python
+class TensorValue:
+    data: torch.Tensor    # the logical tensor value
+    type: TensorType      # the HIR type of this value (carries layout)
 ```
 
-- kind: Python class
-- fields:
-  - data: the logical tensor value
-  - type: the HIR type of this value (carries layout)
 - constraints:
   - `data` holds the value in its **logical shape** — the shape of
     `type` ([types §2](./types.md)), not a layout-domain shape.
@@ -72,13 +68,11 @@ TensorValue(data: torch.Tensor, type: TensorType)
 
 ### `TupleValue`
 
-```text
-TupleValue(elements: tuple[Value, ...])
+```python
+class TupleValue:
+    elements: tuple[Value, ...]    # the per-field `Value`s
 ```
 
-- kind: Python class
-- fields:
-  - elements: the per-field `Value`s
 - constraints:
   - `elements` are the per-field `Value`s; `tuple_get_item` projects one
     by static index.
@@ -113,14 +107,15 @@ def register_eval(op_cls: type[Op]): ...   # decorator
 
 A handler receives an `EvalContext` and returns a `Value`:
 
-- `ctx.args` — the already-evaluated operands in `Call.args` order; each
-  is a `Value` (`TensorValue`, or `TupleValue` for a multi-output
-  operand).
-- `ctx.op` — the op instance; attributes are read as fields (e.g.
-  `ctx.op.kind`, `ctx.op.index`).
-- `ctx.result_type` — the `Call`'s result type.
-- `ctx.device` — the backend device; a handler that materialises a new
-  tensor (e.g. `Zeros`) creates it there.
+```python
+class EvalContext:
+    args: tuple[Value, ...]    # already-evaluated operands in `Call.args` order (TensorValue / TupleValue)
+    op: Op                     # the op instance; attributes read as fields (e.g. `ctx.op.kind`, `ctx.op.index`)
+    result_type: Type          # the `Call`'s result type
+    device: torch.device       # backend device; a handler materialising a new tensor (e.g. `Zeros`) creates it there
+
+def handler(ctx: EvalContext) -> Value: ...    # a registered per-op value handler
+```
 
 A `Call` whose op class has no registered handler raises an error that
 names the op class. Backend dtype promotion follows the backend's own
@@ -133,23 +128,8 @@ Evaluation is an `ExprVisitor[Value]`
 a shared sub-DAG ([hir §1.1](./hir.md)) is evaluated once:
 
 ```python
-def visit(expr):                      # memoized: id(expr) -> Value
-    match expr:
-        case Var():
-            return env[expr]
-        case Constant():
-            return TensorValue(as_tensor(expr.value, expr.type.dtype), expr.type)
-        case Tuple():
-            return TupleValue(tuple(visit(e) for e in expr.elements))
-        case Call(target=Op() as op):                  # value op
-            args = tuple(visit(a) for a in expr.args)
-            return eval_registry[type(op)](EvalContext(op, args, expr.type))
-        case Call(target=Function() as fn):            # function call
-            args = [visit(a) for a in expr.args]
-            sub_env = {p: a for p, a in zip(fn.params, args)}
-            return Evaluator(sub_env).visit(fn.body)
-        case GridRegionExpr():
-            return eval_grid(expr)                      # §5
+class Evaluator(ExprVisitor[Value]):             # memoized on id(expr): a shared sub-DAG is evaluated once
+    def visit(self, expr: Expr) -> Value: ...    # dispatch by expr kind: Var / Constant / Tuple / Call(Op) / Call(Function) / GridRegionExpr
 ```
 
 - A `Var` resolves to its binding in the current environment; a
@@ -169,18 +149,7 @@ A `GridRegionExpr` ([hir §1.2](./hir.md)) is a loop over its iteration
 domain whose carry chain starts from `init_args`:
 
 ```python
-def eval_grid(region):
-    if not region.carried_args:                        # no-carry loop
-        for i in range(0, region.extent, region.step):
-            last = Evaluator({**env, iv: scalar(i)}).visit(region.body)
-        return last                                    # final body value
-
-    carried = [visit(init) for init in region.init_args]
-    for i in range(0, region.extent, region.step):
-        scope = {**env, region.induction_var: scalar(i)}
-        scope.update(zip(region.carried_args, carried))
-        carried = [Evaluator(scope).visit(y) for y in region.yield_values]
-    return carried[0] if len(carried) == 1 else TupleValue(tuple(carried))
+def eval_grid(region: GridRegionExpr) -> Value: ...    # loop over the iteration domain; carry chain starts from init_args
 ```
 
 - The first iteration binds each `carried_args` phi to the matching

--- a/docs/spec/hir.md
+++ b/docs/spec/hir.md
@@ -333,66 +333,14 @@ Every constraint below is enforced by the registered
 - Any HIR Op MUST be value-form ([core-ir §4](./core-ir.md));
   emitting an effect-form Call into HIR is a verify error.
 
-### 3.1 Relation-driven type validity
-
-An op's typeinfer MAY derive the output type from a forward access
-relation ([visitor-registry §4.1](./visitor-registry.md#41-forward-relation-service--type_relation))
-rather than from a hand-written rule. The relation describes one
-shared iteration domain and, per boundary, an access map from that
-domain to the tensor's index space. The relation carries **no tensor
-shape**: the output shape is typeinfer-side data, derived from the
-op's shape rule or (where implemented) from the relation by composing
-the output access map over the domain.
-
-Within the relation:
-
-- A domain dim that appears in an input access map but **not** in the
-  output access map is a **reduction** dim (it is eliminated in the
-  output).
-- A tensor axis whose access maps to a constant (rather than a domain
-  dim) is a **broadcast** axis.
-- A symbolic size is an isl parameter of the domain; the relation's
-  rank is fixed and is read from the input types.
-
-The shard consequences of these structural facts (how `Split` /
-`Broadcast` / `Partial` propagate, and the reduction effect) are
-defined in [shard §9](./shard.md#9-relation-driven-shard-propagation).
-
-### 3.2 Output storage of multi-input ops
-
-A symmetric multi-input op (`Binary`, `MatMul`, `Concat`, `Stack`,
-`Mma`) resolves its output `storage` by **anchoring** on the concrete
-residency among its operands ([types §2](./types.md)). The rule does not
-appeal to any ordering of storage kinds and is independent of operand order:
-
-- An **unmaterialized** operand (`storage=umat`) does not constrain the
-  output — it abstains.
-- One concrete operand storage (alongside any unmaterialized operands) is
-  the **anchor**; the output takes that storage.
-- Several concrete operands that agree on a storage → the output takes that
-  storage.
-- Several concrete operands that disagree on storage → typeinfer MUST
-  `ctx.error`, unless the op defines its own destination/mixed-storage
-  resolution. There is no operand-order tie-break.
-- All operands unmaterialized → the output is unmaterialized (`umat`).
-
-This resolution uses no memory-level lattice; output residency is a function
-of the concrete anchor(s) alone. (The `rmem < smem < gmem` hierarchy in §3 is
-a `Reshard`-*direction* notion and is unrelated to output-storage anchoring.)
-
-### 3.3 Operand layout / mesh ownership
-
-A tensor value's mesh / layout is carried by its `TensorType.layout`
-(`ShardLayout.mesh` names the mesh instance) — that type is the source of
-truth, and the IR places no scope-based restriction on values from
-different meshes coexisting. Each op's registered typeinfer **owns** the
-operand layout / mesh compatibility it requires and its result layout;
-there is no uniform cross-op rule imposed from outside typeinfer.
-`Reshard` is the explicit op that changes a value's layout / mesh.
-
-Per-op typeinfer owns layout compatibility and result layout. For example,
-`Gather` owns whether an indexed access is a pure slice or a layout-preserving
-data-dependent gather.
+Generic, analysis-wide typing behavior is owned by
+[analysis](./analysis.md): relation-driven type validity
+([analysis §1.1](./analysis.md#11-relation-derived-type-behavior)), output
+storage of multi-input ops, and operand layout / mesh ownership
+([analysis §3.3](./analysis.md#33-output-storage-and-meshlayout-compatibility)).
+HIR ops call these services; each op's registered typeinfer owns the layout /
+mesh compatibility and result layout it requires, and `Reshard` is the explicit
+op that changes a value's layout / mesh.
 
 ## 4. `GridRegionExpr`
 

--- a/docs/spec/hir.md
+++ b/docs/spec/hir.md
@@ -37,12 +37,16 @@ class Function(Expr):
     """HIR's function container. An Expr subclass — its value type is
     the function signature, and call sites resolve through Module's
     symbol table."""
-    name: str
+    name: str                               # the function name; call sites resolve through Module's symbol table
     params: tuple[Var, ...]                 # each Var carries a type annotation
     body: Expr | None                       # a single Expr — typically a Call DAG; None for a dispatch prototype
     return_type: IRType                     # TensorType for single output, TupleType for multi
     topologies: tuple[Topology, ...]        # convenience for single-function modules
 ```
+- constraints:
+  - an `Expr` subclass whose value type is the function signature; always returns
+    by value (explicit output params are TIR-only). Typing and shape-dispatch
+    rules are stated below.
 
 `Function.body` is a **single Expr** (usually a Call DAG, possibly
 nested inside a `GridRegionExpr`). HIR has no Stmt sequence; name
@@ -212,15 +216,19 @@ top-level `Module.functions` entry MUST NOT be a variant: a top-level
 class GridRegionExpr(Expr):
     """Loop-phi-shaped structured SSA — the only HIR exception to
     pure Call DAG. Folds a tile-style loop into a single Expr value."""
-    induction_var: Var
-    carried_args: tuple[Var, ...]
-    init_args: tuple[Expr, ...]
-    body: Expr
-    yield_values: tuple[Expr, ...]
+    induction_var: Var                       # loop induction Var, ranging over range(start, extent, step)
+    carried_args: tuple[Var, ...]            # loop-phi carry chain (equal lengths)
+    init_args: tuple[Expr, ...]              # loop-phi carry chain (equal lengths)
+    body: Expr                               # the loop body Expr
+    yield_values: tuple[Expr, ...]           # loop-phi carry chain (equal lengths)
     extent: ShapeDim                         # iteration-domain stop (half-open)
     step: ShapeDim                           # induction-var stride
     start: ShapeDim = 0                       # iteration-domain start (default 0)
 ```
+- constraints:
+  - the only HIR exception to pure Call DAG: loop-phi-shaped structured SSA that
+    folds a tile-style loop into one `Expr` value; `type` is `TensorType` (single
+    carry) or `TupleType` (multi-carry).
 
 **Iteration domain.** Both DSL loop surfaces — `for i in tile(...)` and
 `for i in range(...)` — lower to this one node; they share the domain
@@ -339,24 +347,16 @@ per-name IR classes.
 [torch element-wise ops](https://pytorch.org/docs/stable/torch.html#pointwise-ops).
 
 ##### Binary
-```text
-Binary(kind, lhs, rhs) -> Tensor
+```python
+Binary(kind, lhs, rhs) -> Tensor    # kind: binary arithmetic, comparison, or boolean tag; lhs / rhs: input tensors
 ```
-- kind: HIR op
-- fields:
-  - kind: binary arithmetic, comparison, or boolean tag
-  - lhs / rhs: input tensors
 - constraints:
   - Behavior follows torch pointwise semantics with TileFoundry type promotion.
 
 ##### Unary
-```text
-Unary(kind, x) -> Tensor
+```python
+Unary(kind, x) -> Tensor    # kind: unary tag including neg, abs, logical_not, and rsqrt; x: input tensor
 ```
-- kind: HIR op
-- fields:
-  - kind: unary tag including `neg`, `abs`, `logical_not`, and `rsqrt`
-  - x: input tensor
 - constraints:
   - Behavior follows torch pointwise semantics with TileFoundry type promotion.
 
@@ -369,27 +369,16 @@ Tensor structural operations; consensus ops follow torch / numpy
 Consensus torch / numpy structural ops.
 
 ##### Zeros
-```text
-Zeros(shape, dtype, storage) -> Tensor
+```python
+Zeros(shape, dtype, storage) -> Tensor    # shape: output logical shape; dtype: output dtype; storage: output storage kind
 ```
-- kind: HIR op
-- fields:
-  - shape: output logical shape
-  - dtype: output dtype
-  - storage: output storage kind
 - constraints:
   - The result is zero-initialised.
 
 ##### Reduce
-```text
-Reduce(x, axes, keepdim, kind) -> Tensor
+```python
+Reduce(x, axes, keepdim, kind) -> Tensor    # x: input tensor; axes: reduced logical axes; keepdim: whether reduced axes remain as size-1 axes; kind: mean, sum, abs_max, or max
 ```
-- kind: HIR op
-- fields:
-  - x: input tensor
-  - axes: reduced logical axes
-  - keepdim: whether reduced axes remain as size-1 axes
-  - kind: `mean`, `sum`, `abs_max`, or `max`
 - constraints:
   - The logical result shape follows numpy reduction rules.
   - Storage is preserved.
@@ -402,16 +391,9 @@ Reduce(x, axes, keepdim, kind) -> Tensor
     from an HIR dispatch field.
 
 ##### insert_slice
-```text
-insert_slice(dst, update, offsets) -> Tensor
+```python
+insert_slice(dst, update, offsets) -> Tensor    # dst: target tensor (value form returns a new tensor anchored on this buffer at lowering time); update: tensor written into the slice window; offsets: scalar runtime value or integer literal for the implemented 1-D case
 ```
-- kind: HIR op
-- fields:
-  - dst: target tensor; the value form returns a new tensor anchored on this
-    buffer at lowering time
-  - update: tensor written into the slice window
-  - offsets: scalar runtime value or integer literal for the implemented 1-D
-    case
 - constraints:
   - `update` has the same rank and dtype as `dst`.
   - The implemented 1-D case writes the contiguous window
@@ -434,23 +416,16 @@ Shape-level Ops on whole shape values (per-axis dim Ops are
 [types §3](./types.md)).
 
 ##### ShapeExtract
-```text
-ShapeExtract(shape, axis) -> Dim
+```python
+ShapeExtract(shape, axis) -> Dim    # shape: input shape value; axis: extracted axis
 ```
-- kind: HIR op
-- fields:
-  - shape: input shape value
-  - axis: extracted axis
 - constraints:
   - The result is the dimension at `axis`.
 
 ##### ShapeCompose
-```text
-ShapeCompose(dims) -> Shape
+```python
+ShapeCompose(dims) -> Shape    # dims: per-axis dimensions
 ```
-- kind: HIR op
-- fields:
-  - dims: per-axis dimensions
 - constraints:
   - The result is a shape value assembled in input order.
 
@@ -460,14 +435,9 @@ ShapeCompose(dims) -> Shape
 ([shard §5](./shard.md)).
 
 ##### Reshard
-```text
-Reshard(x, layout=None, storage=None) -> Tensor
+```python
+Reshard(x, layout=None, storage=None) -> Tensor    # x: input tensor; layout: optional target ShardLayout; storage: optional target storage kind
 ```
-- kind: HIR op
-- fields:
-  - x: input tensor
-  - layout: optional target `ShardLayout`
-  - storage: optional target storage kind
 - constraints:
   - Omitting `layout` preserves `x.layout`; omitting `storage` preserves
     `x.storage`.
@@ -505,12 +475,9 @@ cross-CTA data redistribution (all-to-all / gather across CTAs) is not part of
 this op.
 
 ##### Local
-```text
-Local(x) -> Tensor
+```python
+Local(x) -> Tensor    # x: input tensor with ShardLayout
 ```
-- kind: HIR op
-- fields:
-  - x: input tensor with `ShardLayout`
 - constraints:
   - The result shape contracts each `Split` axis by that mesh axis's extent.
   - `dtype` and `storage` are preserved.

--- a/docs/spec/hir.md
+++ b/docs/spec/hir.md
@@ -1,8 +1,12 @@
 # TileFoundry Spec — hir (`@func` pure SSA dataflow IR)
 
-Defines `hir.Function`, the HIR Op subdirectories
-(math / tensor / nn / shape / sharding), the structured-SSA
-exception `GridRegionExpr`, and the parser-level Mesh-scope rule.
+Defines HIR, the pure SSA-as-DAG dataflow IR: its `Expr` constructs — the
+`Function` container, the structured-SSA exception `GridRegionExpr`, and the
+HIR Op subdirectories (math / tensor / nn / shape / sharding) — together with
+their HIR-specific typing rules. Mesh scope is authored in the parser
+([parser](./parser.md)) and its `Mesh` / `Topology` are defined by shard
+([shard §5](./shard.md)); HIR links to those owners where a construct carries
+the result.
 
 ```mermaid
 flowchart TB
@@ -17,7 +21,15 @@ flowchart TB
     Op --> HirOpBase
 ```
 
-## 1. `Function`
+## 1. HIR Expr constructs
+
+HIR values are `Expr` nodes ([core-ir §2](./core-ir.md)): a `Function`
+container, the loop-phi-shaped `GridRegionExpr`, and value `Op` calls. HIR is
+pure **SSA-as-DAG** — there are no `Region` / `Block` abstractions and no Stmt
+sequence; the single structured exception that carries loop-phi-shaped SSA is
+`GridRegionExpr`.
+
+### 1.1 `Function`
 
 ```python
 @dataclass(frozen=True)
@@ -38,7 +50,7 @@ reuse lives in the parser's lexical environment, not the IR. The one
 exception is a **dispatch prototype** — a specialized function's base,
 whose body is `None` (written `pass` in the DSL); it declares the
 signature and dispatch envelope only, and its variants carry the
-implementations ([§5](#5-dispatch-specializations)).
+implementations (see **Shape dispatch and specializations** below).
 
 `Function` always returns by value; explicit output parameters are
 TIR-only (see [tir](./tir.md)). `HirToTirPass` materialises the HIR
@@ -47,7 +59,7 @@ HIR → TIR boundary.
 
 `topologies` is the convenience declaration for a single-function
 program. Before `compile` / `jit`, it lifts to `Module.topologies`
-([core-ir §2](./core-ir.md)). A `with Mesh(topology="cta", ...) as cta:`
+([core-ir §1](./core-ir.md)). A `with Mesh(topology="cta", ...) as cta:`
 inside the body resolves the topology name through the active
 namespace and creates a parser-lexical mesh binding;
 `ShardLayout.mesh` MUST point at an active binding on the lexical
@@ -80,7 +92,7 @@ whose cute factorization straddles a new axis), typeinfer fails at that
 op, not at the boundary. A dispatch-prototype callee (`variants != ()`,
 `body is None`) is not re-derived: the call's result is the declared
 `return_type` and the `None` body is never inspected (variant selection
-is [§5](#5-dispatch-specializations)).
+is **Shape dispatch and specializations** below).
 
 **Signature annotation `Layout.strides` materialization.** A
 `Tensor[..., (sugar)]` annotation on a parameter or return appears
@@ -106,211 +118,12 @@ results is expressed by Python object identity:
 
 There are no `Region` / `Block` abstractions in HIR. The single
 structured exception that carries loop-phi-shaped SSA is
-`GridRegionExpr` ([§4](#4-gridregionexpr)). Everything else is a
+`GridRegionExpr` ([§1.2](#12-gridregionexpr)). Everything else is a
 pure Call DAG.
 
-## 2. Op catalog
-
-HIR Ops are organised under `tilefoundry.ir.hir.<namespace>/`; the
-subdirectory is file organisation, not a separate IR layer. A **custom Op**
-records its full contract (fields, typing / verifier rules, worked examples)
-in its catalog entry below; a **consensus Op** needs only one sentence or a
-grouped external reference, per [SPEC-RULES](../SPEC-RULES.md). The op name is
-the pointer — code carries no back-link to this catalog. Field signatures and
-`ParamDef` listings stay in code ([core-ir §4](./core-ir.md)).
-
-### 2.1 `ir/hir/math/`
-
-Pointwise arithmetic and comparison, torch semantics with TileFoundry
-type-promotion. User-callable names (`add` / `cmp_eq` / `logical_and` / …) are
-surface aliases ([core-ir §4](./core-ir.md)) over the kinded Ops; there are no
-per-name IR classes.
-[torch element-wise ops](https://pytorch.org/docs/stable/torch.html#pointwise-ops).
-
-#### Binary
-```text
-Binary(kind, lhs, rhs) -> Tensor
-```
-- kind: HIR op
-- fields:
-  - kind: binary arithmetic, comparison, or boolean tag
-  - lhs / rhs: input tensors
-- constraints:
-  - Behavior follows torch pointwise semantics with TileFoundry type promotion.
-
-#### Unary
-```text
-Unary(kind, x) -> Tensor
-```
-- kind: HIR op
-- fields:
-  - kind: unary tag including `neg`, `abs`, `logical_not`, and `rsqrt`
-  - x: input tensor
-- constraints:
-  - Behavior follows torch pointwise semantics with TileFoundry type promotion.
-
-### 2.2 `ir/hir/tensor/`
-
-Tensor structural operations; consensus ops follow torch / numpy
-([torch tensor manipulation ops](https://pytorch.org/docs/stable/torch.html#indexing-slicing-joining-mutating-ops)).
-
-#### Reshape / Transpose / Slice / Concat / Stack / Split / Gather / ShapeOf / Rank / Cast
-Consensus torch / numpy structural ops.
-
-#### Zeros
-```text
-Zeros(shape, dtype, storage) -> Tensor
-```
-- kind: HIR op
-- fields:
-  - shape: output logical shape
-  - dtype: output dtype
-  - storage: output storage kind
-- constraints:
-  - The result is zero-initialised.
-
-#### Reduce
-```text
-Reduce(x, axes, keepdim, kind) -> Tensor
-```
-- kind: HIR op
-- fields:
-  - x: input tensor
-  - axes: reduced logical axes
-  - keepdim: whether reduced axes remain as size-1 axes
-  - kind: `mean`, `sum`, `abs_max`, or `max`
-- constraints:
-  - The logical result shape follows numpy reduction rules.
-  - Storage is preserved.
-  - Plain input layout passes through unchanged.
-  - For `ShardLayout` input, every split cute position that belongs to a
-    reduced tensor axis collapses to broadcast with size-1 stride-0 output.
-  - Non-default-stride sharded input must carry explicit producer strides, or
-    typeinfer rejects it.
-  - Lowering emits TIR `Reduce`; runtime dispatch is derived from operands, not
-    from an HIR dispatch field.
-
-#### insert_slice
-```text
-insert_slice(dst, update, offsets) -> Tensor
-```
-- kind: HIR op
-- fields:
-  - dst: target tensor; the value form returns a new tensor anchored on this
-    buffer at lowering time
-  - update: tensor written into the slice window
-  - offsets: scalar runtime value or integer literal for the implemented 1-D
-    case
-- constraints:
-  - `update` has the same rank and dtype as `dst`.
-  - The implemented 1-D case writes the contiguous window
-    `[start, start + update.shape[0])`.
-  - Higher-rank inputs share the surface but are rejected until implemented.
-  - Statically out-of-bounds windows fail typeinfer; runtime-only bounds are
-    checked by eval/runtime.
-
-### 2.3 `ir/hir/nn/`
-
-Neural-network value Ops following torch semantics
-([torch.nn.functional](https://pytorch.org/docs/stable/nn.functional.html)).
-
-#### MatMul / Conv2D / ReLU / Sigmoid / Tanh / SoftMax / LayerNorm
-Consensus torch.nn.functional ops.
-
-### 2.4 `ir/hir/shape/`
-
-Shape-level Ops on whole shape values (per-axis dim Ops are
-[types §3](./types.md)).
-
-#### ShapeExtract
-```text
-ShapeExtract(shape, axis) -> Dim
-```
-- kind: HIR op
-- fields:
-  - shape: input shape value
-  - axis: extracted axis
-- constraints:
-  - The result is the dimension at `axis`.
-
-#### ShapeCompose
-```text
-ShapeCompose(dims) -> Shape
-```
-- kind: HIR op
-- fields:
-  - dims: per-axis dimensions
-- constraints:
-  - The result is a shape value assembled in input order.
-
-### 2.5 `ir/hir/sharding/`
-
-`ShardLayout` and `Mesh` are type-system constructs, not Expr inputs
-([shard §5](./shard.md)).
-
-#### Reshard
-```text
-Reshard(x, layout=None, storage=None) -> Tensor
-```
-- kind: HIR op
-- fields:
-  - x: input tensor
-  - layout: optional target `ShardLayout`
-  - storage: optional target storage kind
-- constraints:
-  - Omitting `layout` preserves `x.layout`; omitting `storage` preserves
-    `x.storage`.
-  - The output preserves the input logical `TensorType.shape`.
-  - Supplied `layout` is a `ShardLayout`.
-  - Destination storage is concrete, not unmaterialized.
-  - The single op covers zero-copy view, cross-storage copy, cross-CTA
-    redistribute, and mixed cases; typeinfer/costmodel classify the call.
-
-**Stride resolution.** Storage direction follows the physical addressability
-hierarchy `rmem < smem < gmem` (per-thread / per-CTA / per-program). Typeinfer
-dispatches on `(layout, storage)`:
-
-- `layout=None`, storage unchanged → `x.type` (no-op).
-- `layout=None`, storage changed → error; a storage change MUST carry an
-  explicit `layout=`.
-- `layout=Layout(strides=None)` (sugar), storage unchanged → dest strides match
-  the form already on `x.layout`: a Split-axes-zero source ⇒ per-instance form;
-  otherwise ⇒ shared-engine C-order over the canonical global shape. When
-  `x.layout` is `None` (plain kernel-param), fall back to shared-engine C-order.
-- `layout=Layout(strides=None)` (sugar), low → high level → dest strides =
-  C-order over `layout.shape` (shared-engine form).
-- `layout=Layout(strides=None)` (sugar), high → low level → dest `strides[k]=0`
-  for every `Split` axis `k`; non-`Split` axes follow C-order over
-  `shard_layout_local_shape(layout)` with size-1 → 0 (per-instance form).
-- `layout=Layout(strides=tuple)` (verbose) → dest strides are taken verbatim;
-  typeinfer MUST NOT rewrite them (e.g. SM80 MMA fragment layouts).
-
-**Cross-CTA fence.** The grid fence for a cross-CTA reshard is owned by the
-reshard lowering, not by a separately authored sync. When a reshard reads a
-gmem shard produced under a different CTA ownership (an ownership change across
-a cta mesh), the lowering MUST emit a grid barrier before the reshard so every
-CTA's prior shard writes are visible. The reshard lowering owns only the fence;
-cross-CTA data redistribution (all-to-all / gather across CTAs) is not part of
-this op.
-
-#### Local
-```text
-Local(x) -> Tensor
-```
-- kind: HIR op
-- fields:
-  - x: input tensor with `ShardLayout`
-- constraints:
-  - The result shape contracts each `Split` axis by that mesh axis's extent.
-  - `dtype` and `storage` are preserved.
-  - The shard wrapper is stripped, leaving the base `Layout`.
-  - Static split sizes divide by mesh extent; symbolic sizes pass through.
-
-## 3. Typing / structural rules
-
-Every constraint below is enforced by the registered
-`@register_typeinfer(<OpClass>)` body via `ctx.error(...)`
-([visitor-registry §4](./visitor-registry.md)).
+**Function typing rules.** Enforced by the registered
+`@register_typeinfer(Function)` body via `ctx.error(...)`
+([visitor-registry §4](./visitor-registry.md)):
 
 - `Function.body` is a single Expr; Stmts MUST NOT appear.
 - `Function.params` entries MUST be `Var`s.
@@ -319,30 +132,80 @@ Every constraint below is enforced by the registered
   `(lo, hi)` bounds; a disagreement is a verify error. A
   `DimVarRangePat` specialization MUST anchor to a `DimVar` reachable
   from an input parameter and lie within that `DimVar`'s envelope
-  ([§5](#5-dispatch-specializations)).
-- `Local(x)`: `x.type.layout` MUST be `ShardLayout`. The result
-  shape contracts per the `Split` axes; dtype is preserved; layout
-  becomes the corresponding local layout.
-- `Reshard(x, layout, storage)`: `layout` and `storage` are attributes
-  (compile-time constants); the output preserves `x.type.shape` (logical).
-  Architecture invariant: after HIR typeinfer runs, every `ShardLayout`
-  reachable from a value's type has concrete `layout.strides` (never `None`) —
-  the un-materialized (`strides=None`) parser sugar MUST be materialized by the
-  owning typeinfer. The per-op `(layout, storage)` resolution table is in the
-  `Reshard` catalog entry (§2.5).
-- Any HIR Op MUST be value-form ([core-ir §4](./core-ir.md));
-  emitting an effect-form Call into HIR is a verify error.
+  (see **Shape dispatch and specializations** below).
 
-Generic, analysis-wide typing behavior is owned by
-[analysis](./analysis.md): relation-driven type validity
-([analysis §1.1](./analysis.md#11-relation-derived-type-behavior)), output
-storage of multi-input ops, and operand layout / mesh ownership
-([analysis §3.3](./analysis.md#33-output-storage-and-meshlayout-compatibility)).
-HIR ops call these services; each op's registered typeinfer owns the layout /
-mesh compatibility and result layout it requires, and `Reshard` is the explicit
-op that changes a value's layout / mesh.
+**Shape dispatch and specializations.**
+`Function` is the sole HIR function `Expr`. Shape-dispatch is carried on a
+single **base** `Function` through its `variants` field; there is no
+separate specialized-function type. The field is the IR-side carrier for
+the parser surface ([parser.md](./parser.md)).
 
-## 4. `GridRegionExpr`
+```python
+@dataclass(frozen=True)
+class Function(Expr):
+    ...
+    specializations: tuple[Pattern, ...] = ()
+    variants: tuple["Function", ...] = ()
+```
+
+*Structure.* A `Function` is exactly one of three shapes:
+
+- **normal** — `specializations == ()`, `variants == ()`, `body` is an
+  `Expr`. An ordinary function.
+- **dispatch prototype (base)** — `specializations == ()`,
+  `variants != ()`, `body is None`. Declares the signature and dispatch
+  envelope only; the implementations live in its variants.
+- **variant** — `specializations != ()`, `variants == ()`, `body` is an
+  `Expr`. A shape-specialized implementation registered on a base.
+
+Nesting is exactly one level: a variant MUST NOT itself carry variants.
+In a sealed (verified) `Module` the invariant is `body is None` ⟺
+`variants != ()` — a function with no body and no variants is uncallable
+and invalid, and a real body combined with variants is invalid. During
+authoring the base is transiently `body is None, variants == ()` between
+`@func def f: pass` and the first `@f.specialize(...)`; this unsealed
+state is allowed only until the base enters a `Module` (see **Authoring
+freeze** below).
+
+- `variants` is a canonical IR field — it participates in structural
+  equality, hashing, and canonical printing.
+- Every variant of a base MUST share the base's `name`, `params`,
+  `return_type`, `target`, and `topologies`: a variant specializes the
+  body, not the signature.
+- A variant carries exactly one `DimVarRangePat` in `specializations`.
+  The canonical signature is
+  `";".join(f"{p.dim_var}${p.lo}_{p.hi}" for p in specializations)`
+  (v0 allows only `DimVarRangePat`). Two variants of one base MUST have
+  distinct canonical signatures.
+
+*Envelope coverage.* A dispatched function's parameter
+`TensorType.shape` carries a `DimVar(name, lo, hi)` whose `(lo, hi)` is
+the dispatch envelope; `DimVarRangePat` references that `DimVar` by name.
+The variants' ranges MUST **partition** the envelope — pairwise
+**disjoint** and jointly **complete** (their union is exactly the
+half-open `[lo, hi)`). Adjacent half-open ranges meet at the shared
+boundary value as `[.., c)` then `[c, ..)`. Every in-envelope shape
+therefore selects exactly one variant.
+
+*Prototype body.* A base's `body is None`: the prototype is never
+typeinferred, lowered, or evaluated as a body. Only its variants carry
+executable bodies. There is no base body to fall back to.
+
+*Dispatch resolution.* A `Call` whose target is a dispatch prototype
+(`variants != ()`) is a dispatch call: the variant whose `DimVarRangePat`
+matches the call's concrete argument shapes is selected and is the call's
+result. A shape outside the envelope matches no variant and is an error;
+there is no base body to fall back to (the prototype body is `None`). A
+`Call` whose target has `variants == ()` is a direct call to that body.
+
+*Authoring freeze.* Variants accumulate during authoring, before the
+base `Function` enters a `Module` ([core-ir §1](./core-ir.md#1-module)). A
+sealed base rejects further variants. Because `variants` participates in
+hashing, a base MUST NOT be hashed while still accumulating variants. A
+top-level `Module.functions` entry MUST NOT be a variant: a top-level
+`Function` with `specializations != ()` is a verifier error.
+
+### 1.2 `GridRegionExpr`
 
 ```python
 @dataclass(frozen=True)
@@ -431,84 +294,225 @@ GridRegionExpr(
 )
 ```
 
-## 5. Dispatch specializations
+### 1.3 Op
 
-`Function` is the sole HIR function `Expr`. Shape-dispatch is carried on a
-single **base** `Function` through its `variants` field; there is no
-separate specialized-function type. The field is the IR-side carrier for
-the parser surface in [parser.md §8](./parser.md#8-dispatch-specializations).
+HIR Ops are organised under `tilefoundry.ir.hir.<namespace>/`; the
+subdirectory is file organisation, not a separate IR layer. A **custom Op**
+records its full contract (fields, typing / verifier rules, worked examples)
+in its catalog entry below; a **consensus Op** needs only one sentence or a
+grouped external reference, per [SPEC-RULES](../SPEC-RULES.md). The op name is
+the pointer — code carries no back-link to this catalog. Field signatures and
+`ParamDef` listings stay in code ([core-ir §2.3](./core-ir.md)).
 
-```python
-@dataclass(frozen=True)
-class Function(Expr):
-    ...
-    specializations: tuple[Pattern, ...] = ()
-    variants: tuple["Function", ...] = ()
+**HIR-specific typing hooks.** Each op's constraints are enforced by its
+registered `@register_typeinfer(<OpClass>)` body via `ctx.error(...)`
+([visitor-registry §4](./visitor-registry.md)):
+
+- `Local(x)`: `x.type.layout` MUST be `ShardLayout`. The result
+  shape contracts per the `Split` axes; dtype is preserved; layout
+  becomes the corresponding local layout.
+- `Reshard(x, layout, storage)`: `layout` and `storage` are attributes
+  (compile-time constants); the output preserves `x.type.shape` (logical).
+  Architecture invariant: after HIR typeinfer runs, every `ShardLayout`
+  reachable from a value's type has concrete `layout.strides` (never `None`) —
+  the un-materialized (`strides=None`) parser sugar MUST be materialized by the
+  owning typeinfer. The per-op `(layout, storage)` resolution table is in the
+  `Reshard` op entry below.
+- Any HIR Op MUST be value-form ([core-ir §2.3](./core-ir.md));
+  emitting an effect-form Call into HIR is a verify error.
+
+Generic, analysis-wide typing behavior is owned by
+[analysis](./analysis.md): relation-driven type validity
+([analysis §1.1](./analysis.md#11-relation-derived-type-behavior)), output
+storage of multi-input ops, and operand layout / mesh ownership
+([analysis §3.3](./analysis.md#33-output-storage-and-meshlayout-compatibility)).
+HIR ops call these services; each op's registered typeinfer owns the layout /
+mesh compatibility and result layout it requires, and `Reshard` is the explicit
+op that changes a value's layout / mesh.
+
+#### `ir/hir/math/`
+
+Pointwise arithmetic and comparison, torch semantics with TileFoundry
+type-promotion. User-callable names (`add` / `cmp_eq` / `logical_and` / …) are
+surface aliases ([core-ir §2.3](./core-ir.md)) over the kinded Ops; there are no
+per-name IR classes.
+[torch element-wise ops](https://pytorch.org/docs/stable/torch.html#pointwise-ops).
+
+##### Binary
+```text
+Binary(kind, lhs, rhs) -> Tensor
 ```
+- kind: HIR op
+- fields:
+  - kind: binary arithmetic, comparison, or boolean tag
+  - lhs / rhs: input tensors
+- constraints:
+  - Behavior follows torch pointwise semantics with TileFoundry type promotion.
 
-**Structure.** A `Function` is exactly one of three shapes:
+##### Unary
+```text
+Unary(kind, x) -> Tensor
+```
+- kind: HIR op
+- fields:
+  - kind: unary tag including `neg`, `abs`, `logical_not`, and `rsqrt`
+  - x: input tensor
+- constraints:
+  - Behavior follows torch pointwise semantics with TileFoundry type promotion.
 
-- **normal** — `specializations == ()`, `variants == ()`, `body` is an
-  `Expr`. An ordinary function.
-- **dispatch prototype (base)** — `specializations == ()`,
-  `variants != ()`, `body is None`. Declares the signature and dispatch
-  envelope only; the implementations live in its variants.
-- **variant** — `specializations != ()`, `variants == ()`, `body` is an
-  `Expr`. A shape-specialized implementation registered on a base.
+#### `ir/hir/tensor/`
 
-Nesting is exactly one level: a variant MUST NOT itself carry variants.
-In a sealed (verified) `Module` the invariant is `body is None` ⟺
-`variants != ()` — a function with no body and no variants is uncallable
-and invalid, and a real body combined with variants is invalid. During
-authoring the base is transiently `body is None, variants == ()` between
-`@func def f: pass` and the first `@f.specialize(...)`; this unsealed
-state is allowed only until the base enters a `Module` (see **Authoring
-freeze** below).
+Tensor structural operations; consensus ops follow torch / numpy
+([torch tensor manipulation ops](https://pytorch.org/docs/stable/torch.html#indexing-slicing-joining-mutating-ops)).
 
-- `variants` is a canonical IR field — it participates in structural
-  equality, hashing, and canonical printing.
-- Every variant of a base MUST share the base's `name`, `params`,
-  `return_type`, `target`, and `topologies`: a variant specializes the
-  body, not the signature.
-- A variant carries exactly one `DimVarRangePat` in `specializations`.
-  The canonical signature is
-  `";".join(f"{p.dim_var}${p.lo}_{p.hi}" for p in specializations)`
-  (v0 allows only `DimVarRangePat`). Two variants of one base MUST have
-  distinct canonical signatures.
+##### Reshape / Transpose / Slice / Concat / Stack / Split / Gather / ShapeOf / Rank / Cast
+Consensus torch / numpy structural ops.
 
-**Envelope coverage.** A dispatched function's parameter
-`TensorType.shape` carries a `DimVar(name, lo, hi)` whose `(lo, hi)` is
-the dispatch envelope; `DimVarRangePat` references that `DimVar` by name.
-The variants' ranges MUST **partition** the envelope — pairwise
-**disjoint** and jointly **complete** (their union is exactly the
-half-open `[lo, hi)`). Adjacent half-open ranges meet at the shared
-boundary value as `[.., c)` then `[c, ..)`. Every in-envelope shape
-therefore selects exactly one variant.
+##### Zeros
+```text
+Zeros(shape, dtype, storage) -> Tensor
+```
+- kind: HIR op
+- fields:
+  - shape: output logical shape
+  - dtype: output dtype
+  - storage: output storage kind
+- constraints:
+  - The result is zero-initialised.
 
-**Prototype body.** A base's `body is None`: the prototype is never
-typeinferred, lowered, or evaluated as a body. Only its variants carry
-executable bodies. There is no base body to fall back to.
+##### Reduce
+```text
+Reduce(x, axes, keepdim, kind) -> Tensor
+```
+- kind: HIR op
+- fields:
+  - x: input tensor
+  - axes: reduced logical axes
+  - keepdim: whether reduced axes remain as size-1 axes
+  - kind: `mean`, `sum`, `abs_max`, or `max`
+- constraints:
+  - The logical result shape follows numpy reduction rules.
+  - Storage is preserved.
+  - Plain input layout passes through unchanged.
+  - For `ShardLayout` input, every split cute position that belongs to a
+    reduced tensor axis collapses to broadcast with size-1 stride-0 output.
+  - Non-default-stride sharded input must carry explicit producer strides, or
+    typeinfer rejects it.
+  - Lowering emits TIR `Reduce`; runtime dispatch is derived from operands, not
+    from an HIR dispatch field.
 
-**Dispatch resolution.** A `Call` whose target is a dispatch prototype
-(`variants != ()`) is a dispatch call: the variant whose `DimVarRangePat`
-matches the call's concrete argument shapes is selected and is the call's
-result. A shape outside the envelope matches no variant and is an error;
-there is no base body to fall back to (the prototype body is `None`). A
-`Call` whose target has `variants == ()` is a direct call to that body.
+##### insert_slice
+```text
+insert_slice(dst, update, offsets) -> Tensor
+```
+- kind: HIR op
+- fields:
+  - dst: target tensor; the value form returns a new tensor anchored on this
+    buffer at lowering time
+  - update: tensor written into the slice window
+  - offsets: scalar runtime value or integer literal for the implemented 1-D
+    case
+- constraints:
+  - `update` has the same rank and dtype as `dst`.
+  - The implemented 1-D case writes the contiguous window
+    `[start, start + update.shape[0])`.
+  - Higher-rank inputs share the surface but are rejected until implemented.
+  - Statically out-of-bounds windows fail typeinfer; runtime-only bounds are
+    checked by eval/runtime.
 
-**Authoring freeze.** Variants accumulate during authoring, before the
-base `Function` enters a `Module` ([core-ir §2](./core-ir.md#2-module)). A
-sealed base rejects further variants. Because `variants` participates in
-hashing, a base MUST NOT be hashed while still accumulating variants. A
-top-level `Module.functions` entry MUST NOT be a variant: a top-level
-`Function` with `specializations != ()` is a verifier error.
+#### `ir/hir/nn/`
 
-**Canonical `DimVar` subject rule.** When a `DimVar D` appears at
-multiple `(param_index, axis)` positions in the function signature,
-the lowering picks the **first** occurrence under
-`(param_index ascending, axis ascending)` as the canonical subject
-for `ShapeOf` lookups. Other occurrences are assumed equal at call
-time (caller responsibility — runtime UB on mismatch).
+Neural-network value Ops following torch semantics
+([torch.nn.functional](https://pytorch.org/docs/stable/nn.functional.html)).
 
-HIR→TIR lowering details: see
-[passes.md §7.1](./passes.md#71-hirtotirpass) `HirToTirPass`.
+##### MatMul / Conv2D / ReLU / Sigmoid / Tanh / SoftMax / LayerNorm
+Consensus torch.nn.functional ops.
+
+#### `ir/hir/shape/`
+
+Shape-level Ops on whole shape values (per-axis dim Ops are
+[types §3](./types.md)).
+
+##### ShapeExtract
+```text
+ShapeExtract(shape, axis) -> Dim
+```
+- kind: HIR op
+- fields:
+  - shape: input shape value
+  - axis: extracted axis
+- constraints:
+  - The result is the dimension at `axis`.
+
+##### ShapeCompose
+```text
+ShapeCompose(dims) -> Shape
+```
+- kind: HIR op
+- fields:
+  - dims: per-axis dimensions
+- constraints:
+  - The result is a shape value assembled in input order.
+
+#### `ir/hir/sharding/`
+
+`ShardLayout` and `Mesh` are type-system constructs, not Expr inputs
+([shard §5](./shard.md)).
+
+##### Reshard
+```text
+Reshard(x, layout=None, storage=None) -> Tensor
+```
+- kind: HIR op
+- fields:
+  - x: input tensor
+  - layout: optional target `ShardLayout`
+  - storage: optional target storage kind
+- constraints:
+  - Omitting `layout` preserves `x.layout`; omitting `storage` preserves
+    `x.storage`.
+  - The output preserves the input logical `TensorType.shape`.
+  - Supplied `layout` is a `ShardLayout`.
+  - Destination storage is concrete, not unmaterialized.
+  - The single op covers zero-copy view, cross-storage copy, cross-CTA
+    redistribute, and mixed cases; typeinfer/costmodel classify the call.
+
+**Stride resolution.** Storage direction follows the physical addressability
+hierarchy `rmem < smem < gmem` (per-thread / per-CTA / per-program). Typeinfer
+dispatches on `(layout, storage)`:
+
+- `layout=None`, storage unchanged → `x.type` (no-op).
+- `layout=None`, storage changed → error; a storage change MUST carry an
+  explicit `layout=`.
+- `layout=Layout(strides=None)` (sugar), storage unchanged → dest strides match
+  the form already on `x.layout`: a Split-axes-zero source ⇒ per-instance form;
+  otherwise ⇒ shared-engine C-order over the canonical global shape. When
+  `x.layout` is `None` (plain kernel-param), fall back to shared-engine C-order.
+- `layout=Layout(strides=None)` (sugar), low → high level → dest strides =
+  C-order over `layout.shape` (shared-engine form).
+- `layout=Layout(strides=None)` (sugar), high → low level → dest `strides[k]=0`
+  for every `Split` axis `k`; non-`Split` axes follow C-order over
+  `shard_layout_local_shape(layout)` with size-1 → 0 (per-instance form).
+- `layout=Layout(strides=tuple)` (verbose) → dest strides are taken verbatim;
+  typeinfer MUST NOT rewrite them (e.g. SM80 MMA fragment layouts).
+
+**Cross-CTA fence.** The grid fence for a cross-CTA reshard is owned by the
+reshard lowering, not by a separately authored sync. When a reshard reads a
+gmem shard produced under a different CTA ownership (an ownership change across
+a cta mesh), the lowering MUST emit a grid barrier before the reshard so every
+CTA's prior shard writes are visible. The reshard lowering owns only the fence;
+cross-CTA data redistribution (all-to-all / gather across CTAs) is not part of
+this op.
+
+##### Local
+```text
+Local(x) -> Tensor
+```
+- kind: HIR op
+- fields:
+  - x: input tensor with `ShardLayout`
+- constraints:
+  - The result shape contracts each `Split` axis by that mesh axis's extent.
+  - `dtype` and `storage` are preserved.
+  - The shard wrapper is stripped, leaving the base `Layout`.
+  - Static split sizes divide by mesh extent; symbolic sizes pass through.

--- a/docs/spec/inspection.md
+++ b/docs/spec/inspection.md
@@ -89,7 +89,7 @@ definitions are emitted in the module prelude / standalone header.
 
 ### 2.6 Specialization printing
 
-A dispatch prototype ([hir.md §5](./hir.md#5-dispatch-specializations))
+A dispatch prototype ([hir.md §1.1](./hir.md#11-function))
 prints as its base `@tilefoundry.func` with a `pass` body, followed by each
 variant as an `@<name>.specialize(pattern)` block in declared order:
 
@@ -106,7 +106,7 @@ def _(x: Tensor[(S,), "f32"]) -> Tensor[(S,), "f32"]:
 The pattern prints in its constructor form (`DimVarRangePat("S", 1, 4)`;
 other `Pattern` subclasses fall back to `repr(pattern)`). The emitted form
 mirrors the authoring surface
-([parser.md §8](./parser.md#8-dispatch-specializations)). Because a
+([parser.md §1.1](./parser.md#11-decorators)). Because a
 dispatch prototype has a `DimVar` parameter, its rendering is a
 **display-only** surface (§2.7): human-readable, not a round-trip
 validation artifact.

--- a/docs/spec/parser.md
+++ b/docs/spec/parser.md
@@ -248,7 +248,9 @@ exactly; otherwise the sugar is rejected. The factorisation is
 opaque to the user: input `N @ m.a` and input
 `(mesh_extent(a) @ m.a, N // mesh_extent(a))` produce the same IR.
 
-**Stride materialization (parser surface)**. The first sugar form
+#### Stride materialization (parser surface)
+
+The first sugar form
 (`'(' axis-spec ... ')'`) emits `Layout(shape=canonical,
 strides=None)` — the cute strides are deferred to `Reshard`
 typeinfer, which fills them in based on the storage-level direction

--- a/docs/spec/parser.md
+++ b/docs/spec/parser.md
@@ -32,11 +32,11 @@ in [§2.7](#27-module-authoring-surface)). A method MAY call a sibling method
 declared *above* it — the call lowers to a `Call` targeting that
 sibling function; forward references (a callee declared below the
 caller) are unresolved (see [§3.3](#33-description)). Functions are
-reached by name on the result (see [core-ir §2.1](./core-ir.md#21-function-access)).
+reached by name on the result (see [core-ir §1.1](./core-ir.md#11-function-access)).
 
 `@tilefoundry.func` and `@tilefoundry.prim_func` decorate functions and
 evaluate to the parsed IR directly: `@func` to a `hir.Function`
-([hir.md §1](./hir.md#1-function)), `@prim_func` to a
+([hir.md §1.1](./hir.md#11-function)), `@prim_func` to a
 `tir.PrimFunction`. The decorated name binds to that IR node, not to
 the original Python function. Used standalone (outside a `@module`
 class), passing the resulting function to `compile` / `jit` lifts it
@@ -54,6 +54,58 @@ class M:
     def f(...):
         return g(...)   # sibling g is declared above → resolves to g's Function
 ```
+
+**Specialization decorators.** A function specializes its body per input
+shape through `Function.specialize`. The base function is defined with
+`@tilefoundry.func`; each variant is added by decorating a throwaway `def`
+with `@base.specialize(pattern)`:
+
+```python
+S = DimVar("S", 1, 9)                                          # envelope [1, 9) = 1..8
+
+@tilefoundry.func
+def f(x: Tensor[(S,), "f32"]) -> Tensor[(S,), "f32"]:
+    pass                                                       # prototype base
+
+@f.specialize(DimVarRangePat("S", 1, 5))
+def _(x: Tensor[(S,), "f32"]) -> Tensor[(S,), "f32"]:
+    return small_impl(x)                                       # variant [1, 5) = 1..4
+
+@f.specialize(DimVarRangePat("S", 5, 9))
+def _(x: Tensor[(S,), "f32"]) -> Tensor[(S,), "f32"]:
+    return large_impl(x)                                       # variant [5, 9) = 5..8
+```
+
+- `@tilefoundry.func` evaluates to the base `hir.Function`. `func()` has no
+  `specializations=` parameter; specialization is reachable only through
+  `.specialize`.
+- The prototype base body is `pass`: it declares the signature and dispatch
+  envelope only and parses to `Function.body is None`. The implementations
+  live in the variants ([hir.md §1.1](./hir.md#11-function)). A
+  `pass` body is legal only for a function that receives variants; a `pass`
+  body with no variants, or a real body combined with variants, is rejected.
+- `base.specialize(pattern)` returns a decorator. It parses the decorated
+  `def` into a variant `hir.Function` (same `name` as the base,
+  `specializations=(pattern,)`), registers it on `base.variants`, and
+  returns the variant. The decorated name is a throwaway: `def _` is
+  reusable across variants because the base is the persistent handle.
+- `pattern` MUST be a single `DimVarRangePat` (see
+  [core-ir §3](./core-ir.md#3-pattern)); other `Pattern` subclasses are rejected for
+  v0. The referenced `DimVar` and its `(lo, hi)` envelope live on the base
+  parameter's shape. Each variant's range MUST fall within that envelope,
+  and the full variant set MUST partition it — disjoint and complete (see
+  [hir.md §1.1](./hir.md#11-function)). Two variants with the
+  same canonical signature are rejected.
+- A `DimVar` shape entry MAY be written **inline** (`DimVar("S", lo, hi)`
+  AST node in the shape tuple) or as a **named alias** (`S = DimVar("S",
+  lo, hi)` then `Tensor[(S,), ...]`). Both resolve to the same `DimVar`
+  instance (type-level cache keyed by `(name, lo, hi)`). A second `DimVar`
+  with the same `name` but conflicting `(lo, hi)` is a hard parse-time
+  error.
+- Variants accumulate on the base only during authoring. Once the base
+  enters a `Module` (see [core-ir §1](./core-ir.md#1-module)) it is sealed and
+  `.specialize` raises. A variant lives only inside `base.variants`; it is
+  never a separate `Module.functions` entry.
 
 ### 1.2 DSL namespace
 
@@ -200,14 +252,14 @@ opaque to the user: input `N @ m.a` and input
 (`'(' axis-spec ... ')'`) emits `Layout(shape=canonical,
 strides=None)` — the cute strides are deferred to `Reshard`
 typeinfer, which fills them in based on the storage-level direction
-(see [hir.md §3](./hir.md#3-typing--structural-rules)). The
+(see [hir.md §1.3](./hir.md#13-op)). The
 verbose form (`'(' axis-tuple ',' stride-tuple ')'`) emits a
 concrete `strides` tuple; typeinfer respects it verbatim. The
 parser does NOT inspect `storage` or do any physical-materialization
 logic — that responsibility lives entirely in `Reshard` typeinfer.
 
 Spec: [shard.md §7.1.1](./shard.md#711-layoutshape),
-[hir.md §3](./hir.md#3-typing--structural-rules).
+[hir.md §1.3](./hir.md#13-op).
 
 Layout sugar is accepted **anywhere the expected surface value is
 a `ShardLayout`**. Dispatch is annotation-driven (see §4.4): the
@@ -248,7 +300,7 @@ in what it lowers to:
   inside `suite`. A tensor's mesh/layout lives on its
   `TensorType.layout`, not on the block it is written in; `reshard` is
   the explicit boundary, and op typeinfer
-  ([hir §3](./hir.md#3-typing--structural-rules)) decides whether values
+  ([hir §1.3](./hir.md#13-op)) decides whether values
   combine.
 - **TIR** lowers it to an explicit `MeshScope` Stmt (§6) carrying the
   `Mesh` and the binding `Var`.
@@ -264,7 +316,7 @@ loop-args   ::= extent-Expr                        # tile: extent / range: stop
 ```
 
 `tile(...)` and `range(...)` share **one** loop domain `(start, extent,
-step)` and lower to the **same** `GridRegionExpr` ([hir §4](./hir.md)) —
+step)` and lower to the **same** `GridRegionExpr` ([hir §1.2](./hir.md)) —
 `range` is not a separate construct and is **not** statically unrolled. The
 only difference is the loop-variable binding:
 
@@ -282,7 +334,7 @@ only difference is the loop-variable binding:
 domain is half-open `[start, extent)`) / `step-Expr` MAY be any `ShapeDim`
 ([types §4](./types.md)), including a dim expression such as `C // N`; the
 value is carried verbatim into `GridRegionExpr.start` / `.extent` / `.step`
-and resolved at evaluate time ([hir §4](./hir.md)).
+and resolved at evaluate time ([hir §1.2](./hir.md)).
 
 A tensor subscript `x[slice0, …]` inside a loop body lifts to a
 `hir.tensor.Slice` Op call. An `ast.Assign` whose single Name target is
@@ -469,7 +521,7 @@ surface so editors complete `T.cuda.mma.<NAME>` and `.atom(...)`.
 ### 2.7 `@module` authoring surface
 
 `@module(entry="<name>")` collects a class of DSL functions into a
-`Module` ([core-ir §2.1](./core-ir.md)). The decorated name binds to the
+`Module` ([core-ir §1](./core-ir.md#1-module)). The decorated name binds to the
 resulting `Module`.
 
 - Every non-dunder class member MUST be an `@func` / `@prim_func` result (an
@@ -634,7 +686,7 @@ real-Op schema sharing the same name.
 
 A registered Op has one or more `OpSchema` entries indexed by
 `(dialect, name)`. Each schema lists the Op's `ParamDef` descriptors
-(see [core-ir §4](./core-ir.md)). When the parser sees a callee:
+(see [core-ir §2.3](./core-ir.md)). When the parser sees a callee:
 
 1. Look up the schema list via
    `op_registry.get_schemas(dialect, name)`.
@@ -700,7 +752,7 @@ prototype** that awaits variants. Immediately after `@func def f: pass`
 and before any `@f.specialize(...)`, the base is transiently
 `body is None, variants == ()` — a valid *unsealed authoring* state. The
 sealed (verified) invariant is `body is None` ⟺ `variants != ()`
-([hir.md §5](./hir.md#5-dispatch-specializations)); the verifier rejects a
+([hir.md §1.1](./hir.md#11-function)); the verifier rejects a
 `body is None` function with no variants, a variant whose body is `pass`
 (a variant MUST carry a real body), and a real body combined with
 variants. The `@base.specialize(...)` parse rejects a `pass`-bodied
@@ -764,57 +816,3 @@ TIR has no SSA-as-DAG sharing rule; every binding is an explicit
 - Layout sugar that would lose mesh information falls through to the
   verbose form (§1.4); if neither is acceptable, the type is
   rejected.
-
-## 8. Dispatch specializations
-
-A function specializes its body per input shape through
-`Function.specialize`. The base function is defined with `@tilefoundry.func`;
-each variant is added by decorating a throwaway `def` with
-`@base.specialize(pattern)`:
-
-```python
-S = DimVar("S", 1, 9)                                          # envelope [1, 9) = 1..8
-
-@tilefoundry.func
-def f(x: Tensor[(S,), "f32"]) -> Tensor[(S,), "f32"]:
-    pass                                                       # prototype base
-
-@f.specialize(DimVarRangePat("S", 1, 5))
-def _(x: Tensor[(S,), "f32"]) -> Tensor[(S,), "f32"]:
-    return small_impl(x)                                       # variant [1, 5) = 1..4
-
-@f.specialize(DimVarRangePat("S", 5, 9))
-def _(x: Tensor[(S,), "f32"]) -> Tensor[(S,), "f32"]:
-    return large_impl(x)                                       # variant [5, 9) = 5..8
-```
-
-- `@tilefoundry.func` evaluates to the base `hir.Function`. `func()` has no
-  `specializations=` parameter; specialization is reachable only through
-  `.specialize`.
-- The prototype base body is `pass`: it declares the signature and dispatch
-  envelope only and parses to `Function.body is None`. The implementations
-  live in the variants ([hir.md §5](./hir.md#5-dispatch-specializations)). A
-  `pass` body is legal only for a function that receives variants; a `pass`
-  body with no variants, or a real body combined with variants, is rejected.
-- `base.specialize(pattern)` returns a decorator. It parses the decorated
-  `def` into a variant `hir.Function` (same `name` as the base,
-  `specializations=(pattern,)`), registers it on `base.variants`, and
-  returns the variant. The decorated name is a throwaway: `def _` is
-  reusable across variants because the base is the persistent handle.
-- `pattern` MUST be a single `DimVarRangePat` (see
-  [core-ir §7](./core-ir.md)); other `Pattern` subclasses are rejected for
-  v0. The referenced `DimVar` and its `(lo, hi)` envelope live on the base
-  parameter's shape. Each variant's range MUST fall within that envelope,
-  and the full variant set MUST partition it — disjoint and complete (see
-  [hir.md §5](./hir.md#5-dispatch-specializations)). Two variants with the
-  same canonical signature are rejected.
-- A `DimVar` shape entry MAY be written **inline** (`DimVar("S", lo, hi)`
-  AST node in the shape tuple) or as a **named alias** (`S = DimVar("S",
-  lo, hi)` then `Tensor[(S,), ...]`). Both resolve to the same `DimVar`
-  instance (type-level cache keyed by `(name, lo, hi)`). A second `DimVar`
-  with the same `name` but conflicting `(lo, hi)` is a hard parse-time
-  error.
-- Variants accumulate on the base only during authoring. Once the base
-  enters a `Module` (see [core-ir §2](./core-ir.md)) it is sealed and
-  `.specialize` raises. A variant lives only inside `base.variants`; it is
-  never a separate `Module.functions` entry.

--- a/docs/spec/parser.md
+++ b/docs/spec/parser.md
@@ -506,7 +506,7 @@ registry.
   visibility (§2.5).
 - `T.cuda.mma` is the CUDA MMA surface: `T.cuda.mma.<NAME>` is an
   `MmaOpSpec` and `T.cuda.mma.atom(op=...)` an `MmaAtom`
-  ([tir §3.7](./tir.md#37-mma-atom-and-the-hand-written-calling-convention)).
+  ([tir §2.3](./tir.md#mma-atom-and-the-hand-written-calling-convention)).
   The folder name (`cuda`) matches `codegen/cuda/` and the runtime tree.
 
 In a `@prim_func` body a chain rooted at a platform sub-namespace is a
@@ -785,7 +785,7 @@ imperative statements that fold into a `Sequential` of Stmts.
 | Python | TIR action |
 |---|---|
 | `x = expr` | `LetStmt(var=x, value=expr, body=<sequential rest>)`. The remaining body of the function is nested as `body`. |
-| `a = Tensor(...)` | `LetStmt(var=a, value=Call(tir.memory.AllocTensor, (), attrs=<TensorType fields>), body=<rest>)`. See [tir §5.1](./tir.md). |
+| `a = Tensor(...)` | `LetStmt(var=a, value=Call(tir.memory.AllocTensor, (), attrs=<TensorType fields>), body=<rest>)`. See [tir §2.3](./tir.md#23-tir-ops). |
 | `foo(a, b)` (effect Op) | `Evaluate(target_op, args)` Stmt. |
 | `foo(a, b)` (value Op) | `Call` Expr embedded in the right-hand side of a `LetStmt` or another Stmt's Expr field. |
 | `for i in range(...)` | `For(induction_var=i, start, stop, step, body)`. |

--- a/docs/spec/parser.md
+++ b/docs/spec/parser.md
@@ -400,23 +400,14 @@ for any name not found on the module's own namespace. Both
 namespaces implement it identically:
 
 ```python
-def __getattr__(name: str) -> type[Op] | Callable:
-    schemas = op_registry.get_schemas(_DIALECT, name)
-    if not schemas:
-        raise AttributeError(name)
-    first = schemas[0]
-    # Surface-alias schema (op_class is None): return the alias
-    # builder fn — it carries `_op_schema` so parser dispatch
-    # recovers the schema uniformly via getattr.
-    if first.op_class is None:
-        return first.builder
-    if len(schemas) == 1:
-        return first.op_class             # bind Op class itself
-    return _make_overload_resolver(schemas)
-
-def __dir__() -> list[str]:
-    return list(op_registry.iter_schema_names(_DIALECT))
+def __getattr__(name: str) -> type[Op] | Callable: ...   # resolve a dialect name to its Op class / alias builder
+def __dir__() -> list[str]: ...                          # list the dialect's registered schema names
 ```
+
+`__getattr__` looks up `op_registry.get_schemas(_DIALECT, name)` and raises
+`AttributeError` on a miss; for a single real-Op schema it returns the `Op`
+class, for a surface-alias schema (`op_class is None`) the alias builder fn, and
+for more than one schema an overload resolver.
 
 Both forms (Op class for real-Op schemas, alias builder fn for
 alias schemas) carry an `_op_schema` attribute, so the parser's

--- a/docs/spec/passes.md
+++ b/docs/spec/passes.md
@@ -35,6 +35,21 @@ pass framework is:
 ## 2. `Pass` base class
 
 
+```text
+Pass(ABC):  name: str;  requires: tuple[str, ...] = ();  run(module: Module) -> Module  [abstract]
+```
+
+- kind: Python class
+- fields:
+  - name: pass name for dump / log
+  - requires: ordered dependency assertion (no scheduling)
+- constraints:
+  - `run(module)` returns a new `Module`; it does not mutate input.
+  - Passes MUST NOT depend on global state. All configuration enters
+    through constructor parameters or pass-local attributes.
+  - Pass failures raise named exceptions (e.g. `VerifyError`); they
+    do not swallow errors.
+
 ```python
 from abc import ABC, abstractmethod
 from tilefoundry.ir.core import Module
@@ -51,14 +66,6 @@ class Pass(ABC):
     def run(self, module: Module) -> Module: ...
 ```
 
-Contract:
-
-- `run(module)` returns a new `Module`; it does not mutate input.
-- Passes MUST NOT depend on global state. All configuration enters
-  through constructor parameters or pass-local attributes.
-- Pass failures raise named exceptions (e.g. `VerifyError`); they
-  do not swallow errors.
-
 ## 3. Three pass granularities
 
 ### 3.1 `ModulePass`
@@ -67,6 +74,16 @@ Runs over the whole `Module` and may add / remove / reorder
 functions. Examples: module-level inline, dead-function elimination,
 HIR → TIR replacement (substitute `tir.PrimFunction` for
 `hir.Function`).
+
+```text
+ModulePass(Pass):  run(module: Module) -> Module  [abstract]
+```
+
+- kind: Python class
+- fields: none — runs over the whole `Module`; may add / remove / reorder functions
+- constraints:
+  - `run` returns a new `Module`; inherits the `Pass` no-mutation / no-global-state
+    contract (§2).
 
 ```python
 class ModulePass(Pass):
@@ -79,6 +96,16 @@ class ModulePass(Pass):
 Visits each `hir.Function`. The framework supplies a default `run`
 that walks `module.functions`, calls `run_function` for HIR
 entries, and reassembles the `Module`.
+
+```text
+FunctionPass(Pass):  run_function(fn: HirFunction, module: Module) -> HirFunction  [abstract];  run(module) [default]
+```
+
+- kind: Python class
+- fields: none — visits each `hir.Function`; framework supplies the default `run`
+- constraints:
+  - inherits the `Pass` contract (§2); the default `run` reassembles the `Module`
+    from `run_function` results.
 
 ```python
 from tilefoundry.ir.hir import Function as HirFunction
@@ -101,6 +128,16 @@ class FunctionPass(Pass):
 
 Same shape as `FunctionPass`, but visits `tir.PrimFunction`. Mirrors
 nncase's `PrimFuncPass.cs`.
+
+```text
+PrimFuncPass(Pass):  run_prim_func(fn: PrimFunction, module: Module) -> PrimFunction  [abstract];  run(module) [default]
+```
+
+- kind: Python class
+- fields: none — visits each `tir.PrimFunction` (mirrors `FunctionPass`)
+- constraints:
+  - inherits the `Pass` contract (§2); same shape as `FunctionPass` over
+    `tir.PrimFunction`.
 
 ```python
 from tilefoundry.ir.tir import PrimFunction
@@ -144,6 +181,16 @@ entry form for TIR effect Ops — is owned by
 A linear scheduler that runs passes in registration order and
 optionally drops per-pass IR dumps when wrapped in a
 `tilefoundry.dump.DumpScope`.
+
+```text
+PassManager:  passes: list[Pass] = [];  add(p: Pass) -> PassManager;  run(module: Module) -> Module
+```
+
+- kind: Python class
+- fields:
+  - passes: the registered passes, run in registration order
+- constraints:
+  - `requires` is an ordering assertion checked before the run, not a topological sort.
 
 ```python
 from dataclasses import dataclass, field
@@ -233,6 +280,17 @@ unified retype / verify is scheduled by `PassManager`.
 ## 7. Implemented passes
 
 ### 7.1 `HirToTirPass`
+
+```text
+HirToTirPass(ModulePass):  run(module: Module) -> Module
+```
+
+- kind: Python pass
+- fields: none — replaces every `hir.Function` with a `tir.PrimFunction`
+- constraints:
+  - TIR has no return-tensor form; HIR outputs become trailing params. The
+    per-op / mesh / `Reshard` / dispatch lowering rules are in the subsections
+    below.
 
 `ModulePass`. Replaces every `hir.Function` with a
 `tir.PrimFunction`, materialising the HIR `Function(params) →
@@ -368,7 +426,7 @@ gains a hidden scalar parameter named `<param.name>_shape_<axis>` of
 `TensorType((), i32)`. The CUDA host wrapper extracts the value from
 the runtime tensor's shape; the parameter is invisible at the user
 FFI surface (see
-[codegen §5](./codegen.md#5-dispatch-and-shape-scalar-abi)).
+[target §6](./target.md#6-dispatch-and-shape-scalar-abi)).
 
 ### 7.2 `BufferizePass`
 
@@ -382,6 +440,16 @@ logical buffer a physical offset / size, and write the result back
 into the `tir.memory.*` descriptors. Policy: every logical buffer
 gets an independent physical allocation; no reuse, pool, or lifetime
 overlap. Buffer planning is not a codegen responsibility.
+
+```text
+BufferizePass(PrimFuncPass):  name = "bufferize";  requires = ("hir_to_tir",)
+```
+
+- kind: Python pass
+- fields: none — assigns each logical buffer a physical offset / size after `HirToTirPass`
+- constraints:
+  - every logical buffer gets an independent physical allocation; no reuse, pool,
+    or lifetime overlap. Buffer planning is not a codegen responsibility.
 
 ```python
 class BufferizePass(PrimFuncPass):

--- a/docs/spec/passes.md
+++ b/docs/spec/passes.md
@@ -35,21 +35,6 @@ pass framework is:
 ## 2. `Pass` base class
 
 
-```text
-Pass(ABC):  name: str;  requires: tuple[str, ...] = ();  run(module: Module) -> Module  [abstract]
-```
-
-- kind: Python class
-- fields:
-  - name: pass name for dump / log
-  - requires: ordered dependency assertion (no scheduling)
-- constraints:
-  - `run(module)` returns a new `Module`; it does not mutate input.
-  - Passes MUST NOT depend on global state. All configuration enters
-    through constructor parameters or pass-local attributes.
-  - Pass failures raise named exceptions (e.g. `VerifyError`); they
-    do not swallow errors.
-
 ```python
 from abc import ABC, abstractmethod
 from tilefoundry.ir.core import Module
@@ -66,6 +51,13 @@ class Pass(ABC):
     def run(self, module: Module) -> Module: ...
 ```
 
+- constraints:
+  - `run(module)` returns a new `Module`; it does not mutate input.
+  - Passes MUST NOT depend on global state. All configuration enters
+    through constructor parameters or pass-local attributes.
+  - Pass failures raise named exceptions (e.g. `VerifyError`); they
+    do not swallow errors.
+
 ## 3. Three pass granularities
 
 ### 3.1 `ModulePass`
@@ -75,21 +67,15 @@ functions. Examples: module-level inline, dead-function elimination,
 HIR → TIR replacement (substitute `tir.PrimFunction` for
 `hir.Function`).
 
-```text
-ModulePass(Pass):  run(module: Module) -> Module  [abstract]
-```
-
-- kind: Python class
-- fields: none — runs over the whole `Module`; may add / remove / reorder functions
-- constraints:
-  - `run` returns a new `Module`; inherits the `Pass` no-mutation / no-global-state
-    contract (§2).
-
 ```python
-class ModulePass(Pass):
+class ModulePass(Pass):                             # runs over the whole Module; may add / remove / reorder functions
     @abstractmethod
     def run(self, module: Module) -> Module: ...
 ```
+
+- constraints:
+  - `run` returns a new `Module`; inherits the `Pass` no-mutation / no-global-state
+    contract (§2).
 
 ### 3.2 `FunctionPass`
 
@@ -97,57 +83,36 @@ Visits each `hir.Function`. The framework supplies a default `run`
 that walks `module.functions`, calls `run_function` for HIR
 entries, and reassembles the `Module`.
 
-```text
-FunctionPass(Pass):  run_function(fn: HirFunction, module: Module) -> HirFunction  [abstract];  run(module) [default]
-```
-
-- kind: Python class
-- fields: none — visits each `hir.Function`; framework supplies the default `run`
-- constraints:
-  - inherits the `Pass` contract (§2); the default `run` reassembles the `Module`
-    from `run_function` results.
-
 ```python
 from tilefoundry.ir.hir import Function as HirFunction
 
-class FunctionPass(Pass):
+class FunctionPass(Pass):                                                       # visits each hir.Function; framework supplies the default run
     @abstractmethod
-    def run_function(self, fn: HirFunction, module: Module) -> HirFunction: ...
-
-    def run(self, module: Module) -> Module:
-        new_fns = []
-        for fn in module.functions:
-            if isinstance(fn, HirFunction):
-                new_fns.append(self.run_function(fn, module))
-            else:
-                new_fns.append(fn)
-        return Module(name=module.name, functions=tuple(new_fns))
+    def run_function(self, fn: HirFunction, module: Module) -> HirFunction: ...  # visit one HIR function
+    def run(self, module: Module) -> Module: ...                                # default reassembles the Module from run_function results
 ```
+
+- constraints:
+  - inherits the `Pass` contract (§2); the default `run` reassembles the `Module`
+    from `run_function` results.
 
 ### 3.3 `PrimFuncPass`
 
 Same shape as `FunctionPass`, but visits `tir.PrimFunction`. Mirrors
 nncase's `PrimFuncPass.cs`.
 
-```text
-PrimFuncPass(Pass):  run_prim_func(fn: PrimFunction, module: Module) -> PrimFunction  [abstract];  run(module) [default]
-```
-
-- kind: Python class
-- fields: none — visits each `tir.PrimFunction` (mirrors `FunctionPass`)
-- constraints:
-  - inherits the `Pass` contract (§2); same shape as `FunctionPass` over
-    `tir.PrimFunction`.
-
 ```python
 from tilefoundry.ir.tir import PrimFunction
 
-class PrimFuncPass(Pass):
+class PrimFuncPass(Pass):                                                       # visits each tir.PrimFunction (mirrors FunctionPass)
     @abstractmethod
     def run_prim_func(self, fn: PrimFunction, module: Module) -> PrimFunction: ...
-
     def run(self, module: Module) -> Module: ...   # default mirrors FunctionPass
 ```
+
+- constraints:
+  - inherits the `Pass` contract (§2); same shape as `FunctionPass` over
+    `tir.PrimFunction`.
 
 ## 4. Transform pass idiom
 
@@ -182,46 +147,19 @@ A linear scheduler that runs passes in registration order and
 optionally drops per-pass IR dumps when wrapped in a
 `tilefoundry.dump.DumpScope`.
 
-```text
-PassManager:  passes: list[Pass] = [];  add(p: Pass) -> PassManager;  run(module: Module) -> Module
-```
-
-- kind: Python class
-- fields:
-  - passes: the registered passes, run in registration order
-- constraints:
-  - `requires` is an ordering assertion checked before the run, not a topological sort.
-
 ```python
 from dataclasses import dataclass, field
-from tilefoundry.dump import DumpFlags, DumpScope, dump
 
 @dataclass
 class PassManager:
-    passes: list[Pass] = field(default_factory=list)
+    passes: list[Pass] = field(default_factory=list)  # the registered passes, run in registration order
 
-    def add(self, p: Pass) -> "PassManager":
-        self.passes.append(p)
-        return self
-
-    def run(self, module: Module) -> Module:
-        self._check_requires()
-        for seq, p in enumerate(self.passes):
-            with DumpScope(f"{seq:02d}_{p.name}"):
-                dump("before.txt", repr(module), DumpFlags.PASS_IR)
-                module = p.run(module)
-                dump("after.txt", repr(module), DumpFlags.PASS_IR)
-        return module
-
-    def _check_requires(self) -> None:
-        """`requires` is an ordering assertion, not a topological sort."""
-        seen: set[str] = set()
-        for p in self.passes:
-            for r in p.requires:
-                if r not in seen:
-                    raise ValueError(f"pass {p.name!r} requires {r!r} not registered before it")
-            seen.add(p.name)
+    def add(self, p: Pass) -> "PassManager": ...      # register a pass; returns self for chaining
+    def run(self, module: Module) -> Module: ...      # run passes in registration order
 ```
+
+- constraints:
+  - `requires` is an ordering assertion checked before the run, not a topological sort.
 
 `PassManager` does not own a dump destination. When the caller
 wraps the run in a `DumpScope` and `DumpFlags.PASS_IR` is enabled,
@@ -281,12 +219,11 @@ unified retype / verify is scheduled by `PassManager`.
 
 ### 7.1 `HirToTirPass`
 
-```text
-HirToTirPass(ModulePass):  run(module: Module) -> Module
+```python
+class HirToTirPass(ModulePass):                     # replaces every hir.Function with a tir.PrimFunction
+    name = "hir_to_tir"
 ```
 
-- kind: Python pass
-- fields: none — replaces every `hir.Function` with a `tir.PrimFunction`
 - constraints:
   - TIR has no return-tensor form; HIR outputs become trailing params. The
     per-op / mesh / `Reshard` / dispatch lowering rules are in the subsections
@@ -298,11 +235,6 @@ tensor` calling convention into the TIR explicit-output-param form
 `PrimFunction(params=(inputs..., outputs...), body=...)`. TIR has
 no return-tensor form. After this pass, `PassManager` reruns HIR
 `typeinfer` / TIR `verify` on the dirty scope.
-
-```python
-class HirToTirPass(ModulePass):
-    name = "hir_to_tir"
-```
 
 #### Per-op lowering dispatch
 
@@ -441,21 +373,15 @@ into the `tir.memory.*` descriptors. Policy: every logical buffer
 gets an independent physical allocation; no reuse, pool, or lifetime
 overlap. Buffer planning is not a codegen responsibility.
 
-```text
-BufferizePass(PrimFuncPass):  name = "bufferize";  requires = ("hir_to_tir",)
-```
-
-- kind: Python pass
-- fields: none — assigns each logical buffer a physical offset / size after `HirToTirPass`
-- constraints:
-  - every logical buffer gets an independent physical allocation; no reuse, pool,
-    or lifetime overlap. Buffer planning is not a codegen responsibility.
-
 ```python
-class BufferizePass(PrimFuncPass):
+class BufferizePass(PrimFuncPass):                  # assigns each logical buffer a physical offset / size after HirToTirPass
     name = "bufferize"
     requires = ("hir_to_tir",)
 ```
+
+- constraints:
+  - every logical buffer gets an independent physical allocation; no reuse, pool,
+    or lifetime overlap. Buffer planning is not a codegen responsibility.
 
 ## 8. Directory layout
 

--- a/docs/spec/passes.md
+++ b/docs/spec/passes.md
@@ -335,7 +335,7 @@ The pass lowers each `Module.functions` entry by its shape
      symbol, not by narrowed param types.
   2. The prototype emits one entry `tir.PrimFunction` under the
      unmangled `name` whose body is a single `tir.DispatchCall`
-     (see [tir.md §6](./tir.md#6-dispatchcall)):
+     (see [tir.md §1.6](./tir.md#16-dispatchcall)):
      - `subjects = (ShapeOf(param, axis),)` for the canonical
        `(param, axis)` of the dispatch `DimVar`;
      - `case_patterns` carries each variant's pattern in source

--- a/docs/spec/passes.md
+++ b/docs/spec/passes.md
@@ -34,6 +34,7 @@ pass framework is:
 
 ## 2. `Pass` base class
 
+
 ```python
 from abc import ABC, abstractmethod
 from tilefoundry.ir.core import Module
@@ -321,7 +322,7 @@ Worked example: `SM80_16x8x16_F32BF16BF16F32_TN` with
 #### Dispatch lowering
 
 The pass lowers each `Module.functions` entry by its shape
-([hir.md §5](./hir.md#5-dispatch-specializations)):
+([hir.md §1.1](./hir.md#11-function)):
 
 - A normal function (`variants == ()`) lowers on the default
   single-body path.
@@ -357,7 +358,7 @@ derived from `call.args[param_index].type.shape[axis]`:
 
 An empty reachable set is a compile-time error. Coverage and
 disjointness of the variants over the dispatch envelope are verified
-statically (the partition rule, [hir.md §5](./hir.md#5-dispatch-specializations)),
+statically (the partition rule, [hir.md §1.1](./hir.md#11-function)),
 so an in-envelope shape always selects exactly one variant. The
 `tir.DispatchCall.fallback` (`Abort`) is reached only by an
 out-of-envelope shape — a call-contract violation.

--- a/docs/spec/passes.md
+++ b/docs/spec/passes.md
@@ -120,22 +120,11 @@ Transform passes use the visitor / mutator base classes from
 [visitor-mutator](./visitor-mutator.md) rather than hand-written
 `isinstance` dispatch.
 
-```python
-from tilefoundry.ir.visitor import StmtExprMutator
-from tilefoundry.passes.pass_base import PrimFuncPass
-
-class MyRewritePass(PrimFuncPass):
-    name = "my_rewrite"
-
-    class _Impl(StmtExprMutator):
-        def visit_Evaluate(self, stmt): ...   # match on Evaluate; dispatch on type(stmt.callable)
-
-    def run_prim_func(self, fn, module):
-        new_body = self._Impl().visit_stmt(fn.body)
-        if new_body is fn.body:
-            return fn                          # identity preservation
-        return replace(fn, body=new_body)
-```
+A transform `PrimFuncPass` wraps a `StmtExprMutator` subclass: `run_prim_func`
+runs the mutator over `fn.body`, returns `fn` unchanged when the mutator
+preserves identity (the returned body is the same object), and otherwise
+returns `replace(fn, body=new_body)`. The inner mutator matches on `Evaluate`
+and dispatches on `type(stmt.callable)`.
 
 The visit-and-rewrite contract — including the `visit_Evaluate`
 entry form for TIR effect Ops — is owned by

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -14,9 +14,23 @@ snapshot.
 
 ### 1.1 `RuntimeModule`
 
-`RuntimeModule` is the result object of `tilefoundry.build(mod)`,
-`tilefoundry.compile(mod)`, and `tilefoundry.jit(fn_or_mod)`. It is directly
-callable:
+```text
+RuntimeModule:  source;  kernels;  entry;  launch_config;  functions;  entry_function;  __call__(*args)
+```
+
+- kind: Python class
+- fields:
+  - source: generated target source string, e.g. CUDA `.cu` text
+  - kernels: kernel metadata keyed by generated kernel name
+  - entry: name of the default entry function (`str`)
+  - launch_config: launch metadata (grid/block dims)
+  - functions: mapping of function name → `RuntimeFunction` callable
+  - entry_function: `functions[entry]` — the default `RuntimeFunction`
+  - __call__(*args): delegates to `entry_function(*args)`
+- constraints:
+  - `RuntimeModule` is the result object of `tilefoundry.build(mod)`,
+    `tilefoundry.compile(mod)`, and `tilefoundry.jit(fn_or_mod)`; it is directly
+    callable.
 
 ```python
 # AOT (full compile pipeline)
@@ -28,19 +42,20 @@ rt = tilefoundry.jit(mod_or_fn, target="cuda", options=...)
 out = rt(a)
 ```
 
-| field / property | meaning |
-|---|---|
-| `source` | generated target source string, e.g. CUDA `.cu` text |
-| `kernels` | kernel metadata keyed by generated kernel name |
-| `entry` | name of the default entry function (`str`) |
-| `launch_config` | launch metadata (grid/block dims) |
-| `functions` | mapping of function name → `RuntimeFunction` callable |
-| `entry_function` | `functions[entry]` — the default `RuntimeFunction` |
-| `__call__(*args)` | delegates to `entry_function(*args)` |
-
 ### 1.1.1 `RuntimeFunction`
 
 Each compiled function is wrapped as a `RuntimeFunction`:
+
+```text
+RuntimeFunction:  type: CallableType;  __call__(*args)
+```
+
+- kind: Python class
+- fields:
+  - type: the calling convention — `CallableType` (params + input / output counts)
+- constraints:
+  - `__call__(*args)` auto-allocates outputs when `len(args) == type.input_count`,
+    otherwise uses the provided output tensors (pre-alloc); see §1.2.
 
 ```python
 class RuntimeFunction:
@@ -85,6 +100,19 @@ Output metadata (dtype, shape) comes from `CallableType.output_params` (set by
 codegen from lowered IR, NOT guessed at runtime).
 
 ### 1.2 `jit()` API
+
+```text
+jit(fn_or_mod: Function | Module, *, target: str = "cuda", options: CompilerOptions | None = None) -> RuntimeModule
+```
+
+- kind: runtime func
+- fields:
+  - fn_or_mod: a `hir.Function` or `Module` (normalized to a `Module`)
+  - target: the back-end target (default `"cuda"`)
+  - options: optional `CompilerOptions`
+- constraints:
+  - accepts only TileFoundry IR (`Function` / `Module`); raw Python functions
+    raise `TypeError`; the full input contract is stated below.
 
 `tilefoundry.jit(fn_or_mod, *, target="cuda", options=None)` is the JIT
 entry point.  It accepts a `hir.Function` or `Module`, normalizes to a
@@ -151,6 +179,18 @@ boundary the TIR/codegen surface is explicit input/output parameters.
 
 ### 1.3 `launch_config`
 
+```text
+launch_config  # launch geometry metadata (grid / block dims)
+```
+
+- kind: Python class
+- fields:
+  - grid dims: derived from CTA-level topology
+  - block dims: derived from thread-level topology
+- constraints:
+  - metadata only, not a runtime scheduler; records the launch shape the
+    generated kernel was compiled for.
+
 `launch_config` is derived from the outer `MeshScope` topology information in
 the lowered TIR/codegen input.
 
@@ -180,101 +220,108 @@ include only the umbrella header and MUST NOT include target subheaders directly
 
 ### 2.1 `TopologyScope`
 
-```cpp
+```text
 enum class TopologyScope { cta, thread, scope_count };
 ```
 
-- `cta` maps to `blockIdx`
-- `thread` maps to `threadIdx`
-- `scope_count` is a sentinel
+- kind: C++ class
+- fields:
+  - cta: maps to `blockIdx`
+  - thread: maps to `threadIdx`
+  - scope_count: a sentinel
+- constraints: none — a fixed enumeration of program topology levels
 
 ### 2.2 Topology Metadata
 
-```cpp
-template <TopologyScope T>
-auto program_shape() noexcept;  // shape of topology level T
-
-template <TopologyScope T>
-auto program_dim() noexcept;    // size of topology level T
-
-template <TopologyScope T>
-auto program_id() noexcept;     // linearized runtime id of T
+```text
+template <TopologyScope T> auto program_shape() noexcept;  // shape of topology level T
+template <TopologyScope T> auto program_dim() noexcept;    // size of topology level T
+template <TopologyScope T> auto program_id() noexcept;     // linearized runtime id of T
 ```
 
-- `program_shape<T>()` returns the shape of topology level `T` (e.g.
-  `program_shape<cta>()` → grid dims).
-- `program_dim<T>()` returns the size of `T`.
-- `program_id<T>()` returns a **linearized** scalar runtime id for `T`
-  (`program_id<cta>()` → linearized block index; `program_id<thread>()` →
-  linearized thread index).
+- kind: runtime func
+- fields:
+  - program_shape<T>(): the shape of topology level `T` (e.g.
+    `program_shape<cta>()` → grid dims)
+  - program_dim<T>(): the size of `T`
+  - program_id<T>(): a **linearized** scalar runtime id for `T`
+    (`program_id<cta>()` → linearized block index; `program_id<thread>()` →
+    linearized thread index)
+- constraints:
+  - static vs dynamic (launch-provided CTA) behavior and the emission rule are
+    stated below ([target §7](./target.md#7-program-shape-and-dynamic-cta)).
 
 For a static topology level, `program_shape<T>()` and `program_dim<T>()` are
 compile-time constants. For a launch-provided (dynamic) CTA count, no constexpr
 `program_shape<cta>` is emitted and `program_dim<cta>()` resolves to the
 launch-provided grid extent at runtime; the emission rule is owned by
-[codegen §6](./codegen.md#6-program-shape-and-dynamic-cta). `program_id<T>()` is
+[target §7](./target.md#7-program-shape-and-dynamic-cta). `program_id<T>()` is
 always a runtime query returning the current execution instance id.
 
 ### 2.3 `tilefoundry::Mesh`
 
-```cpp
+```text
 template <class MeshLayout, TopologyScope... Topos>
-struct Mesh {
-    MeshLayout mesh_layout;
-    static constexpr auto topologies = cute::make_tuple(Topos...);
-};
-```
-
-- `MeshLayout` is a CuTe-compatible layout type
-- `Topos...` are compile-time `TopologyScope` values encoding the sparse topology list; only the topology levels this mesh actually uses are included
-- `topologies` is a `static constexpr` tuple — type-level information, not runtime state
-
-Axes-to-topology mapping: axes are partitioned into contiguous groups, matched from the **end** of `mesh_layout.shape` backwards, in **reverse** `topologies` tuple order. For each topology, greedily consume consecutive trailing axes until their product equals that topology's device count.
-
-```cpp
+struct Mesh { MeshLayout mesh_layout;  static constexpr auto topologies = cute::make_tuple(Topos...); };
 auto local_index() const noexcept;
 ```
 
-- for each topology in `topologies`, calls `program_id<T>()` to get the runtime id
-- converts each runtime id to sub-coordinates via `idx2crd(id, sub_shape, sub_stride)`
-- concatenates into a full mesh coordinate (CuTe coord / int-tuple)
-
-Constraint:
-
-- for each topology `T` in `topologies`, the product of its assigned axes'
-  extents equals the device count of `T`
+- kind: C++ class
+- fields:
+  - mesh_layout: a CuTe-compatible layout type
+  - topologies: a `static constexpr` tuple of the sparse `TopologyScope` list
+    (`Topos...`) this mesh uses — type-level information, not runtime state; only
+    the topology levels the mesh actually uses are included
+- constraints:
+  - Axes-to-topology mapping: axes are partitioned into contiguous groups, matched
+    from the **end** of `mesh_layout.shape` backwards, in **reverse** `topologies`
+    tuple order. For each topology, greedily consume consecutive trailing axes
+    until their product equals that topology's device count.
+  - `local_index()` — for each topology in `topologies`, calls `program_id<T>()`
+    to get the runtime id, converts each runtime id to sub-coordinates via
+    `idx2crd(id, sub_shape, sub_stride)`, and concatenates into a full mesh
+    coordinate (CuTe coord / int-tuple).
+  - for each topology `T` in `topologies`, the product of its assigned axes'
+    extents equals the device count of `T`
 
 ### 2.4 `tilefoundry::ShardLayout`
 
-```cpp
+```text
 template <class Layout, class Attrs, class Mesh>
-struct ShardLayout {
-    Layout layout;
-    Attrs attrs;
-    Mesh mesh;
-};
+struct ShardLayout { Layout layout;  Attrs attrs;  Mesh mesh; };
 ```
 
-- `layout` is the underlying CuTe layout
-- `attrs` are shard attributes, ordered by mesh axis
-- `mesh` is the bound device domain
+- kind: C++ class
+- fields:
+  - layout: the underlying CuTe layout
+  - attrs: shard attributes, ordered by mesh axis
+  - mesh: the bound device domain
+- constraints: none — a plain layout / attrs / mesh aggregate
 
 ### 2.5 `tilefoundry::shard` — Shard Attributes
 
-```cpp
+```text
 namespace tilefoundry::shard {
-template <int Axis> struct S {};  // Split along axis
-struct B {};                       // Broadcast (replicate)
-template <class Reduction> struct P {};  // Partial reduction
-struct Dynamic {};                 // Dynamic / data-dependent
+  template <int Axis> struct S {};         // Split along axis
+  struct B {};                             // Broadcast (replicate)
+  template <class Reduction> struct P {};  // Partial reduction
+  struct Dynamic {};                       // Dynamic / data-dependent
 }
 ```
+
+- kind: C++ class
+- fields:
+  - S<Axis>: Split along axis
+  - B: Broadcast (replicate)
+  - P<Reduction>: Partial reduction
+  - Dynamic: Dynamic / data-dependent
+- constraints: none — compile-time shard-attribute tags
 
 Shorthand: `S<Axis>` = Split, `B` = Broadcast, `P<Reduction>` = Partial.
 
 ### 2.6 `tilefoundry::ShardTensor`
 
-```cpp
+```text
 template <class Engine_, class GlobalLayout_, class ShardLayout_>
 struct ShardTensor {
   using engine_type = Engine_;
@@ -286,6 +333,16 @@ struct ShardTensor {
   auto data() const;
 };
 ```
+
+- kind: C++ class
+- fields:
+  - engine: CuTe tensor / view (gmem / smem / rmem); a raw pointer is rejected
+  - shard_layout: runtime shard-layout value (dynamic dims carry real extents)
+  - data(): underlying pointer of the wrapped cute tensor
+- constraints:
+  - `engine` must be a full cute tensor/view, never a raw pointer (residency
+    lives on the engine type); `data()` drops the residency tag. The full
+    residency / raw-pointer rules are stated below.
 
 `engine` holds the **full cute tensor/view, not a raw pointer**. The
 gmem / smem / rmem **residency category** lives on the cute engine *type*;
@@ -302,17 +359,22 @@ use `local()` instead.
 
 ### 2.7 `tilefoundry::make_shard_tensor`
 
-```cpp
+```text
 template <class T, class GL, class SL>
 auto make_shard_tensor(T const& tensor, GL global_layout, SL shard_layout)
   -> ShardTensor<T, GL, SL>;
 ```
 
-Factory. `T` must be a CuTe tensor/view; raw pointers rejected at compile time.
+- kind: runtime func
+- fields:
+  - tensor: a CuTe tensor / view (raw pointers rejected at compile time)
+  - global_layout / shard_layout: the global and shard layouts to bind
+- constraints:
+  - Factory. `T` must be a CuTe tensor/view; raw pointers rejected at compile time.
 
 ### 2.8 `tilefoundry::copy` — Shard-aware Overloads
 
-```cpp
+```text
 // shard → plain
 template <class T, class GL, class SL, class DT>
 void copy(ShardTensor<T, GL, SL> const& src, DT& dst);
@@ -322,16 +384,24 @@ template <class ST, class T, class GL, class SL>
 void copy(ST const& src, ShardTensor<T, GL, SL>& dst);
 ```
 
-Copies the full tensor between a shard tensor and a plain tensor.
+- kind: runtime func
+- fields:
+  - src / dst: a shard tensor and a plain tensor (either direction)
+- constraints:
+  - Copies the full tensor between a shard tensor and a plain tensor.
 
 ### 2.10 `local()`
 
-```cpp
+```text
 template <class E, class GL, class SL>
 auto local(ShardTensor<E, GL, SL> const& t) noexcept;
 ```
 
-Returns the cute `Tensor` view this execution instance owns on `t`.
+- kind: runtime func
+- fields:
+  - t: the `ShardTensor` to project to this execution instance's local view
+- constraints:
+  - Returns the cute `Tensor` view this execution instance owns on `t`.
 
 #### 2.10.1 Inputs
 
@@ -369,13 +439,16 @@ storage-specific branching is required.
 
 ### 2.9 Tensor And Storage
 
-```cpp
+```text
 cute::Tensor<Engine, Layout>
 ```
 
-- `Engine` is the CuTe engine / iterator / pointer category
-- `Layout` is a CuTe layout or `tilefoundry::ShardLayout`
-- when `Layout` is `ShardLayout`, the tensor has distributed semantics
+- kind: C++ class
+- fields:
+  - `Engine` is the CuTe engine / iterator / pointer category
+  - `Layout` is a CuTe layout or `tilefoundry::ShardLayout`
+- constraints:
+  - when `Layout` is `ShardLayout`, the tensor has distributed semantics
 
 | storage | C++ |
 |---------|-----|
@@ -410,54 +483,57 @@ selects a tier, computes a per-tier parameter, or carries the selection on the
 TIR op. `ops::reduce` ([§3.5](#35-tilefoundryopsreduce-reduction-family))
 derives its reduction level from the operand shard layouts and `ops::sync`
 ([§3.4](#34-tilefoundryopssync-mesh-scoped-barrier)) derives its participant
-predicate from the barrier geometry; both are instances of this principle. The
+predicate from the barrier geometry; both are instances of this principle. A
+target runtime implementation MAY select an internal optimized load/store path
+(such as a wider vector copy) behind this single entry without changing the
+public entry or its observable result. The
 codegen side is
-[codegen §3.1](./codegen.md#31-runtime-owned-op-dispatch).
+[codegen §3](./codegen.md#3-runtime-owned-op-dispatch).
 
 ### 3.1 `cute::copy`
 
-```cpp
+```text
 template <class SrcTensor, class DstTensor>
 void copy(SrcTensor const& src, DstTensor& dst);
 ```
 
-Semantics:
-
-- copies data from `src` to `dst`
-
-Preconditions:
-
-- `size(src) == size(dst)`
-- source and destination dtypes are compatible
+- kind: runtime func
+- fields:
+  - src / dst: source and destination tensors
+- constraints:
+  - copies data from `src` to `dst`
+  - `size(src) == size(dst)`
+  - source and destination dtypes are compatible
 
 ### 3.2 `cute::fill`
 
-```cpp
+```text
 template <class Tensor, class Value>
 void fill(Tensor& tensor, Value val);
 ```
 
-Semantics:
-
-- fills `tensor` with scalar `val`
+- kind: runtime func
+- fields:
+  - tensor / val: the destination tensor and the scalar fill value
+- constraints:
+  - fills `tensor` with scalar `val`
 
 ### 3.3 `tilefoundry::shard_partition`
 
-```cpp
+```text
 template <class Tensor>
 auto shard_partition(Tensor const& tensor);
 ```
 
-Semantics:
-
-- extracts `mesh` from `tensor.layout()`
-- calls `mesh.local_index()` to get the current device coordinate
-- projects the tensor to the local view at that coordinate
-- returns a `cute::Tensor` with plain CuTe layout
-
-Preconditions:
-
-- `tensor.layout()` is a `ShardLayout`
+- kind: runtime func
+- fields:
+  - tensor: a tensor whose `layout()` is a `ShardLayout`
+- constraints:
+  - extracts `mesh` from `tensor.layout()`
+  - calls `mesh.local_index()` to get the current device coordinate
+  - projects the tensor to the local view at that coordinate
+  - returns a `cute::Tensor` with plain CuTe layout
+  - `tensor.layout()` is a `ShardLayout`
 
 ### 3.4 `tilefoundry::ops::sync` (mesh-scoped barrier)
 
@@ -520,26 +596,3 @@ __device__ void copy_async(TSrc const& src, TDst& dst);
     `cp_async_commit` and `cp_async_wait`.
   - Runtime implementation details such as vector width, tail handling, and
     architecture fallback live in code comments, not this spec entry.
-
-### 3.7 Wide-load fast path in `copy()`
-
-The shard-aware `copy()` selects a 128-bit vector-load fast path from the
-operands alone, per the runtime-owned dispatch principle
-([§3](#3-runtime-ops)): one `copy()` entry, no codegen-visible selection. It is
-taken only when all of the following hold, and otherwise the copy falls back to
-the scalar element loop with identical results:
-
-- the source is gmem-resident (`cute::is_gmem` on the `ShardTensor` engine);
-- the destination local view is a static, rank-1, contiguous fragment whose
-  contiguous run is at least 128 bits wide —
-  `cute::max_common_vector(dst, dst) × cute::sizeof_bits<value_type> ≥ 128`,
-  where `value_type` is the cute view element type, not the `ShardTensor` engine
-  type;
-- at runtime the source base address is 16-byte aligned and the fragment is
-  contiguous (the gmem local view is dynamic-int, so contiguity is checked with
-  address arithmetic — pure ALU, no memory access).
-
-When taken, each 128-bit run is loaded as a vector into registers and scattered
-into the destination; the remaining sub-128-bit tail uses the element loop. A
-non-gmem source, a sub-128-bit run, an unaligned base, or a strided source all
-fall back to the scalar loop.

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -14,56 +14,35 @@ snapshot.
 
 ### 1.1 `RuntimeModule`
 
-```text
-RuntimeModule:  source;  kernels;  entry;  launch_config;  functions;  entry_function;  __call__(*args)
+```python
+class RuntimeModule:
+    source: str                            # generated target source string, e.g. CUDA `.cu` text
+    kernels: dict[str, KernelInfo]         # kernel metadata keyed by generated kernel name
+    entry: str                             # name of the default entry function
+    launch_config: LaunchConfig            # launch metadata (grid / block dims)
+    functions: dict[str, RuntimeFunction]  # mapping of function name → RuntimeFunction callable
+    entry_function: RuntimeFunction        # functions[entry] — the default RuntimeFunction
+    def __call__(self, *args): ...         # delegates to entry_function(*args)
 ```
 
-- kind: Python class
-- fields:
-  - source: generated target source string, e.g. CUDA `.cu` text
-  - kernels: kernel metadata keyed by generated kernel name
-  - entry: name of the default entry function (`str`)
-  - launch_config: launch metadata (grid/block dims)
-  - functions: mapping of function name → `RuntimeFunction` callable
-  - entry_function: `functions[entry]` — the default `RuntimeFunction`
-  - __call__(*args): delegates to `entry_function(*args)`
 - constraints:
   - `RuntimeModule` is the result object of `tilefoundry.build(mod)`,
     `tilefoundry.compile(mod)`, and `tilefoundry.jit(fn_or_mod)`; it is directly
     callable.
 
-```python
-# AOT (full compile pipeline)
-rm = tilefoundry.compile(mod, target="cuda", options=...)
-out = rm(a)
-
-# JIT (thin convenience wrapper with cache)
-rt = tilefoundry.jit(mod_or_fn, target="cuda", options=...)
-out = rt(a)
-```
-
 ### 1.1.1 `RuntimeFunction`
 
 Each compiled function is wrapped as a `RuntimeFunction`:
 
-```text
-RuntimeFunction:  type: CallableType;  __call__(*args)
+```python
+class RuntimeFunction:
+    type: CallableType                # the calling convention — CallableType (params + input / output counts)
+    def __call__(self, *args): ...    # auto-alloc outputs when len(args) == type.input_count, else pre-alloc; see §1.2
 ```
 
-- kind: Python class
-- fields:
-  - type: the calling convention — `CallableType` (params + input / output counts)
 - constraints:
   - `__call__(*args)` auto-allocates outputs when `len(args) == type.input_count`,
     otherwise uses the provided output tensors (pre-alloc); see §1.2.
-
-```python
-class RuntimeFunction:
-    type: CallableType   # calling convention: params + input/output counts
-    # __call__(*args):
-    #   auto-alloc: len(args) == type.input_count → alloc outputs, return result(s)
-    #   pre-alloc:  len(args) == len(type.params)  → use provided outs, return outs
-```
 
 `CallableType` carries `params`, `input_count`, `output_count` — set by
 codegen from the lowered IR metadata.
@@ -101,15 +80,15 @@ codegen from lowered IR, NOT guessed at runtime).
 
 ### 1.2 `jit()` API
 
-```text
-jit(fn_or_mod: Function | Module, *, target: str = "cuda", options: CompilerOptions | None = None) -> RuntimeModule
+```python
+def jit(
+    fn_or_mod: Function | Module,             # a hir.Function or Module (normalized to a Module)
+    *,
+    target: str = "cuda",                     # the back-end target (default "cuda")
+    options: CompilerOptions | None = None,   # optional CompilerOptions
+) -> RuntimeModule: ...
 ```
 
-- kind: runtime func
-- fields:
-  - fn_or_mod: a `hir.Function` or `Module` (normalized to a `Module`)
-  - target: the back-end target (default `"cuda"`)
-  - options: optional `CompilerOptions`
 - constraints:
   - accepts only TileFoundry IR (`Function` / `Module`); raw Python functions
     raise `TypeError`; the full input contract is stated below.
@@ -117,21 +96,6 @@ jit(fn_or_mod: Function | Module, *, target: str = "cuda", options: CompilerOpti
 `tilefoundry.jit(fn_or_mod, *, target="cuda", options=None)` is the JIT
 entry point.  It accepts a `hir.Function` or `Module`, normalizes to a
 `Module`, compiles with cache, and returns a callable `RuntimeModule`.
-
-```python
-from tilefoundry import jit
-
-cta = Topology("cta", 128)
-thread = Topology("thread", 8 * 32)
-
-@func(topologies=(cta, thread))
-def fn(x: Tensor[(32,128), "f32"]):
-    with Mesh(topology="cta", layout=Layout(shape=(128,), strides=(1,))) as cta_mesh:
-        ...
-
-rt = jit(fn, target="cuda")
-out = rt(a)  # callable
-```
 
 **Input contract**:
 - Only TileFoundry IR objects (`Function` / `Module`) accepted.
@@ -179,14 +143,12 @@ boundary the TIR/codegen surface is explicit input/output parameters.
 
 ### 1.3 `launch_config`
 
-```text
-launch_config  # launch geometry metadata (grid / block dims)
+```python
+class LaunchConfig:      # launch geometry metadata (grid / block dims)
+    grid: tuple[int, ...]    # grid dims, derived from CTA-level topology
+    block: tuple[int, ...]   # block dims, derived from thread-level topology
 ```
 
-- kind: Python class
-- fields:
-  - grid dims: derived from CTA-level topology
-  - block dims: derived from thread-level topology
 - constraints:
   - metadata only, not a runtime scheduler; records the launch shape the
     generated kernel was compiled for.
@@ -220,33 +182,24 @@ include only the umbrella header and MUST NOT include target subheaders directly
 
 ### 2.1 `TopologyScope`
 
-```text
-enum class TopologyScope { cta, thread, scope_count };
+```cpp
+enum class TopologyScope {
+  cta,          // maps to blockIdx
+  thread,       // maps to threadIdx
+  scope_count,  // a sentinel
+};
 ```
 
-- kind: C++ class
-- fields:
-  - cta: maps to `blockIdx`
-  - thread: maps to `threadIdx`
-  - scope_count: a sentinel
 - constraints: none — a fixed enumeration of program topology levels
 
 ### 2.2 Topology Metadata
 
-```text
-template <TopologyScope T> auto program_shape() noexcept;  // shape of topology level T
+```cpp
+template <TopologyScope T> auto program_shape() noexcept;  // shape of topology level T (e.g. program_shape<cta>() → grid dims)
 template <TopologyScope T> auto program_dim() noexcept;    // size of topology level T
-template <TopologyScope T> auto program_id() noexcept;     // linearized runtime id of T
+template <TopologyScope T> auto program_id() noexcept;     // linearized scalar runtime id of T (current execution instance)
 ```
 
-- kind: runtime func
-- fields:
-  - program_shape<T>(): the shape of topology level `T` (e.g.
-    `program_shape<cta>()` → grid dims)
-  - program_dim<T>(): the size of `T`
-  - program_id<T>(): a **linearized** scalar runtime id for `T`
-    (`program_id<cta>()` → linearized block index; `program_id<thread>()` →
-    linearized thread index)
 - constraints:
   - static vs dynamic (launch-provided CTA) behavior and the emission rule are
     stated below ([target §7](./target.md#7-program-shape-and-dynamic-cta)).
@@ -260,18 +213,15 @@ always a runtime query returning the current execution instance id.
 
 ### 2.3 `tilefoundry::Mesh`
 
-```text
+```cpp
 template <class MeshLayout, TopologyScope... Topos>
-struct Mesh { MeshLayout mesh_layout;  static constexpr auto topologies = cute::make_tuple(Topos...); };
-auto local_index() const noexcept;
+struct Mesh {
+  MeshLayout mesh_layout;                                        // a CuTe-compatible layout type
+  static constexpr auto topologies = cute::make_tuple(Topos...); // sparse TopologyScope list this mesh uses (type-level, not runtime state)
+  auto local_index() const noexcept;                             // full mesh coordinate for this execution instance
+};
 ```
 
-- kind: C++ class
-- fields:
-  - mesh_layout: a CuTe-compatible layout type
-  - topologies: a `static constexpr` tuple of the sparse `TopologyScope` list
-    (`Topos...`) this mesh uses — type-level information, not runtime state; only
-    the topology levels the mesh actually uses are included
 - constraints:
   - Axes-to-topology mapping: axes are partitioned into contiguous groups, matched
     from the **end** of `mesh_layout.shape` backwards, in **reverse** `topologies`
@@ -286,21 +236,20 @@ auto local_index() const noexcept;
 
 ### 2.4 `tilefoundry::ShardLayout`
 
-```text
+```cpp
 template <class Layout, class Attrs, class Mesh>
-struct ShardLayout { Layout layout;  Attrs attrs;  Mesh mesh; };
+struct ShardLayout {
+  Layout layout;   // the underlying CuTe layout
+  Attrs attrs;     // shard attributes, ordered by mesh axis
+  Mesh mesh;       // the bound device domain
+};
 ```
 
-- kind: C++ class
-- fields:
-  - layout: the underlying CuTe layout
-  - attrs: shard attributes, ordered by mesh axis
-  - mesh: the bound device domain
 - constraints: none — a plain layout / attrs / mesh aggregate
 
 ### 2.5 `tilefoundry::shard` — Shard Attributes
 
-```text
+```cpp
 namespace tilefoundry::shard {
   template <int Axis> struct S {};         // Split along axis
   struct B {};                             // Broadcast (replicate)
@@ -309,19 +258,13 @@ namespace tilefoundry::shard {
 }
 ```
 
-- kind: C++ class
-- fields:
-  - S<Axis>: Split along axis
-  - B: Broadcast (replicate)
-  - P<Reduction>: Partial reduction
-  - Dynamic: Dynamic / data-dependent
 - constraints: none — compile-time shard-attribute tags
 
 Shorthand: `S<Axis>` = Split, `B` = Broadcast, `P<Reduction>` = Partial.
 
 ### 2.6 `tilefoundry::ShardTensor`
 
-```text
+```cpp
 template <class Engine_, class GlobalLayout_, class ShardLayout_>
 struct ShardTensor {
   using engine_type = Engine_;
@@ -334,11 +277,6 @@ struct ShardTensor {
 };
 ```
 
-- kind: C++ class
-- fields:
-  - engine: CuTe tensor / view (gmem / smem / rmem); a raw pointer is rejected
-  - shard_layout: runtime shard-layout value (dynamic dims carry real extents)
-  - data(): underlying pointer of the wrapped cute tensor
 - constraints:
   - `engine` must be a full cute tensor/view, never a raw pointer (residency
     lives on the engine type); `data()` drops the residency tag. The full
@@ -359,22 +297,20 @@ use `local()` instead.
 
 ### 2.7 `tilefoundry::make_shard_tensor`
 
-```text
+```cpp
 template <class T, class GL, class SL>
-auto make_shard_tensor(T const& tensor, GL global_layout, SL shard_layout)
+auto make_shard_tensor(T const& tensor,   // a CuTe tensor / view (raw pointers rejected at compile time)
+                       GL global_layout,  // the global layout to bind
+                       SL shard_layout)   // the shard layout to bind
   -> ShardTensor<T, GL, SL>;
 ```
 
-- kind: runtime func
-- fields:
-  - tensor: a CuTe tensor / view (raw pointers rejected at compile time)
-  - global_layout / shard_layout: the global and shard layouts to bind
 - constraints:
   - Factory. `T` must be a CuTe tensor/view; raw pointers rejected at compile time.
 
 ### 2.8 `tilefoundry::copy` — Shard-aware Overloads
 
-```text
+```cpp
 // shard → plain
 template <class T, class GL, class SL, class DT>
 void copy(ShardTensor<T, GL, SL> const& src, DT& dst);
@@ -384,22 +320,16 @@ template <class ST, class T, class GL, class SL>
 void copy(ST const& src, ShardTensor<T, GL, SL>& dst);
 ```
 
-- kind: runtime func
-- fields:
-  - src / dst: a shard tensor and a plain tensor (either direction)
 - constraints:
   - Copies the full tensor between a shard tensor and a plain tensor.
 
 ### 2.10 `local()`
 
-```text
+```cpp
 template <class E, class GL, class SL>
-auto local(ShardTensor<E, GL, SL> const& t) noexcept;
+auto local(ShardTensor<E, GL, SL> const& t) noexcept;   // project t to this execution instance's local view
 ```
 
-- kind: runtime func
-- fields:
-  - t: the `ShardTensor` to project to this execution instance's local view
 - constraints:
   - Returns the cute `Tensor` view this execution instance owns on `t`.
 
@@ -439,14 +369,12 @@ storage-specific branching is required.
 
 ### 2.9 Tensor And Storage
 
-```text
-cute::Tensor<Engine, Layout>
+```cpp
+template <class Engine,   // the CuTe engine / iterator / pointer category
+          class Layout>   // a CuTe layout or tilefoundry::ShardLayout
+class cute::Tensor;
 ```
 
-- kind: C++ class
-- fields:
-  - `Engine` is the CuTe engine / iterator / pointer category
-  - `Layout` is a CuTe layout or `tilefoundry::ShardLayout`
 - constraints:
   - when `Layout` is `ShardLayout`, the tensor has distributed semantics
 
@@ -460,8 +388,8 @@ cute::Tensor<Engine, Layout>
 
 Codegen targets one public namespace function per runtime op/family:
 
-```text
-tilefoundry::ops::<op>(...)
+```cpp
+tilefoundry::ops::<op>(...)   // one public namespace function per runtime op / family
 ```
 
 ```mermaid
@@ -492,14 +420,11 @@ codegen side is
 
 ### 3.1 `cute::copy`
 
-```text
+```cpp
 template <class SrcTensor, class DstTensor>
-void copy(SrcTensor const& src, DstTensor& dst);
+void copy(SrcTensor const& src, DstTensor& dst);   // source and destination tensors
 ```
 
-- kind: runtime func
-- fields:
-  - src / dst: source and destination tensors
 - constraints:
   - copies data from `src` to `dst`
   - `size(src) == size(dst)`
@@ -507,27 +432,21 @@ void copy(SrcTensor const& src, DstTensor& dst);
 
 ### 3.2 `cute::fill`
 
-```text
+```cpp
 template <class Tensor, class Value>
-void fill(Tensor& tensor, Value val);
+void fill(Tensor& tensor, Value val);   // the destination tensor and the scalar fill value
 ```
 
-- kind: runtime func
-- fields:
-  - tensor / val: the destination tensor and the scalar fill value
 - constraints:
   - fills `tensor` with scalar `val`
 
 ### 3.3 `tilefoundry::shard_partition`
 
-```text
+```cpp
 template <class Tensor>
-auto shard_partition(Tensor const& tensor);
+auto shard_partition(Tensor const& tensor);   // a tensor whose layout() is a ShardLayout
 ```
 
-- kind: runtime func
-- fields:
-  - tensor: a tensor whose `layout()` is a `ShardLayout`
 - constraints:
   - extracts `mesh` from `tensor.layout()`
   - calls `mesh.local_index()` to get the current device coordinate
@@ -537,18 +456,13 @@ auto shard_partition(Tensor const& tensor);
 
 ### 3.4 `tilefoundry::ops::sync` (mesh-scoped barrier)
 
-```text
-template <SyncKind Kind, int Base = 0, int Count = 0, unsigned Mask = 0u,
+```cpp
+template <SyncKind Kind,                                              // compile-time barrier kind; selects CTA, warp, named-barrier, or grid behavior
+          int Base = 0, int Count = 0, unsigned Mask = 0u,            // compile-time participant geometry
           int BarId = 0>
-__device__ void sync(unsigned int* grid_bar = nullptr);
+__device__ void sync(unsigned int* grid_bar = nullptr);   // optional two-word global counter pair used only by grid barriers
 ```
 
-- kind: runtime func
-- fields:
-  - Kind: compile-time barrier kind; selects CTA, warp, named-barrier, or grid
-    behavior inside the runtime entry
-  - Base / Count / Mask / BarId: compile-time participant geometry
-  - grid_bar: optional two-word global counter pair used only by grid barriers
 - constraints:
   - Codegen emits only `sync`; it does not call lower-level barrier helpers.
   - Grid barriers require every CTA of the launch to be co-resident and to
@@ -558,19 +472,14 @@ __device__ void sync(unsigned int* grid_bar = nullptr);
 
 ### 3.5 `tilefoundry::ops::reduce` (reduction family)
 
-```text
-template <class Op, class Axes, class Src, class Dst, class Ws = no_workspace>
+```cpp
+template <class Op,                 // compile-time combine tag (sum, mean, max, absmax)
+          class Axes,               // compile-time reduced logical axes
+          class Src, class Dst,     // source and destination operands; sharded operands carry ShardLayout
+          class Ws = no_workspace>  // optional shared-memory workspace; no_workspace keeps the reduce within one warp
 __device__ void reduce(Src const& src, Dst& dst, Ws&& ws = {});
 ```
 
-- kind: runtime func
-- fields:
-  - Op: compile-time combine tag (`sum`, `mean`, `max`, `absmax`)
-  - Axes: compile-time reduced logical axes
-  - src / dst: source and destination operands; sharded operands carry
-    `ShardLayout`
-  - ws: optional shared-memory workspace value; `no_workspace` means the reduce
-    stays within one warp
 - constraints:
   - `reduce` is the only public runtime reduce entry; tier names and helper
     functions are internal.
@@ -582,15 +491,11 @@ __device__ void reduce(Src const& src, Dst& dst, Ws&& ws = {});
 
 ### 3.6 `tilefoundry::ops::copy_async` (async gmem→smem staging)
 
-```text
+```cpp
 template <class TSrc, class TDst>
-__device__ void copy_async(TSrc const& src, TDst& dst);
+__device__ void copy_async(TSrc const& src, TDst& dst);   // per-thread projected operands; fast path stages gmem source into smem destination
 ```
 
-- kind: runtime func
-- fields:
-  - src / dst: per-thread projected operands; the supported fast path stages
-    global source data into shared destination storage
 - constraints:
   - The call is non-blocking; generated code orders later reads through
     `cp_async_commit` and `cp_async_wait`.

--- a/docs/spec/shard.md
+++ b/docs/spec/shard.md
@@ -56,8 +56,12 @@ The primitive building block, taken from pycute's `shape` / `stride`
 convention. It is not just a flat tuple — nested tuples are allowed:
 
 ```python
-IntTuple = int | tuple["IntTuple", ...]
+IntTuple = int | tuple[IntTuple, ...]    # entry: an `int`, a symbolic/dynamic dim (`ShapeDim`), `None` (launch-provided extent), or a nested `IntTuple`
 ```
+
+- constraints:
+  - admits both a unique flat `int`-tuple view and a unique nested-structure view;
+    the `shape` / `strides` of `Layout` and `ShardLayout` are `IntTuple`.
 
 Flatten-equivalence: every `IntTuple` admits both a unique flat
 `int`-tuple view and a unique nested-structure view. The `shape` and
@@ -78,11 +82,15 @@ and `T.sync` participation (tir.md §1.5) — require static `int` entries and
 the `Layout` hierarchy:
 
 ```python
-class LayoutBase: pass
-class Layout(LayoutBase): ...
-class ComposedLayout(LayoutBase): ...
-class ShardLayout(LayoutBase): ...
+class LayoutBase: ...                    # abstract base
+class Layout(LayoutBase): ...            # concrete `LayoutBase` member
+class ComposedLayout(LayoutBase): ...    # concrete `LayoutBase` member
+class ShardLayout(LayoutBase): ...       # concrete `LayoutBase` member
 ```
+
+- constraints:
+  - `TensorType.layout` accepts only objects in this hierarchy; the common contract
+    below applies to every legal layout object.
 
 Common contract — every legal layout object MUST satisfy:
 
@@ -104,11 +112,14 @@ An object that does not satisfy these conditions cannot enter
 Mirrors `pycute.layout.Layout`:
 
 ```python
-@dataclass(frozen=True)
 class Layout(LayoutBase):
-    shape: IntTuple        # entries: ShapeDim | None (§1)
-    stride: IntTuple | None = None  # entries: ShapeDim; whole tuple None = un-materialized
+    shape: IntTuple                 # layout-domain shape (entries `ShapeDim | None`)
+    stride: IntTuple | None = None  # step rule from domain to physical index; whole tuple `None` = un-materialized
 ```
+
+- constraints:
+  - the pure primitive layout; it has no `offset` field. Field meanings and
+    semantics below.
 
 Field meanings:
 
@@ -139,12 +150,15 @@ The primitive `Layout` has **no** `offset` field. `offset` belongs to
 Mirrors CuTeDSL `make_composed_layout(inner, offset, outer)`:
 
 ```python
-@dataclass(frozen=True)
 class ComposedLayout(LayoutBase):
-    inner: LayoutBase
-    offset: int
-    outer: LayoutBase
+    inner: LayoutBase   # applied last (output-side layout)
+    offset: int         # intermediate scalar offset (a property of the composition)
+    outer: LayoutBase   # applied first (input / domain-side layout)
 ```
+
+- constraints:
+  - `idx = inner(offset + outer(coord))`; inherits domain shape and axis numbering
+    from `outer`.
 
 Field meanings:
 
@@ -169,31 +183,24 @@ axis exposed by `outer`.
 ## 5. `Mesh`
 
 ```python
-@dataclass(frozen=True)
-class Topology:
+class Topology:                            # device-domain description
     name: str
     num_devices: int
 
-@dataclass(frozen=True)
-class Mesh:
+class Mesh:                                # the parallel device domain
     topology: Topology
-    layout: Layout | ComposedLayout
+    layout: Layout | ComposedLayout        # a plain `Layout` (un-sliced) or a `ComposedLayout` (a constant `m[...]` slice)
     names: tuple[str, ...] | None = None
-    # compile-time constant; Python value, does not enter the IR graph.
-    # ``layout`` is a plain ``Layout`` for an un-sliced mesh. ``Mesh[key]``
-    # (``__getitem__``) slices a constant sub-mesh used by ``T.sync``
-    # (tir.md §1.5): it replaces ``layout`` with a ``ComposedLayout`` recording
-    # the participating sub-box — the selected per-axis extents over the parent
-    # strides in ``outer`` and the slice origin ``Σ start_i · stride_i`` in
-    # ``offset`` (identity ``inner``). The slice never becomes an IR/SSA value;
-    # the enclosing full mesh supplies the parent shape when a slice is verified.
 
-@dataclass(frozen=True)
-class MeshAxis:
+class MeshAxis:                            # single-axis object via `mesh.x` / `mesh.axes[i]`
     mesh: Mesh
     index: int
     size: int
 ```
+
+- constraints:
+  - a compile-time constant that does not enter the IR graph; describes the device
+    domain, not a tensor layout object. A slice never becomes an IR/SSA value.
 
 Field meanings:
 
@@ -214,22 +221,20 @@ object.
 ## 6. `ShardAttr`
 
 ```python
-@dataclass(frozen=True)
-class Split:
+class Split:                          # binds the current mesh axis to the layout's `axis`-th cute domain axis
     axis: int
 
-@dataclass(frozen=True)
-class Broadcast:
-    pass
+class Broadcast: ...                  # the value is replicated across this mesh axis
 
-@dataclass(frozen=True)
-class Dynamic:
-    pass
+class Dynamic: ...                    # the distribution policy is not yet resolved
 
-@dataclass(frozen=True)
-class Partial:
-    reduction: str = "sum"    # "sum" / "max" / "min"
+class Partial:                        # an un-reduced partial value (`sum` / `max` / `min`)
+    reduction: str = "sum"
 ```
+
+- constraints:
+  - each entry of `ShardLayout.attrs` describes one mesh axis by its tuple
+    position; per-attr semantics and surface sugar below.
 
 Each entry of `ShardLayout.attrs` describes one **mesh axis** (by its
 position in the tuple); the attr says what that mesh axis does. `Split`
@@ -279,12 +284,15 @@ a new layout-algebra primitive, it binds an underlying layout's domain
 axes to mesh axes.
 
 ```python
-@dataclass(frozen=True)
 class ShardLayout(LayoutBase):
-    layout: LayoutBase            # Layout or ComposedLayout being bound
-    attrs: tuple[Split | Broadcast | Dynamic | Partial, ...]
-    mesh: Mesh
+    layout: LayoutBase                                        # the underlying `Layout` / `ComposedLayout` being bound
+    attrs: tuple[Split | Broadcast | Dynamic | Partial, ...]  # per-mesh-axis attributes, ordered by mesh axis
+    mesh: Mesh                                                # the device-domain `Mesh`
 ```
+
+- constraints:
+  - the distributed binding layer; binds an underlying layout's domain axes to mesh
+    axes without a new layout-algebra primitive. Sub-field contracts in §7.1–§7.5.
 
 The distribution-changing transformation (redistribute / sharding) is
 itself an IR op (`hir.sharding.Reshard`, see [hir](./hir.md) §2.5).

--- a/docs/spec/shard.md
+++ b/docs/spec/shard.md
@@ -422,66 +422,12 @@ it verbatim.
 
 ---
 
-## 8. Logical shape to layout domain
+## 8. Layout propagation
 
-- `TensorType.shape` is the logical shape.
-- `layout` has its own domain shape.
-- The current interpretation is canonical regroup: linearize first
-  along the logical shape's row-major order, then reinterpret along
-  the layout domain's row-major order.
-
-## 9. Relation-driven shard propagation
-
-When an op's output `ShardLayout` is derived from a forward access
-relation ([hir §3.1](./hir.md#31-relation-driven-type-validity)), the
-output `ShardAttr`s are determined from the input shards and the
-relation's access maps by a single rule, shared across ops.
-
-**Reduction effect.** A reduction dim (a domain dim absent from the
-output access map) carries one of two effects, declared by the
-op/relation:
-
-- `partial` — the per-shard result is a partial that still needs a
-  cross-shard reduction (e.g. a contraction dim split across the mesh);
-- `complete` — the reduction is already complete within each shard
-  (e.g. an explicit reduce over a sharded axis).
-
-**Propagation.** Per input mesh axis, by its attr:
-
-1. `Split(k)` — map cute axis `k` to the input's logical tensor axis,
-   then to a domain dim via the input access map.
-2. If that domain dim appears in the output access map, the output
-   carries `Split` on the **output layout axis** the domain dim maps to.
-3. If that domain dim is a reduction dim, the output mesh axis becomes
-   `Partial(reduction)` when the effect is `partial`, or `Broadcast`
-   when the effect is `complete`. The resulting `Partial` carries no
-   cute axis — it is a value state on that mesh axis.
-4. `Partial(reduction)` input — propagates on the **same mesh axis**:
-   propagate unchanged when the dataflow is homogeneous in `reduction`;
-   resolve to `Broadcast` via an explicit reduction / allreduce over that
-   axis; error on a non-homogeneous use or an unreduced function
-   output / return. There is no cute-axis mapping for a `Partial`.
-5. A `Broadcast` (size-1) input axis contributes no `Split`.
-6. Two inputs binding the same domain dim to incompatible mesh axes is
-   an error.
-
-A `Partial` MUST NOT be silently eliminated by an ordinary op
-(no silent loss); only an explicit `Reshard` / allreduce from `Partial`
-to `Broadcast` completes it.
-
-A fully-`Broadcast` input `ShardLayout` (every attr `Broadcast`) is
-**replicated**: it carries no real sharding, so it contributes no
-`Split` / `Partial` and does not pin a mesh — it MAY combine with an
-input sharded on a different mesh. When no input carries real sharding
-the output carries none.
-
-An input `Split` that accesses a non-projection domain dim, or an
-output-surviving dim reachable only through a non-projection output
-access, MUST **fail closed** rather than guess a mapping. The rule
-reads only the access maps' affine structure (which domain dim each
-axis uses), never the domain bounds, so it is size-agnostic and
-identical for static and dynamic shapes.
-
-**Owner axis.** `Split(axis)` indexes an **output layout (cute) axis**,
-not the logical tensor axis. A reduction-induced `Partial` attaches to no
-cute axis — it is a value state on the mesh axis that was reduced.
+`ShardLayout` here is the data model that the analysis services read and
+produce. Logical-shape-to-layout-domain interpretation and relation-driven
+shard propagation are owned by [analysis §3](./analysis.md#3-shard-propagation):
+logical shape → layout domain in
+[analysis §3.1](./analysis.md#31-logical-shape-to-layout-domain), and
+relation-driven propagation in
+[analysis §3.2](./analysis.md#32-relation-driven-shard-propagation).

--- a/docs/spec/shard.md
+++ b/docs/spec/shard.md
@@ -46,7 +46,7 @@ any `LayoutBase`. Pure-layout invariants and shard-binding
 invariants live with the construct they constrain. Enforcement is
 dispatched by [visitor-registry](./visitor-registry.md); concrete
 checks live in [tir §4](./tir.md#4-verify-rules) (TIR side) and
-[hir §3](./hir.md#3-typing--structural-rules) (HIR side).
+[hir §1.3](./hir.md#13-op) (HIR side).
 
 ---
 
@@ -336,7 +336,7 @@ relevant mesh axis.
   strides have not yet been fixed; the layout's `shape` /
   partition is determined but the per-axis stride form is deferred
   to `Reshard` typeinfer
-  ([hir.md §3](./hir.md#3-typing--structural-rules)). Surface
+  ([hir.md §1.3](./hir.md#13-op)). Surface
   sugar `(N @ m.a, ...)` always emits `S is None`; verbose
   `((shape), (strides))` always emits a concrete `S`. After
   `Reshard` typeinfer has run on a value, `S` reachable from that
@@ -417,7 +417,7 @@ buffer.
 A reshard whose user-provided cute strides are non-default (e.g. an
 SM80 mma fragment) bypasses this materialization step: the layout
 already has a concrete `strides` tuple, so the `Reshard` typeinfer
-rule ([hir.md §3](./hir.md#3-typing--structural-rules)) preserves
+rule ([hir.md §1.3](./hir.md#13-op)) preserves
 it verbatim.
 
 ---

--- a/docs/spec/shard.md
+++ b/docs/spec/shard.md
@@ -45,7 +45,7 @@ flowchart TB
 any `LayoutBase`. Pure-layout invariants and shard-binding
 invariants live with the construct they constrain. Enforcement is
 dispatched by [visitor-registry](./visitor-registry.md); concrete
-checks live in [tir §4](./tir.md#4-verify-rules) (TIR side) and
+checks live in [tir §1.3](./tir.md#13-primfunction) (TIR side) and
 [hir §1.3](./hir.md#13-op) (HIR side).
 
 ---
@@ -67,7 +67,7 @@ A `shape` / `stride` entry is not restricted to a static `int`: it may be a
 symbolic / dynamic dim (a `DimVar` or dim `Expr` — a `ShapeDim`), or `None`
 for a launch-provided (dynamic-CTA) extent (`Layout(shape=(None,),
 strides=(1,))`). Consumers that need a concrete integer — `Mesh.__getitem__`
-and `T.sync` participation (tir.md §2.4) — require static `int` entries and
+and `T.sync` participation (tir.md §1.5) — require static `int` entries and
 **fail closed** on a symbolic / dynamic one rather than guessing.
 
 ---
@@ -182,7 +182,7 @@ class Mesh:
     # compile-time constant; Python value, does not enter the IR graph.
     # ``layout`` is a plain ``Layout`` for an un-sliced mesh. ``Mesh[key]``
     # (``__getitem__``) slices a constant sub-mesh used by ``T.sync``
-    # (tir.md §2.4): it replaces ``layout`` with a ``ComposedLayout`` recording
+    # (tir.md §1.5): it replaces ``layout`` with a ``ComposedLayout`` recording
     # the participating sub-box — the selected per-axis extents over the parent
     # strides in ``outer`` and the slice origin ``Σ start_i · stride_i`` in
     # ``offset`` (identity ``inner``). The slice never becomes an IR/SSA value;
@@ -200,7 +200,7 @@ Field meanings:
 - `topology` — device-domain description (`name` + `num_devices`)
 - `layout` — the mesh's own shape / strides (a `Layout`); a constant slice
   (`m[...]`) replaces it with a `ComposedLayout` recording the sub-box
-  (tir.md §2.4)
+  (tir.md §1.5)
 - `names` — optional human-readable names (`cta.x`, `cta.y`, …)
 - `MeshAxis` — single-axis object retrieved via `mesh.x` / `mesh.y` /
   `mesh.axes[i]`, used by parser static evaluation

--- a/docs/spec/target.md
+++ b/docs/spec/target.md
@@ -22,13 +22,11 @@ and codegen. Emitting source and linking the artifact are owned by
 
 ## 2. `Target`
 
-```text
-Target(name: str)
+```python
+class Target:
+    name: str    # the stable back-end identifier
 ```
 
-- kind: Python class
-- fields:
-  - name: the stable back-end identifier
 - constraints:
   - MUST be the stable back-end identifier used for target resolution and for the
     function-target grouping in codegen.
@@ -40,15 +38,13 @@ codegen products ([codegen §4](./codegen.md#4-codegen-products)).
 
 CUDA is the current reference target.
 
-```text
-CudaTarget(name: str = "cuda", arch: str = "sm_90", topology_levels: tuple[str, ...] = ("cta", "thread"))
+```python
+class CudaTarget:
+    name: str = "cuda"                                     # the back-end identifier, fixed to "cuda"
+    arch: str = "sm_90"                                    # the SM architecture the device source is compiled for
+    topology_levels: tuple[str, ...] = ("cta", "thread")  # the program topology level set the target admits
 ```
 
-- kind: Python class
-- fields:
-  - name: the back-end identifier, fixed to `"cuda"`
-  - arch: the SM architecture the device source is compiled for
-  - topology_levels: the program topology level set the target admits
 - constraints:
   - MUST be `"cuda"`.
   - MUST name the SM architecture the device source is compiled for.
@@ -61,13 +57,11 @@ CudaTarget(name: str = "cuda", arch: str = "sm_90", topology_levels: tuple[str, 
 
 ## 4. `CpuTarget`
 
-```text
-CpuTarget(name: str = "cpu")
+```python
+class CpuTarget:
+    name: str = "cpu"    # the back-end identifier, fixed to "cpu"
 ```
 
-- kind: Python class
-- fields:
-  - name: the back-end identifier, fixed to `"cpu"`
 - constraints:
   - MUST be `"cpu"`.
 

--- a/docs/spec/target.md
+++ b/docs/spec/target.md
@@ -22,15 +22,16 @@ and codegen. Emitting source and linking the artifact are owned by
 
 ## 2. `Target`
 
-```python
-@dataclass(frozen=True)
-class Target:
-    name: str
+```text
+Target(name: str)
 ```
 
-#### `name`
-- MUST be the stable back-end identifier used for target resolution and for the
-  function-target grouping in codegen.
+- kind: Python class
+- fields:
+  - name: the stable back-end identifier
+- constraints:
+  - MUST be the stable back-end identifier used for target resolution and for the
+    function-target grouping in codegen.
 
 A `Target` MUST NOT carry the linkable / linked artifact dataclasses; those are
 codegen products ([codegen §4](./codegen.md#4-codegen-products)).
@@ -39,39 +40,119 @@ codegen products ([codegen §4](./codegen.md#4-codegen-products)).
 
 CUDA is the current reference target.
 
-```python
-@dataclass(frozen=True)
-class CudaTarget(Target):
-    name: str = "cuda"
-    arch: str = "sm_90"
-    topology_levels: tuple[str, ...] = ("cta", "thread")
+```text
+CudaTarget(name: str = "cuda", arch: str = "sm_90", topology_levels: tuple[str, ...] = ("cta", "thread"))
 ```
 
-#### `name`
-- MUST be `"cuda"`.
-
-#### `arch`
-- MUST name the SM architecture the device source is compiled for.
-
-#### `topology_levels`
-- MUST be the program topology level set the target admits: `{cta, thread}`.
-- `warp` / `lane` / `warpgroup` MUST be expressed as axes of a thread mesh
-  layout ([shard](./shard.md)), not as program topology levels.
-- A function whose declared program topology levels are not a subset of this set
-  MUST raise at lowering. The level set is consumed by the device program
-  accessors ([codegen §6](./codegen.md#6-program-shape-and-dynamic-cta)).
+- kind: Python class
+- fields:
+  - name: the back-end identifier, fixed to `"cuda"`
+  - arch: the SM architecture the device source is compiled for
+  - topology_levels: the program topology level set the target admits
+- constraints:
+  - MUST be `"cuda"`.
+  - MUST name the SM architecture the device source is compiled for.
+  - MUST be the program topology level set the target admits: `{cta, thread}`.
+  - `warp` / `lane` / `warpgroup` MUST be expressed as axes of a thread mesh
+    layout ([shard](./shard.md)), not as program topology levels.
+  - A function whose declared program topology levels are not a subset of this set
+    MUST raise at lowering. The level set is consumed by the device program
+    accessors ([§7](#7-program-shape-and-dynamic-cta)).
 
 ## 4. `CpuTarget`
 
-```python
-@dataclass(frozen=True)
-class CpuTarget(Target):
-    name: str = "cpu"
+```text
+CpuTarget(name: str = "cpu")
 ```
 
-#### `name`
-- MUST be `"cpu"`.
+- kind: Python class
+- fields:
+  - name: the back-end identifier, fixed to `"cpu"`
+- constraints:
+  - MUST be `"cpu"`.
 
 The CPU target hosts the entry that marshals arguments and invokes the device
 entry through its C-ABI launch shim
-([codegen §3](./codegen.md#3-target-driven-emission)).
+([§5](#5-target-driven-emission)).
+
+## 5. Target-driven emission
+
+Emission is split by function `target`; one `LinkableModule` is produced per
+target group.
+
+- A `cpu`-target entry function emits the **host translation unit**: a host
+  wrapper that marshals `tvm::ffi::Tensor` arguments and invokes the device
+  entry through its C-ABI launch shim. For a dispatch prototype the wrapper
+  also performs the `DispatchCall` selection (§6).
+- A `cuda`-target function emits the **device translation unit**: a
+  `__global__` kernel plus its C-ABI launch shim. An operand's layout selects
+  how it is viewed inside the kernel — `cute::` for a plain `Layout`,
+  `tilefoundry::` shard tensor for a `ShardLayout` (§8) — it does not change the
+  function into a `__device__`-parameter function.
+
+## 6. Dispatch and shape-scalar ABI
+
+
+A `tir.PrimFunction` produced by HIR→TIR lowering for a dispatch prototype
+([hir §1.1](./hir.md#11-function)) emits as a host dispatch entry
+plus its variant kernels:
+
+- **Dispatch entry** (PrimFunction whose body is a single `tir.DispatchCall`):
+  the host module emits a host-only entry — no kernel. It reads the dispatch
+  subject from the host-visible tensor shape, evaluates the case predicates in
+  source order, and invokes the matching variant's C-ABI launch shim. The
+  `fallback` MUST fail the host call with a host-side error.
+- **Variant**: a `cuda`-target function (§5) — a `__global__` kernel plus its
+  C-ABI launch shim in the CUDA module, carrying the hidden shape-scalar
+  parameters below. A variant has no host wrapper of its own; the dispatch entry
+  calls its shim.
+
+**Host-visible entry symbol.** The host-visible entry wrapper (the CPU entry) is
+emitted under an internal symbol `__tilefoundry_<sanitized>_host`, where
+`<sanitized>` is the user-facing name with `$` replaced by `__` (`$` is a GCC
+extension, not portable C++). The user-facing name is republished via the
+runtime ABI macro:
+
+```cpp
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(<name>, __tilefoundry_<sanitized>_host);
+```
+
+**Shape-scalar parameter ABI.** Each `tir.ShapeOf(param, axis)`
+([tir §2.2](./tir.md#22-shapeof)) reachable from a PrimFunction body adds a hidden
+kernel-scalar parameter named `f"{param.name}_shape_<axis>"` — a rank-0 `i32`
+shape-scalar `TensorType` with `storage=None`. The host wrapper extracts the
+value from the
+corresponding `tvm::ffi::Tensor.shape()[axis]` and forwards it. These hidden
+parameters are filtered out of the exported `CallableType.params` so they remain
+invisible at the user FFI surface. A user-declared rank-0 `i32` parameter is
+*not* filtered — the filter is keyed on the canonical `<name>_shape_<axis>` form
+synthesised by lowering.
+
+## 7. Program shape and dynamic CTA
+
+The emitted device source reads its program geometry through two accessors:
+
+- `program_shape<T>()` MUST be the shape composed of a topology level's program
+  dims.
+- `program_dim<T>()` MUST be the size of one topology level `T`.
+
+For a static CTA count, `program_dim<cta>()` is a compile-time constant and a
+constexpr `program_shape<cta>` is emitted. For a launch-provided (dynamic) CTA
+count, the emitter MUST NOT emit a constexpr `program_shape<cta>`; device code
+MUST read the count through `program_dim<cta>()`, which resolves to the
+launch-provided grid extent. The topology level set a target admits is owned by
+[§3](#3-cudatarget).
+
+## 8. `ShardLayout` / `ShardTensor` mapping
+
+A `ShardLayout` ([shard §7](./shard.md)) on a TIR tensor type is materialised
+through `tilefoundry::make_shard_tensor(buffer, global_layout, shard_layout)`
+([runtime](./runtime.md)). A handler that consumes a sharded operand emits the
+shard-tensor view; effect Ops then route through `tilefoundry::` runtime helpers
+(for example `tilefoundry::copy`) instead of plain `cute::` primitives. A plain
+`Layout` operand goes through `cute::` directly. The selection is handler-local,
+based on `arg.type.layout`.
+
+Codegen consumes the `ShardLayout` already present on the TIR tensor type; the
+cute MMA fragment → `ShardLayout` recipe that produces it is owned by the
+lowering pass ([passes.md §7.1](./passes.md#71-hirtotirpass)).

--- a/docs/spec/tilegraph.md
+++ b/docs/spec/tilegraph.md
@@ -53,12 +53,10 @@ shared `SSAValue` whose `type` MUST be a `TensorType`.
 
 ### 3.2 `Domain`
 
-```text
-Domain = isl.set
+```python
+Domain = isl.set    # legal iteration domain of the current TileGraph, carried by isl.set
 ```
 
-- kind: Python class
-- fields: the legal iteration domain of the current `TileGraph`, carried by `isl.set`
 - constraints: none — carried directly by `isl.set`
 
 `Domain` is carried directly by `isl.set`. It represents the legal iteration
@@ -66,12 +64,10 @@ domain of the current `TileGraph`.
 
 ### 3.3 `DomainRelation`
 
-```text
-DomainRelation = isl.multi_aff
+```python
+DomainRelation = isl.multi_aff    # map from parent TileGraph.domain onto current TileGraph.domain, carried by isl.multi_aff
 ```
 
-- kind: Python class
-- fields: the map from the parent `TileGraph.domain` onto the current `TileGraph.domain`, carried by `isl.multi_aff`
 - constraints: none — `isl.multi_aff` is sufficient at this layer
 
 `DomainRelation` is carried directly by `isl.multi_aff`. It maps the parent
@@ -80,12 +76,10 @@ sufficient at this layer.
 
 ### 3.4 `AccessRelation`
 
-```text
-AccessRelation = isl.multi_aff
+```python
+AccessRelation = isl.multi_aff    # affine map from current TileGraph.domain to a boundary value's index space, carried by isl.multi_aff
 ```
 
-- kind: Python class
-- fields: the affine map from the current `TileGraph.domain` to a boundary value's index space, carried by `isl.multi_aff`
 - constraints:
   - `AccessRelation` itself does not carry a tensor or value reference, a read /
     write mode, or any further semantics; those bindings live on the surrounding
@@ -96,16 +90,12 @@ from the current `TileGraph.domain` to a boundary value's index space.
 
 ### 3.5 `ITileNode`
 
-```text
-ITileNode
-  inputs:  Value[]
-  outputs: Value[]
+```python
+class ITileNode:
+    inputs: list[Value]     # boundary input Values
+    outputs: list[Value]    # boundary output Values
 ```
 
-- kind: Python class
-- fields:
-  - inputs: boundary input `Value`s
-  - outputs: boundary output `Value`s
 - constraints:
   - `ITileNode` unifies graph-node boundaries only; it does not unify `domain`.
 
@@ -114,16 +104,12 @@ a `TileGraph` body.
 
 ### 3.6 `DiGraph<TNode>`
 
-```text
-DiGraph<TNode>
-  nodes
-  edges
+```python
+class DiGraph(Generic[TNode]):
+    nodes    # the graph nodes
+    edges    # the graph edges
 ```
 
-- kind: Python class
-- fields:
-  - nodes: the graph nodes
-  - edges: the graph edges
 - constraints: none — the in-memory API is not pinned by this spec (reading-style reference: networkx)
 
 `TileGraph.body` is carried by a directed-graph object. Reading-style
@@ -131,25 +117,17 @@ reference: networkx. The in-memory API is not pinned by this spec.
 
 ### 3.7 `TileGraph`
 
-```text
-TileGraph : ITileNode
-  domain: Domain
-  domain_relation: DomainRelation        # optional; child graphs only
-  inputs:  Value[]
-  input_access_relations:  AccessRelation[]
-  outputs: Value[]
-  output_access_relations: AccessRelation[]
-  body: DiGraph<ITileNode>
+```python
+class TileGraph(ITileNode):
+    domain: Domain                                   # iteration domain of the current graph
+    domain_relation: DomainRelation                  # optional; child graphs only
+    inputs: list[Value]                              # boundary input Values
+    input_access_relations: list[AccessRelation]     # aligns positionally with inputs
+    outputs: list[Value]                             # boundary output Values
+    output_access_relations: list[AccessRelation]    # aligns positionally with outputs
+    body: DiGraph[ITileNode]                         # the directed graph at the current level
 ```
 
-- kind: Python class
-- fields:
-  - `domain` is the iteration domain of the current graph.
-  - `domain_relation` belongs to `TileGraph` only; ordinary `ITileNode`
-    members do not carry one.
-  - `input_access_relations` aligns positionally with `inputs`.
-  - `output_access_relations` aligns positionally with `outputs`.
-  - `body` is the directed graph at the current level.
 - constraints:
   - the composite node; a per-level SSA DAG. `domain_relation` is present on
     child graphs only.
@@ -158,18 +136,13 @@ TileGraph : ITileNode
 
 ### 3.8 `TileUnit`
 
-```text
-TileUnit : ITileNode
-  op_kind: str
-  inputs:  Value[]
-  outputs: Value[]
+```python
+class TileUnit(ITileNode):
+    op_kind: str            # the unit's op kind
+    inputs: list[Value]     # boundary input Values
+    outputs: list[Value]    # boundary output Values
 ```
 
-- kind: Python class
-- fields:
-  - op_kind: the unit's op kind
-  - inputs: boundary input `Value`s
-  - outputs: boundary output `Value`s
 - constraints:
   - a `TileUnit` does not own its own `domain`,
   - it does not own its own `domain_relation`,

--- a/docs/spec/tilegraph.md
+++ b/docs/spec/tilegraph.md
@@ -53,71 +53,85 @@ shared `SSAValue` whose `type` MUST be a `TensorType`.
 
 ### 3.2 `Domain`
 
-`Domain` is carried directly by `isl.set`:
-
-```
+```text
 Domain = isl.set
 ```
 
-It represents the legal iteration domain of the current `TileGraph`.
+- kind: Python class
+- fields: the legal iteration domain of the current `TileGraph`, carried by `isl.set`
+- constraints: none — carried directly by `isl.set`
+
+`Domain` is carried directly by `isl.set`. It represents the legal iteration
+domain of the current `TileGraph`.
 
 ### 3.3 `DomainRelation`
 
-`DomainRelation` is carried directly by `isl.multi_aff`:
-
-```
+```text
 DomainRelation = isl.multi_aff
 ```
 
-It maps the parent `TileGraph.domain` onto the current
-`TileGraph.domain`. `isl.multi_aff` is sufficient at this layer.
+- kind: Python class
+- fields: the map from the parent `TileGraph.domain` onto the current `TileGraph.domain`, carried by `isl.multi_aff`
+- constraints: none — `isl.multi_aff` is sufficient at this layer
+
+`DomainRelation` is carried directly by `isl.multi_aff`. It maps the parent
+`TileGraph.domain` onto the current `TileGraph.domain`. `isl.multi_aff` is
+sufficient at this layer.
 
 ### 3.4 `AccessRelation`
 
-`AccessRelation` is also carried by `isl.multi_aff`:
-
-```
+```text
 AccessRelation = isl.multi_aff
 ```
 
-It expresses the affine map from the current `TileGraph.domain` to a
-boundary value's index space. `AccessRelation` itself does not carry
-a tensor or value reference, a read / write mode, or any further
-semantics; those bindings live on the surrounding `TileGraph`'s
-boundary fields.
+- kind: Python class
+- fields: the affine map from the current `TileGraph.domain` to a boundary value's index space, carried by `isl.multi_aff`
+- constraints:
+  - `AccessRelation` itself does not carry a tensor or value reference, a read /
+    write mode, or any further semantics; those bindings live on the surrounding
+    `TileGraph`'s boundary fields.
+
+`AccessRelation` is also carried by `isl.multi_aff`. It expresses the affine map
+from the current `TileGraph.domain` to a boundary value's index space.
 
 ### 3.5 `ITileNode`
 
-`ITileNode` is the abstract base of every node that participates in
-a `TileGraph` body:
-
-```
+```text
 ITileNode
   inputs:  Value[]
   outputs: Value[]
 ```
 
-`ITileNode` unifies graph-node boundaries only; it does not unify
-`domain`.
+- kind: Python class
+- fields:
+  - inputs: boundary input `Value`s
+  - outputs: boundary output `Value`s
+- constraints:
+  - `ITileNode` unifies graph-node boundaries only; it does not unify `domain`.
+
+`ITileNode` is the abstract base of every node that participates in
+a `TileGraph` body.
 
 ### 3.6 `DiGraph<TNode>`
 
-`TileGraph.body` is carried by a directed-graph object:
-
-```
+```text
 DiGraph<TNode>
   nodes
   edges
 ```
 
-Reading-style reference: networkx. The in-memory API is not pinned
-by this spec.
+- kind: Python class
+- fields:
+  - nodes: the graph nodes
+  - edges: the graph edges
+- constraints: none — the in-memory API is not pinned by this spec (reading-style reference: networkx)
+
+`TileGraph.body` is carried by a directed-graph object. Reading-style
+reference: networkx. The in-memory API is not pinned by this spec.
 
 ### 3.7 `TileGraph`
 
-`TileGraph` is the composite node:
-
-```
+```text
 TileGraph : ITileNode
   domain: Domain
   domain_relation: DomainRelation        # optional; child graphs only
@@ -128,32 +142,41 @@ TileGraph : ITileNode
   body: DiGraph<ITileNode>
 ```
 
-Where:
+- kind: Python class
+- fields:
+  - `domain` is the iteration domain of the current graph.
+  - `domain_relation` belongs to `TileGraph` only; ordinary `ITileNode`
+    members do not carry one.
+  - `input_access_relations` aligns positionally with `inputs`.
+  - `output_access_relations` aligns positionally with `outputs`.
+  - `body` is the directed graph at the current level.
+- constraints:
+  - the composite node; a per-level SSA DAG. `domain_relation` is present on
+    child graphs only.
 
-- `domain` is the iteration domain of the current graph.
-- `domain_relation` belongs to `TileGraph` only; ordinary `ITileNode`
-  members do not carry one.
-- `input_access_relations` aligns positionally with `inputs`.
-- `output_access_relations` aligns positionally with `outputs`.
-- `body` is the directed graph at the current level.
+`TileGraph` is the composite node.
 
 ### 3.8 `TileUnit`
 
-`TileUnit` is the minimum-unit node:
-
-```
+```text
 TileUnit : ITileNode
   op_kind: str
   inputs:  Value[]
   outputs: Value[]
 ```
 
-Where:
+- kind: Python class
+- fields:
+  - op_kind: the unit's op kind
+  - inputs: boundary input `Value`s
+  - outputs: boundary output `Value`s
+- constraints:
+  - a `TileUnit` does not own its own `domain`,
+  - it does not own its own `domain_relation`,
+  - as the minimum unit it is interpreted under the `domain` of the
+    enclosing `TileGraph`.
 
-- a `TileUnit` does not own its own `domain`,
-- it does not own its own `domain_relation`,
-- as the minimum unit it is interpreted under the `domain` of the
-  enclosing `TileGraph`.
+`TileUnit` is the minimum-unit node.
 
 ## 4. Semantic skeleton
 

--- a/docs/spec/tir.md
+++ b/docs/spec/tir.md
@@ -24,10 +24,12 @@ the work, structural Stmts carry control flow.
 ### 1.1 `Stmt`
 
 ```python
-@dataclass(frozen=True)
 class Stmt:
-    loc: str | None = None
+    loc: str | None = None    # optional debug location; not load-bearing for semantics
 ```
+
+- constraints:
+  - the abstract base of every TIR Stmt subclass; HIR has no `Stmt`.
 
 `Stmt` is the abstract base of every TIR Stmt subclass. HIR has no
 `Stmt`. `loc` is a debug surface; it is not load-bearing for
@@ -50,45 +52,41 @@ flowchart TB
 ### 1.2 Structural Stmts (`tir.stmts`)
 
 ```python
-@dataclass(frozen=True)
 class Sequential(Stmt):
-    body: tuple[Stmt, ...]            # __iter__ / __len__ / __getitem__ provided
+    body: tuple[Stmt, ...]            # a Stmt sequence (__iter__ / __len__ / __getitem__ provided)
 
-@dataclass(frozen=True)
 class LetStmt(Stmt):
-    var: Var
+    var: Var                          # binds var to value; let chains nest body
     value: Expr
-    body: Sequential                  # let chains nest body
+    body: Sequential
 
-@dataclass(frozen=True)
 class For(Stmt):
-    induction_var: Var
+    induction_var: Var                # counted loop
     start: Expr
     stop: Expr
     step: Expr
     body: Sequential
 
-@dataclass(frozen=True)
-class While(Stmt):
+class While(Stmt):                    # control flow
     cond: Expr
     body: Sequential
 
-@dataclass(frozen=True)
-class If(Stmt):
+class If(Stmt):                       # control flow
     cond: Expr
     then_body: Sequential
     else_body: Sequential
 
-@dataclass(frozen=True)
 class MeshScope(Stmt):
-    mesh: Mesh
+    mesh: Mesh                        # scopes a mesh binding over body
     binding: Var
     body: Sequential
 
-@dataclass(frozen=True)
 class Return(Stmt):
-    pass                              # @prim_func has no value return
+    ...                               # @prim_func has no value return
 ```
+
+- constraints:
+  - the structural (control-flow / binding) Stmt family; bodies are `Sequential`.
 
 - `MeshScope.mesh` carries the `Mesh` object; the `binding` `Var`
   scopes the mesh inside `body`.
@@ -96,13 +94,16 @@ class Return(Stmt):
 ### 1.3 `PrimFunction`
 
 ```python
-@dataclass(frozen=True)
 class PrimFunction(Stmt):
-    name: str
-    params: tuple[Var, ...]
-    body: Sequential
+    name: str                         # the function name
+    params: tuple[Var, ...]           # parameter Vars (the trailing output_count are outputs)
+    body: Sequential                  # the function body
     output_count: int = 1             # number of trailing output params
 ```
+
+- constraints:
+  - itself a `Stmt`, not a separate top-level node; returns no value.
+    `verify_prim_function` enforces the rules below.
 
 `PrimFunction` is itself a `Stmt`, not a separate top-level node;
 it sits inside the TIR Stmt tree along with everything else.
@@ -133,11 +134,14 @@ it sits inside the TIR Stmt tree along with everything else.
 ### 1.4 `Evaluate`
 
 ```python
-@dataclass(frozen=True)
 class Evaluate(Stmt):
-    callable: Op | SymbolRef
-    args: tuple[Expr, ...]
+    callable: Op | SymbolRef    # an effect-form Op or a SymbolRef callee
+    args: tuple[Expr, ...]      # the callable's operands in ParamDef / parameter order
 ```
+
+- constraints:
+  - TIR's single Stmt-position wrapper for a no-result invocation; verify and
+    lowering dispatch on `type(callable)`.
 
 `Evaluate` is TIR's single Stmt-position wrapper for a callable
 invocation that has no result value. The `callable` is one of:
@@ -179,10 +183,13 @@ authored `T.sync(m)`, and appears in Stmt position wrapped by `Evaluate`
 `T.sync(m)` / `T.sync(m[slice])` — there is no `m.sync()` receiver form.
 
 ```python
-@register_op(dialect="T", category="sync")
 class Sync(Op):
-    mesh = ParamDef(kind="attribute", annotation=Mesh)
+    mesh = attribute(Mesh)    # effect-form op `tir.sync.Sync`, authored `T.sync(m)`; the (possibly sliced) mesh the barrier synchronizes
 ```
+
+- constraints:
+  - a mesh-scoped barrier; in Stmt position it is wrapped by `Evaluate`. The
+    participant set, barrier mapping, and named-barrier id rules are below.
 
 #### `mesh` — the participating threads
 
@@ -272,14 +279,17 @@ It is the lowered form of an HIR dispatch prototype
 to a dispatch-prototype callee.
 
 ```python
-@dataclass(frozen=True)
 class DispatchCall(Stmt):
     callee_name: str                                  # unmangled dispatcher name (debug / printer)
-    subjects: tuple[Expr, ...]                        # one per dispatch axis
-    case_patterns: tuple[tuple[Pattern, ...], ...]    # parallel to case_calls; inner length == len(subjects)
-    case_calls: tuple[Evaluate, ...]                  # parallel to case_patterns
-    fallback: Sequential                              # taken when no case matches
+    subjects: tuple[Expr, ...]                        # one Expr per dispatch axis
+    case_patterns: tuple[tuple[Pattern, ...], ...]    # parallel case table: patterns
+    case_calls: tuple[Evaluate, ...]                  # parallel case table: Evaluate(SymbolRef, args)
+    fallback: Sequential                              # the Sequential taken when no case matches
 ```
+
+- constraints:
+  - a control Stmt (not an `Evaluate` callable) implementing first-match dispatch;
+    source order is part of the IR contract. Verifier rules below.
 
 `DispatchCall` is a control Stmt, not an `Evaluate` callable
 ([§1.4](#14-evaluate)); each `case_calls[i]` is an
@@ -311,10 +321,12 @@ matched key. A single dispatch axis makes this ordering trivial.
 ### 1.7 `Abort`
 
 ```python
-@dataclass(frozen=True)
 class Abort(Stmt):
-    message: str = ""
+    message: str = ""    # a debug surface; carries no semantics
 ```
+
+- constraints:
+  - a terminating Stmt on believed-unreachable paths (notably `DispatchCall.fallback`).
 
 - `Abort` is terminating. It exists in code paths the compiler
   believes are unreachable (notably `DispatchCall.fallback`).
@@ -327,11 +339,13 @@ class Abort(Stmt):
 
 ```python
 @intrinsic
-def some_intrinsic(a: Expr, b: Expr) -> None:
-    """verify body — runs as register_verify_stmt."""
-    if a.type.shape != b.type.shape:
-        raise VerifyError(...)
+def <name>(<param>: Expr, ...) -> None: ...    # decorated function's signature defines the synthesized Stmt subclass; its body becomes the verifier
 ```
+
+- constraints:
+  - synthesises a Stmt subclass, registers the body as its verifier, and wires
+    parser dispatch under the snake-case name; parameters are annotated `Expr` and
+    the return annotation is `None`.
 
 `tilefoundry.ir.tir.intrinsic.intrinsic` synthesises a Stmt subclass
 from the decorated function's signature, registers the function
@@ -344,12 +358,15 @@ under the function's snake-case name. Parameters MUST be annotated
 ### 2.1 `SymbolRef`
 
 ```python
-@dataclass(frozen=True)
 class SymbolRef(Expr):
-    name: str
-    nested: tuple[str, ...] = ()
-    # type: CallableType — the resolved callee's IR-level CallableType
+    name: str                       # canonical name of the callee PrimFunction (may be a mangled specialization name)
+    nested: tuple[str, ...] = ()    # empty — the Module holds only top-level functions
+    # type: CallableType — the resolved callee's CallableType, set at construction
 ```
+
+- constraints:
+  - a leaf `Expr` naming a callee as an `Evaluate` / `Launch` target; resolution
+    is module-level and unique. Per-field rules below.
 
 `SymbolRef` is a leaf `Expr` naming a callee `PrimFunction` as a call
 target: the `callable` of an `Evaluate(SymbolRef, args)`
@@ -391,11 +408,14 @@ carries its `type` directly.
 ### 2.2 `ShapeOf`
 
 ```python
-@dataclass(frozen=True)
 class ShapeOf(Expr):
-    param: Var
-    axis: int
+    param: Var    # a parameter Var of the enclosing PrimFunction
+    axis: int     # a valid axis index of param.type
 ```
+
+- constraints:
+  - `type` is a rank-0 `i32` `TensorType` (scalar); it is the runtime-extent ABI
+    for a dynamic tensor dimension. Per-field and ABI rules below.
 
 - `ShapeOf.type` is rank-0 `TensorType` of dtype `i32` (a scalar).
 - `param` MUST resolve to a parameter `Var` of the enclosing
@@ -439,49 +459,79 @@ below; code carries only a one-line purpose docstring
 #### Memory Ops (`tir.memory.*`)
 
 ##### AllocTensor
-Allocate a tensor (value form; result type on the `tensor_type` attribute).
+```python
+AllocTensor(tensor_type) -> Tensor          # value form; tensor_type: attribute carrying the allocated tensor's result type
+```
+- constraints:
+  - allocate a tensor; a value Op anchored by `LetStmt.value`.
 
 ##### MemorySpan
-Re-interpret a memory region as a typed tensor (value form).
+```python
+MemorySpan(region, tensor_type) -> Tensor    # value form; region: the memory region being re-interpreted; tensor_type: the typed-tensor view placed over it
+```
+- constraints:
+  - re-interpret a memory region as a typed tensor; a value Op.
 
 ##### PtrOf
-Take the device address of a tensor for downstream view ops (value form).
+```python
+PtrOf(tensor) -> ptr                          # value form; tensor: the tensor whose device address is taken
+```
+- constraints:
+  - take the device address of a tensor for downstream view ops; a value Op.
 
 ##### TensorView
-Derive a sub-view of a tensor (value form).
+```python
+TensorView(tensor, ...) -> Tensor             # value form; tensor: the base tensor; view spec: the sub-view descriptor (offsets / layout)
+```
+- constraints:
+  - derive a sub-view of a tensor; a value Op.
 
 ##### Copy
-Byte-equivalent copy between two tensors (effect form).
+```python
+Copy(src, dst)                                # effect form; src / dst: source and destination tensors
+```
+- constraints:
+  - byte-equivalent copy between two tensors.
 
 ##### Fill
-Broadcast a scalar value into a tensor (effect form).
+```python
+Fill(dst, value)                              # effect form; dst: destination tensor; value: scalar broadcast into dst
+```
+- constraints:
+  - broadcast a scalar value into a tensor.
 
 #### NN Ops (`tir.nn.*`)
 
 ##### Mma
-Matrix-multiply-accumulate `acc += lhs @ rhs` (effect form); per-target PTX
-lowering lives in [target](./target.md), the atom calling convention in
-[§2.3](#mma-atom-and-the-hand-written-calling-convention).
+```python
+Mma(acc, lhs, rhs, atom?)                     # effect form: acc += lhs @ rhs; acc / lhs / rhs: accumulator and operand fragments; atom: optional compile-time MmaAtom attribute, absent ⇒ bare-Mma per-target path
+```
+- constraints:
+  - matrix-multiply-accumulate `acc += lhs @ rhs`; per-target PTX lowering lives in
+    [target](./target.md), the atom calling convention in
+    [§2.3](#mma-atom-and-the-hand-written-calling-convention).
 
 ##### ReLU
-Pointwise `max(x, 0)` (effect form).
+```python
+ReLU(x, dst)                                  # effect form; x / dst: input and destination tensors
+```
+- constraints:
+  - pointwise `max(x, 0)`.
 
 ##### RMSNorm
-Fused RMS normalisation (effect form).
+```python
+RMSNorm(x, dst, ...)                          # effect form; x / dst: input and normalised-output tensors
+```
+- constraints:
+  - fused RMS normalisation.
 
 #### Tensor Ops (`tir.tensor.*`)
 
 ##### Reduce
 
-```text
-Reduce(src, dst, workspace?, axes, kind)
+```python
+Reduce(src, dst, workspace?, axes, kind)    # src / dst: effect-form operands; workspace: optional staging buffer sized by lowering; axes: reduced-axis tuple; kind: ReduceKind tag
 ```
-- kind: TIR op
-- fields:
-  - src / dst: effect-form operands
-  - workspace: optional staging buffer sized by lowering
-  - axes: reduced-axis tuple
-  - kind: `ReduceKind` tag
 - constraints:
   - `Reduce` carries no dispatch parameter; runtime selects the strategy.
   - `workspace` is present only when lowering sizes cross-warp staging.
@@ -497,26 +547,16 @@ per-op classes; they appear as `Evaluate(op, args)`. `BinaryKind` /
 TIR; lowering preserves the kind value without re-mapping.
 
 ##### Binary
-```text
-Binary(lhs, rhs, dst, kind)
+```python
+Binary(lhs, rhs, dst, kind)    # lhs / rhs: input operands; dst: destination operand; kind: BinaryKind tag
 ```
-- kind: TIR op
-- fields:
-  - lhs / rhs: input operands
-  - dst: destination operand
-  - kind: `BinaryKind` tag
 - constraints:
   - Lowers to the binary runtime family without per-kind TIR classes.
 
 ##### Unary
-```text
-Unary(src, dst, kind)
+```python
+Unary(src, dst, kind)    # src: input operand; dst: destination operand; kind: UnaryKind tag, including rsqrt
 ```
-- kind: TIR op
-- fields:
-  - src: input operand
-  - dst: destination operand
-  - kind: `UnaryKind` tag, including `rsqrt`
 - constraints:
   - Lowers to the unary runtime family without per-kind TIR classes.
 
@@ -525,6 +565,15 @@ Unary(src, dst, kind)
 Effect Op for a host-side launch of a device kernel (CPU entry only, no value);
 the callee `SymbolRef` and grid/block extents flow through the `Evaluate` args,
 the non-grid/block launch config through the Op attributes.
+
+```python
+Launch(cluster?, dynamic_smem?, stream?, attrs?)    # effect form; cluster / dynamic_smem / stream / attrs: attribute-carried launch configuration
+# Evaluate(Launch(...), (SymbolRef(callee), grid_x, grid_y, grid_z, block_x, block_y, block_z, *forwarded_args))
+```
+
+- constraints:
+  - appears only in a CPU (host) entry body; grid/block extents are launch config,
+    not kernel parameters. Per-arg / per-attribute rules below.
 
 `Launch` appears only in a CPU (host) entry body, as `Evaluate(Launch(...),
 args)` with `args = (SymbolRef(callee), grid_x, grid_y, grid_z, block_x,
@@ -565,15 +614,18 @@ layout `ir/{dialect}/{target}/{category}`.
 A named, fully-specified MMA instruction (the CuTe `MMA_Op` analog).
 
 ```python
-@dataclass(frozen=True)
 class MmaOpSpec:
-    name: str
-    shape_mnk: tuple[int, int, int]
-    dtype_a: DType
-    dtype_b: DType
-    dtype_c: DType
-    operand_layout: str
+    name: str                         # uniquely identifies the instruction; the other fields mirror it
+    shape_mnk: tuple[int, int, int]   # the instruction's static (M, N, K)
+    dtype_a: DType                    # lhs operand element type
+    dtype_b: DType                    # rhs operand element type
+    dtype_c: DType                    # accumulator element type
+    operand_layout: str               # source operand order string (e.g. "TN")
 ```
+
+- constraints:
+  - a fully-specified MMA instruction descriptor carrying no fragment-layout
+    knowledge. Per-field rules below.
 
 ###### `name`
 
@@ -613,14 +665,17 @@ The realized atom for an `op` (the CuTe `MMA_Atom` analog), built by
 ([parser §2.6](./parser.md#26-platform-sub-namespaces)).
 
 ```python
-@dataclass(frozen=True)
 class MmaAtom:
-    op: MmaOpSpec
-    A: ShardLayout
-    B: ShardLayout
-    C: ShardLayout
-    required_scope: Mesh
+    op: MmaOpSpec         # the MmaOpSpec this atom realizes
+    A: ShardLayout        # lhs fragment ShardLayout contract
+    B: ShardLayout        # rhs fragment ShardLayout contract
+    C: ShardLayout        # accumulator fragment ShardLayout contract
+    required_scope: Mesh  # the thread-participation contract, carried as its own Mesh
 ```
+
+- constraints:
+  - the realized atom for an `op`; fragment layouts are returned as-is and not
+    rebound onto the caller's mesh. Per-field rules below.
 
 ###### `op`
 
@@ -704,12 +759,9 @@ producer issues copies, groups them, and a consumer waits on the group queue.
 
 ##### CopyAsync
 
-```text
-CopyAsync(src, dst)
+```python
+CopyAsync(src, dst)    # src / dst: async staging operands
 ```
-- kind: TIR op
-- fields:
-  - src / dst: async staging operands
 - constraints:
   - Lowers to `tilefoundry::ops::copy_async(src, dst)`.
   - A later read of `dst` is ordered by `CpAsyncCommit` followed by
@@ -717,23 +769,17 @@ CopyAsync(src, dst)
 
 ##### CpAsyncCommit
 
-```text
-CpAsyncCommit()
+```python
+CpAsyncCommit()    # effect: closes the current in-flight async-copy group
 ```
-- kind: TIR op
-- fields:
-  - effect: closes the current in-flight async-copy group
 - constraints:
   - Later `CpAsyncWait` counts committed groups.
 
 ##### CpAsyncWait
 
-```text
-CpAsyncWait(n)
+```python
+CpAsyncWait(n)    # n: most-recent committed groups allowed to remain in flight
 ```
-- kind: TIR op
-- fields:
-  - n: most-recent committed groups allowed to remain in flight
 - constraints:
   - `n` is a non-negative compile-time count.
   - `n = 0` drains every outstanding committed group.

--- a/docs/spec/tir.md
+++ b/docs/spec/tir.md
@@ -23,6 +23,7 @@ the work, structural Stmts carry control flow.
 
 ## 2. `Stmt`
 
+
 ```python
 @dataclass(frozen=True)
 class Stmt:
@@ -118,7 +119,7 @@ together with `args`; an `Op` callable carries no result, so its
 `Call` form is unit-typed.
 
 The value-producing counterpart is the `Call(Op, args)` Expr
-([core-ir.md §5](./core-ir.md#5-call)): it has a non-`Unit` result
+([core-ir.md §2.1](./core-ir.md#21-call)): it has a non-`Unit` result
 type and is anchored by `LetStmt`. `Evaluate` is the unit-typed,
 Stmt-position form and the only Stmt-position invocation wrapper.
 
@@ -377,7 +378,7 @@ block_y, block_z, *forwarded_args)`:
 A hand-written kernel issues an MMA through an explicit **atom** — a
 realized instruction descriptor — instead of the bare `Mma` op whose
 fragment layouts the per-target lowering chooses
-([hir §2.3](./hir.md#23-irhirnn), [passes](./passes.md)). An MMA atom fixes a
+([hir §1.3](./hir.md#irhirnn), [passes](./passes.md)). An MMA atom fixes a
 concrete hardware instruction, so the whole MMA surface is **target-owned**:
 the `Mma` op and the `MmaOpSpec` / `MmaAtom` descriptors
 (`tilefoundry.ir.tir.cuda.nn`, mirroring the CuTe `MMA_Op` → `MMA_Atom`
@@ -607,7 +608,7 @@ CpAsyncWait(n)
 `tir.DispatchCall` is a first-class TIR Stmt that implements
 pattern-based first-match dispatch over a tuple of `Expr` subjects.
 It is the lowered form of an HIR dispatch prototype
-([hir.md §5](./hir.md#5-dispatch-specializations)) and of any sub-call
+([hir.md §1.1](./hir.md#11-function)) and of any sub-call
 to a dispatch-prototype callee.
 
 ```python
@@ -639,7 +640,7 @@ The verifier requires:
 - `len(case_patterns) == len(case_calls)`.
 - Each `case_patterns[i]` has length `== len(subjects) == 1`.
 - Each `case_patterns[i][0]` is a `DimVarRangePat`
-  ([core-ir.md §7.1](./core-ir.md#71-dimvarrangepat)).
+  ([core-ir.md §3.1](./core-ir.md#31-dimvarrangepat)).
 - `fallback` is exactly `Sequential((Abort(),))` — a length-1 body
   containing one `Abort`.
 
@@ -709,7 +710,7 @@ target: the `callable` of an `Evaluate(SymbolRef, args)`
 
 #### `name`
 - MUST be the canonical name of a `PrimFunction` in the enclosing
-  `Module` ([core-ir.md §2](./core-ir.md#2-module)), exactly as stored
+  `Module` ([core-ir.md §1](./core-ir.md#1-module)), exactly as stored
   in `PrimFunction.name`. It MAY be a generated / mangled
   specialization name.
 
@@ -730,7 +731,7 @@ target: the `callable` of an `Evaluate(SymbolRef, args)`
   it never back-fills.
 
 Resolution is module level: a unique lookup over the `Module`
-([core-ir.md §2](./core-ir.md#2-module)) MUST map `name` to exactly
+([core-ir.md §1](./core-ir.md#1-module)) MUST map `name` to exactly
 one `PrimFunction`; zero or more than one match is an error.
 Specialization variants each carry a distinct canonical
 `PrimFunction.name`, so a `SymbolRef` to a variant resolves

--- a/docs/spec/tir.md
+++ b/docs/spec/tir.md
@@ -5,8 +5,6 @@ into TIR; the lowering pass `HirToTirPass` ([passes](./passes.md))
 also produces TIR. TIR has no value return; effect-form Ops carry
 the work, structural Stmts carry control flow.
 
-## 1. Role and scope
-
 - **Container**: `tir.PrimFunction(name, params, body, output_count)`.
   `body` is a `Sequential`; the function returns no value.
 - **Stmt tree**: function bodies are nested Stmts only. Exprs appear
@@ -14,15 +12,16 @@ the work, structural Stmts carry control flow.
 - **Effect Ops** (`Copy`, `Fill`, `Mma`, `ReLU`, `RMSNorm`, `Reduce`)
   are value-class Ops registered with `@register_op`; in Stmt
   position they are invoked as `Evaluate(op, args)`
-  ([§2.2](#22-evaluate)).
+  ([§1.4](#14-evaluate)).
 - **Value Ops** (`AllocTensor`, `MemorySpan`, `PtrOf`, `TensorView`)
   are anchored by `LetStmt` so their result `Var` has stable
   identity.
 - **No HIR Ops** reach TIR; HIR-to-TIR rewriting is owned by the
   pass layer.
 
-## 2. `Stmt`
+## 1. TIR Stmt hierarchy
 
+### 1.1 `Stmt`
 
 ```python
 @dataclass(frozen=True)
@@ -48,7 +47,7 @@ flowchart TB
     Stmt --> EvaluateStmt
 ```
 
-### 2.1 Structural Stmts (`tir.stmts`)
+### 1.2 Structural Stmts (`tir.stmts`)
 
 ```python
 @dataclass(frozen=True)
@@ -91,7 +90,47 @@ class Return(Stmt):
     pass                              # @prim_func has no value return
 ```
 
-### 2.2 `Evaluate`
+- `MeshScope.mesh` carries the `Mesh` object; the `binding` `Var`
+  scopes the mesh inside `body`.
+
+### 1.3 `PrimFunction`
+
+```python
+@dataclass(frozen=True)
+class PrimFunction(Stmt):
+    name: str
+    params: tuple[Var, ...]
+    body: Sequential
+    output_count: int = 1             # number of trailing output params
+```
+
+`PrimFunction` is itself a `Stmt`, not a separate top-level node;
+it sits inside the TIR Stmt tree along with everything else.
+
+`tir.verify.verify_prim_function(fn, *, module_fns=())` enforces:
+
+- **Param homogeneity**. All parameters' layouts MUST be uniformly
+  `ShardLayout` or uniformly non-`ShardLayout`; mixing is rejected.
+- **Fresh `Var` identity**. The same `Var` object MUST NOT be bound
+  by more than one `LetStmt` / `For` / `MeshScope` across the
+  function. Parameters seed the bound set.
+- **`LetStmt` typing**. `LetStmt.var.type` MUST equal the typeinfer
+  of `LetStmt.value`.
+- **`AllocTensor` placement**. `Call(AllocTensor, ...)` MAY only
+  appear directly as `LetStmt.value`. Nesting it inside any other
+  Expr is rejected.
+- **`MeshScope` mesh in scope**. Any embedded `ShardLayout` MUST
+  reference a mesh on the active `MeshScope` stack or a parameter's
+  `ShardLayout.mesh`.
+- **`Evaluate.callable`**. When `callable` is a `SymbolRef`
+  ([§2.1](#21-symbolref)), module-level resolution MUST find exactly one
+  `PrimFunction` of that name in the enclosing `Module`, `args` length
+  MUST match the resolved callee's `params`, and the `SymbolRef.type`
+  MUST equal the resolved callee's `CallableType`. When `callable` is
+  an `Op`, the per-Op verifier registered via
+  `@register_verify_stmt(Op)` runs.
+
+### 1.4 `Evaluate`
 
 ```python
 @dataclass(frozen=True)
@@ -104,14 +143,14 @@ class Evaluate(Stmt):
 invocation that has no result value. The `callable` is one of:
 
 - an effect-form `Op` (e.g. `tir.memory.Copy`, `tir.cuda.nn.Mma`,
-  `tir.tensor.Reduce`, `tir.Launch` [§3.6](#36-launch)). `args` are
+  `tir.tensor.Reduce`, `tir.Launch` [§2.3](#launch)). `args` are
   the Op's operands in `ParamDef` order; the per-Op verifier
   registered via `@register_verify_stmt(Op)` runs.
-- a `SymbolRef` ([§9](#9-symbolref)) — a reference to a callee
+- a `SymbolRef` ([§2.1](#21-symbolref)) — a reference to a callee
   `PrimFunction` in the enclosing `Module`. `args` follow the callee's
   parameter order, the final `output_count` positions binding output
   buffers; the callee is resolved uniquely at module level
-  ([§4](#4-verify-rules)).
+  ([§1.3](#13-primfunction)).
 
 Verify and lowering MUST dispatch on `type(callable)`. The per-Op
 verify / codegen handlers are keyed by `Op` type and receive the Op
@@ -127,30 +166,16 @@ Stmt-position form and the only Stmt-position invocation wrapper.
 unconditional invocation — an effect `Op` or a function `SymbolRef` —
 is expressed as `Evaluate(callable, args)`. A construct that carries
 its own control flow stays a first-class `Stmt`, not an `Evaluate`
-callable: `DispatchCall` ([§6](#6-dispatchcall)) is a first-match
+callable: `DispatchCall` ([§1.6](#16-dispatchcall)) is a first-match
 `if`/`else` over patterns with a fallback, and `Abort`
-([§8](#8-abort)) is a terminator. Their nested function invocations
+([§1.7](#17-abort)) is a terminator. Their nested function invocations
 are themselves `Evaluate(SymbolRef, args)`.
 
-### 2.3 `PrimFunction`
-
-```python
-@dataclass(frozen=True)
-class PrimFunction(Stmt):
-    name: str
-    params: tuple[Var, ...]
-    body: Sequential
-    output_count: int = 1             # number of trailing output params
-```
-
-`PrimFunction` is itself a `Stmt`, not a separate top-level node;
-it sits inside the TIR Stmt tree along with everything else.
-
-### 2.4 `Sync`
+### 1.5 `Sync`
 
 `Sync` is a mesh-scoped barrier. It is an **effect-form op** (`tir.sync.Sync`),
 authored `T.sync(m)`, and appears in Stmt position wrapped by `Evaluate`
-([§2.2](#22-evaluate)) like any other effect op. The surface is **only**
+([§1.4](#14-evaluate)) like any other effect op. The surface is **only**
 `T.sync(m)` / `T.sync(m[slice])` — there is no `m.sync()` receiver form.
 
 ```python
@@ -238,372 +263,7 @@ the mesh, and any slice of it, is a compile-time descriptor rather than an SSA
 value, and the barrier kind is derived from that set by one shared routine so
 verify and codegen cannot disagree.
 
-## 3. TIR Ops
-
-Value Ops MUST be anchored by `LetStmt.value` — their result `Var` is the only
-handle. Effect Ops appear in Stmt position as `Evaluate(op, args)`
-([§2.2](#22-evaluate)). Each Op's full contract lives here, in its catalog entry
-below; code carries only a one-line purpose docstring
-([SPEC-RULES](../SPEC-RULES.md)).
-
-### 3.1 Memory Ops (`tir.memory.*`)
-
-#### AllocTensor
-Allocate a tensor (value form; result type on the `tensor_type` attribute).
-
-#### MemorySpan
-Re-interpret a memory region as a typed tensor (value form).
-
-#### PtrOf
-Take the device address of a tensor for downstream view ops (value form).
-
-#### TensorView
-Derive a sub-view of a tensor (value form).
-
-#### Copy
-Byte-equivalent copy between two tensors (effect form).
-
-#### Fill
-Broadcast a scalar value into a tensor (effect form).
-
-### 3.2 NN Ops (`tir.nn.*`)
-
-#### Mma
-Matrix-multiply-accumulate `acc += lhs @ rhs` (effect form); per-target PTX
-lowering lives in [target](./target.md), the atom calling convention in
-[§3.7](#37-mma-atom-and-the-hand-written-calling-convention).
-
-#### ReLU
-Pointwise `max(x, 0)` (effect form).
-
-#### RMSNorm
-Fused RMS normalisation (effect form).
-
-### 3.3 Tensor Ops (`tir.tensor.*`)
-
-#### Reduce
-
-```text
-Reduce(src, dst, workspace?, axes, kind)
-```
-- kind: TIR op
-- fields:
-  - src / dst: effect-form operands
-  - workspace: optional staging buffer sized by lowering
-  - axes: reduced-axis tuple
-  - kind: `ReduceKind` tag
-- constraints:
-  - `Reduce` carries no dispatch parameter; runtime selects the strategy.
-  - `workspace` is present only when lowering sizes cross-warp staging.
-  - All forms lower to the single public runtime entry
-    `tilefoundry::ops::reduce<Op, Axes>(src, dst[, workspace])`.
-  - Plain and sharded runtime extents/tiers are derived inside the runtime.
-
-### 3.4 Generic kind-tagged effect Ops (`tir.arith`)
-
-`Binary` / `Unary` are effect-form Ops that dispatch on a kind enum rather than
-per-op classes; they appear as `Evaluate(op, args)`. `BinaryKind` /
-`UnaryKind` / `ReduceKind` are compiler-wide tag enums shared across HIR and
-TIR; lowering preserves the kind value without re-mapping.
-
-#### Binary
-```text
-Binary(lhs, rhs, dst, kind)
-```
-- kind: TIR op
-- fields:
-  - lhs / rhs: input operands
-  - dst: destination operand
-  - kind: `BinaryKind` tag
-- constraints:
-  - Lowers to the binary runtime family without per-kind TIR classes.
-
-#### Unary
-```text
-Unary(src, dst, kind)
-```
-- kind: TIR op
-- fields:
-  - src: input operand
-  - dst: destination operand
-  - kind: `UnaryKind` tag, including `rsqrt`
-- constraints:
-  - Lowers to the unary runtime family without per-kind TIR classes.
-
-### 3.5 `@intrinsic` — user-defined effect Stmts
-
-```python
-@intrinsic
-def some_intrinsic(a: Expr, b: Expr) -> None:
-    """verify body — runs as register_verify_stmt."""
-    if a.type.shape != b.type.shape:
-        raise VerifyError(...)
-```
-
-`tilefoundry.ir.tir.intrinsic.intrinsic` synthesises a Stmt subclass
-from the decorated function's signature, registers the function
-body as the Stmt's verifier, and wires the parser dispatch entry
-under the function's snake-case name. Parameters MUST be annotated
-`Expr`; the return annotation MUST be `None`.
-
-### 3.6 `Launch`
-
-Effect Op for a host-side launch of a device kernel (CPU entry only, no value);
-the callee `SymbolRef` and grid/block extents flow through the `Evaluate` args,
-the non-grid/block launch config through the Op attributes.
-
-`Launch` appears only in a CPU (host) entry body, as `Evaluate(Launch(...),
-args)` with `args = (SymbolRef(callee), grid_x, grid_y, grid_z, block_x,
-block_y, block_z, *forwarded_args)`:
-
-- **callee**: `args[0]` MUST be a `SymbolRef` ([§9](#9-symbolref)) resolving to
-  a device `PrimFunction` with a CUDA target.
-- **grid / block**: `args[1:7]` are the grid then block extents in the fixed
-  order `grid_x, grid_y, grid_z, block_x, block_y, block_z`. Each is an `Expr`
-  — a `Constant` for a static extent, a `ShapeOf` ([§7](#7-shapeof)) for a
-  launch-provided (dynamic) one, or a dim-arithmetic `Call` over those. They are
-  launch configuration, not kernel parameters: the device observes geometry
-  through `gridDim` / `blockIdx` (the codegen `program_dim` / `program_shape`
-  accessors), never as arguments.
-- **forwarded args**: the remaining `args` bind the callee's host-visible
-  parameters in declaration order. They MUST NOT include the hidden
-  `<param>_shape_<axis>` scalar parameters ([§7](#7-shapeof)) — the host fills
-  those from a tensor argument's runtime shape.
-- **attributes**: `cluster`, `dynamic_smem`, `stream`, and `attrs` carry the
-  non-grid/block launch configuration. A `cluster` / `stream` / `attrs` value
-  the active CUDA target does not support MUST be rejected in target lowering.
-
-### 3.7 MMA atom and the hand-written calling convention
-
-A hand-written kernel issues an MMA through an explicit **atom** — a
-realized instruction descriptor — instead of the bare `Mma` op whose
-fragment layouts the per-target lowering chooses
-([hir §1.3](./hir.md#irhirnn), [passes](./passes.md)). An MMA atom fixes a
-concrete hardware instruction, so the whole MMA surface is **target-owned**:
-the `Mma` op and the `MmaOpSpec` / `MmaAtom` descriptors
-(`tilefoundry.ir.tir.cuda.nn`, mirroring the CuTe `MMA_Op` → `MMA_Atom`
-layering), the concrete instructions, and their fragment layouts all live
-under `tilefoundry.ir.tir.cuda.nn.mma` / `mma_atom`, following IR's dialect-first
-layout `ir/{dialect}/{target}/{category}`.
-
-#### `MmaOpSpec`
-
-A named, fully-specified MMA instruction (the CuTe `MMA_Op` analog).
-
-```python
-@dataclass(frozen=True)
-class MmaOpSpec:
-    name: str
-    shape_mnk: tuple[int, int, int]
-    dtype_a: DType
-    dtype_b: DType
-    dtype_c: DType
-    operand_layout: str
-```
-
-##### `name`
-
-- MUST uniquely identify the instruction. dtype / shape / source layout
-  are fixed by it; the remaining fields mirror the name so verify and
-  codegen do not re-parse the string.
-
-##### `shape_mnk`
-
-- MUST be the instruction's `(M, N, K)` tuple; every entry MUST be a
-  static int.
-
-##### `dtype_a`
-
-- MUST be the `lhs` operand element type (`DType`).
-
-##### `dtype_b`
-
-- MUST be the `rhs` operand element type (`DType`); it MAY differ from
-  `dtype_a`.
-
-##### `dtype_c`
-
-- MUST be the accumulator element type (`DType`); it MAY differ from the
-  operand types (e.g. `f32` accumulation over `bf16` operands).
-
-##### `operand_layout`
-
-- MUST encode the source operand order as a string, e.g. `"TN"` (A
-  row-major, B col-major). An `MmaOpSpec` MUST NOT carry fragment-layout
-  knowledge.
-
-#### `MmaAtom`
-
-The realized atom for an `op` (the CuTe `MMA_Atom` analog), built by
-`T.cuda.mma.atom(op=...)`
-([parser §2.6](./parser.md#26-platform-sub-namespaces)).
-
-```python
-@dataclass(frozen=True)
-class MmaAtom:
-    op: MmaOpSpec
-    A: ShardLayout
-    B: ShardLayout
-    C: ShardLayout
-    required_scope: Mesh
-```
-
-##### `op`
-
-- MUST be the `MmaOpSpec` this atom realizes.
-
-##### `A`
-
-- MUST be the `lhs` operand fragment `ShardLayout` contract — the
-  lane→value layout the instruction reads. It MUST be returned **as-is**
-  at a use site and MUST NOT be rebound onto the caller's mesh.
-
-##### `B`
-
-- MUST be the `rhs` operand fragment `ShardLayout` contract; the same
-  as-is / no-rebind rule as `A` applies.
-
-##### `C`
-
-- MUST be the accumulator fragment `ShardLayout` contract; the same
-  as-is / no-rebind rule as `A` applies.
-
-##### `required_scope`
-
-- MUST be the thread-participation contract the atom needs, carried as
-  its own `Mesh` (for the SM80 `16x8x16` instruction, 32 lanes arranged
-  as a `(4, 8)` thread mesh). It MUST NOT be the caller's mesh; the
-  caller's enclosing scope MUST be checked against it at verify (below).
-
-#### Calling convention
-
-Load, compute, and store are **three separate** effect statements under
-an enclosing `MeshScope` ([§5](#5-topology-and-storage)); `T.mma` is
-verify-only and MUST NOT fuse the loads or the store.
-
-```python
-atom = T.cuda.mma.atom(op=T.cuda.mma.SM80_16x8x16_F32BF16BF16F32_TN)
-with Mesh(Topology("thread", 32), Layout(shape=(4, 8), strides=(1, 4))) as warp:
-    a_frag = T.alloc_tensor(TensorType(..., layout=atom.A, storage=rmem))
-    acc    = T.alloc_tensor(TensorType(..., layout=atom.C, storage=rmem))
-    T.copy(T.tensor_view(a, layout=atom.A), a_frag)   # load
-    T.fill(acc, 0.0)
-    T.mma(acc, a_frag, b_frag, atom=atom)             # compute
-    T.copy(acc, T.tensor_view(c, layout=atom.C))      # store
-```
-
-- The author allocates each register fragment with the matching
-  `atom.A/B/C` layout and fills it with its own `T.copy`. The
-  accumulator is initialised with `Fill` and then read-modify-written.
-- `atom` is a compile-time attribute on the `Mma` Op
-  ([parser §2.6](./parser.md#26-platform-sub-namespaces)), not a runtime
-  operand. When absent, lowering takes the bare-`Mma` per-target path.
-
-#### Verify
-
-A `T.mma` carrying an `atom` MUST satisfy:
-
-- **operand contracts**: `acc.layout == atom.C`, `lhs.layout == atom.A`,
-  `rhs.layout == atom.B`.
-- **scope**: some mesh on the active `MeshScope` stack provides the
-  atom's required thread scope —
-  `mesh_scope_matches_required_scope(mesh, atom.required_scope)`. The
-  match is identity- and name-independent (mesh object identity, the
-  binding-var name, and axis names are not compared); it holds iff:
-  - the two meshes share the same program topology level — a `cta`
-    scope is never a `thread` / warp scope, even when its layout carries
-    the same shape;
-  - both topology domains (the product of the topology extents) are
-    statically known;
-  - each mesh is self-consistent (`topology domain == layout extent`),
-    and the enclosing mesh is inverse-projectable;
-  - the thread-value decomposition matches **exactly** — same layout
-    shape and strides. A flat lane layout cannot host the atom's
-    multi-axis fragment `Split` and is rejected.
-
-Per-target PTX emission dispatches on the atom ([target](./target.md)).
-
-### 3.8 Async copy Ops (`tir.async.*`)
-
-Non-blocking `cp.async` gmem→smem staging for warp-specialized pipelines: a
-producer issues copies, groups them, and a consumer waits on the group queue.
-
-#### CopyAsync
-
-```text
-CopyAsync(src, dst)
-```
-- kind: TIR op
-- fields:
-  - src / dst: async staging operands
-- constraints:
-  - Lowers to `tilefoundry::ops::copy_async(src, dst)`.
-  - A later read of `dst` is ordered by `CpAsyncCommit` followed by
-    `CpAsyncWait`.
-
-#### CpAsyncCommit
-
-```text
-CpAsyncCommit()
-```
-- kind: TIR op
-- fields:
-  - effect: closes the current in-flight async-copy group
-- constraints:
-  - Later `CpAsyncWait` counts committed groups.
-
-#### CpAsyncWait
-
-```text
-CpAsyncWait(n)
-```
-- kind: TIR op
-- fields:
-  - n: most-recent committed groups allowed to remain in flight
-- constraints:
-  - `n` is a non-negative compile-time count.
-  - `n = 0` drains every outstanding committed group.
-
-## 4. Verify rules
-
-`tir.verify.verify_prim_function(fn, *, module_fns=())` enforces:
-
-- **Param homogeneity**. All parameters' layouts MUST be uniformly
-  `ShardLayout` or uniformly non-`ShardLayout`; mixing is rejected.
-- **Fresh `Var` identity**. The same `Var` object MUST NOT be bound
-  by more than one `LetStmt` / `For` / `MeshScope` across the
-  function. Parameters seed the bound set.
-- **`LetStmt` typing**. `LetStmt.var.type` MUST equal the typeinfer
-  of `LetStmt.value`.
-- **`AllocTensor` placement**. `Call(AllocTensor, ...)` MAY only
-  appear directly as `LetStmt.value`. Nesting it inside any other
-  Expr is rejected.
-- **`MeshScope` mesh in scope**. Any embedded `ShardLayout` MUST
-  reference a mesh on the active `MeshScope` stack or a parameter's
-  `ShardLayout.mesh`.
-- **`Evaluate.callable`**. When `callable` is a `SymbolRef`
-  ([§9](#9-symbolref)), module-level resolution MUST find exactly one
-  `PrimFunction` of that name in the enclosing `Module`, `args` length
-  MUST match the resolved callee's `params`, and the `SymbolRef.type`
-  MUST equal the resolved callee's `CallableType`. When `callable` is
-  an `Op`, the per-Op verifier registered via
-  `@register_verify_stmt(Op)` runs.
-
-## 5. Topology and storage
-
-- `MeshScope.mesh` carries the `Mesh` object; the `binding` `Var`
-  scopes the mesh inside `body`.
-- `TensorType.storage` is a `StorageKind` (`gmem` / `smem` / `rmem` / `host` /
-  `tmem`) or `None` ([types §2](./types.md)). `storage=None` is rank-0-only,
-  reserved for shape-element tensors. A memory-resident TIR tensor MUST carry a
-  concrete level; the unmaterialized `umat` ([types §2](./types.md)) is an
-  HIR-only value and MUST already be materialized to a concrete level by the
-  time `HirToTirPass` produces TIR — it never appears in TIR.
-- `Reshard` does not appear in TIR; HIR-side `Reshard` is lowered
-  into `LetStmt(AllocTensor)` + `Evaluate(Copy, ...)` chains
-  during `HirToTirPass` ([passes](./passes.md)).
-
-## 6. `DispatchCall`
+### 1.6 `DispatchCall`
 
 `tir.DispatchCall` is a first-class TIR Stmt that implements
 pattern-based first-match dispatch over a tuple of `Expr` subjects.
@@ -622,7 +282,7 @@ class DispatchCall(Stmt):
 ```
 
 `DispatchCall` is a control Stmt, not an `Evaluate` callable
-([§2.2](#22-evaluate)); each `case_calls[i]` is an
+([§1.4](#14-evaluate)); each `case_calls[i]` is an
 `Evaluate(SymbolRef, args)` invoking that case's specialized callee.
 
 Semantics: the i-th `case_patterns` matches against `subjects` by
@@ -631,7 +291,7 @@ position; the first `i` whose every pattern matches runs
 runs. Source order is part of the IR contract — printers and viewers
 MUST preserve it.
 
-### 6.1 Verifier rules
+#### Verifier rules
 
 The verifier requires:
 
@@ -648,7 +308,87 @@ The verifier requires:
 across compiles: ordered by axis kind, then by canonical name of the
 matched key. A single dispatch axis makes this ordering trivial.
 
-## 7. `ShapeOf`
+### 1.7 `Abort`
+
+```python
+@dataclass(frozen=True)
+class Abort(Stmt):
+    message: str = ""
+```
+
+- `Abort` is terminating. It exists in code paths the compiler
+  believes are unreachable (notably `DispatchCall.fallback`).
+- The CUDA emitter renders `Abort` as `__trap();` in device contexts
+  and `assert(false);` in host contexts so a runtime hit is loud
+  rather than silent.
+- `message` is a debug surface; it does not carry semantics.
+
+### 1.8 `@intrinsic` — user-defined effect Stmts
+
+```python
+@intrinsic
+def some_intrinsic(a: Expr, b: Expr) -> None:
+    """verify body — runs as register_verify_stmt."""
+    if a.type.shape != b.type.shape:
+        raise VerifyError(...)
+```
+
+`tilefoundry.ir.tir.intrinsic.intrinsic` synthesises a Stmt subclass
+from the decorated function's signature, registers the function
+body as the Stmt's verifier, and wires the parser dispatch entry
+under the function's snake-case name. Parameters MUST be annotated
+`Expr`; the return annotation MUST be `None`.
+
+## 2. TIR Expr and callable constructs
+
+### 2.1 `SymbolRef`
+
+```python
+@dataclass(frozen=True)
+class SymbolRef(Expr):
+    name: str
+    nested: tuple[str, ...] = ()
+    # type: CallableType — the resolved callee's IR-level CallableType
+```
+
+`SymbolRef` is a leaf `Expr` naming a callee `PrimFunction` as a call
+target: the `callable` of an `Evaluate(SymbolRef, args)`
+([§1.4](#14-evaluate)) function invocation and `args[0]` of a `Launch`
+([§2.3](#launch)).
+
+#### `name`
+- MUST be the canonical name of a `PrimFunction` in the enclosing
+  `Module` ([core-ir.md §1](./core-ir.md#1-module)), exactly as stored
+  in `PrimFunction.name`. It MAY be a generated / mangled
+  specialization name.
+
+#### `nested`
+- MUST be empty: the `Module` holds only top-level functions, so a
+  non-empty `nested` is rejected.
+
+#### `type`
+- MUST be the resolved callee's IR-level `CallableType`
+  ([types §7](./types.md#7-callabletype)): `parameters` are the callee
+  `params` types in order; `return_type` is `UnitType`
+  ([types §6](./types.md#6-unittype)) — a TIR `PrimFunction` returns
+  no value, its outputs are trailing params ([§1.4](#14-evaluate)).
+- MUST be set at construction from the callee in hand; a `SymbolRef`
+  with a deferred or unresolved type MUST NOT enter constructed IR.
+  `Expr` is frozen and verify MUST NOT mutate IR, so verify only
+  checks `type` against the resolved callee ([§1.3](#13-primfunction)) —
+  it never back-fills.
+
+Resolution is module level: a unique lookup over the `Module`
+([core-ir.md §1](./core-ir.md#1-module)) MUST map `name` to exactly
+one `PrimFunction`; zero or more than one match is an error.
+Specialization variants each carry a distinct canonical
+`PrimFunction.name`, so a `SymbolRef` to a variant resolves
+unambiguously; the unmangled dispatcher name lives on
+`DispatchCall.callee_name` ([§1.6](#16-dispatchcall)), not on a
+`SymbolRef`. Local typeinfer does not resolve a `SymbolRef`; it
+carries its `type` directly.
+
+### 2.2 `ShapeOf`
 
 ```python
 @dataclass(frozen=True)
@@ -676,66 +416,324 @@ produced:
   tensor parameter / axis in which it occurs.
 - A CPU host entry MUST NOT expose such a scalar at its user-facing
   surface — it reads the extent from its tensor argument's runtime shape
-  and forwards it ([§3.6](#36-launch)).
+  and forwards it ([§2.3](#launch)).
 
-## 8. `Abort`
+### 2.3 TIR Ops
 
-```python
-@dataclass(frozen=True)
-class Abort(Stmt):
-    message: str = ""
+Value Ops MUST be anchored by `LetStmt.value` — their result `Var` is the only
+handle. Effect Ops appear in Stmt position as `Evaluate(op, args)`
+([§1.4](#14-evaluate)). Each Op's full contract lives here, in its catalog entry
+below; code carries only a one-line purpose docstring
+([SPEC-RULES](../SPEC-RULES.md)).
+
+- `TensorType.storage` is a `StorageKind` (`gmem` / `smem` / `rmem` / `host` /
+  `tmem`) or `None` ([types §2](./types.md)). `storage=None` is rank-0-only,
+  reserved for shape-element tensors. A memory-resident TIR tensor MUST carry a
+  concrete level; the unmaterialized `umat` ([types §2](./types.md)) is an
+  HIR-only value and MUST already be materialized to a concrete level by the
+  time `HirToTirPass` produces TIR — it never appears in TIR.
+- `Reshard` does not appear in TIR; HIR-side `Reshard` is lowered
+  into `LetStmt(AllocTensor)` + `Evaluate(Copy, ...)` chains
+  during `HirToTirPass` ([passes](./passes.md)).
+
+#### Memory Ops (`tir.memory.*`)
+
+##### AllocTensor
+Allocate a tensor (value form; result type on the `tensor_type` attribute).
+
+##### MemorySpan
+Re-interpret a memory region as a typed tensor (value form).
+
+##### PtrOf
+Take the device address of a tensor for downstream view ops (value form).
+
+##### TensorView
+Derive a sub-view of a tensor (value form).
+
+##### Copy
+Byte-equivalent copy between two tensors (effect form).
+
+##### Fill
+Broadcast a scalar value into a tensor (effect form).
+
+#### NN Ops (`tir.nn.*`)
+
+##### Mma
+Matrix-multiply-accumulate `acc += lhs @ rhs` (effect form); per-target PTX
+lowering lives in [target](./target.md), the atom calling convention in
+[§2.3](#mma-atom-and-the-hand-written-calling-convention).
+
+##### ReLU
+Pointwise `max(x, 0)` (effect form).
+
+##### RMSNorm
+Fused RMS normalisation (effect form).
+
+#### Tensor Ops (`tir.tensor.*`)
+
+##### Reduce
+
+```text
+Reduce(src, dst, workspace?, axes, kind)
 ```
+- kind: TIR op
+- fields:
+  - src / dst: effect-form operands
+  - workspace: optional staging buffer sized by lowering
+  - axes: reduced-axis tuple
+  - kind: `ReduceKind` tag
+- constraints:
+  - `Reduce` carries no dispatch parameter; runtime selects the strategy.
+  - `workspace` is present only when lowering sizes cross-warp staging.
+  - All forms lower to the single public runtime entry
+    `tilefoundry::ops::reduce<Op, Axes>(src, dst[, workspace])`.
+  - Plain and sharded runtime extents/tiers are derived inside the runtime.
 
-- `Abort` is terminating. It exists in code paths the compiler
-  believes are unreachable (notably `DispatchCall.fallback`).
-- The CUDA emitter renders `Abort` as `__trap();` in device contexts
-  and `assert(false);` in host contexts so a runtime hit is loud
-  rather than silent.
-- `message` is a debug surface; it does not carry semantics.
+#### Generic kind-tagged effect Ops (`tir.arith`)
 
-## 9. `SymbolRef`
+`Binary` / `Unary` are effect-form Ops that dispatch on a kind enum rather than
+per-op classes; they appear as `Evaluate(op, args)`. `BinaryKind` /
+`UnaryKind` / `ReduceKind` are compiler-wide tag enums shared across HIR and
+TIR; lowering preserves the kind value without re-mapping.
+
+##### Binary
+```text
+Binary(lhs, rhs, dst, kind)
+```
+- kind: TIR op
+- fields:
+  - lhs / rhs: input operands
+  - dst: destination operand
+  - kind: `BinaryKind` tag
+- constraints:
+  - Lowers to the binary runtime family without per-kind TIR classes.
+
+##### Unary
+```text
+Unary(src, dst, kind)
+```
+- kind: TIR op
+- fields:
+  - src: input operand
+  - dst: destination operand
+  - kind: `UnaryKind` tag, including `rsqrt`
+- constraints:
+  - Lowers to the unary runtime family without per-kind TIR classes.
+
+#### `Launch`
+
+Effect Op for a host-side launch of a device kernel (CPU entry only, no value);
+the callee `SymbolRef` and grid/block extents flow through the `Evaluate` args,
+the non-grid/block launch config through the Op attributes.
+
+`Launch` appears only in a CPU (host) entry body, as `Evaluate(Launch(...),
+args)` with `args = (SymbolRef(callee), grid_x, grid_y, grid_z, block_x,
+block_y, block_z, *forwarded_args)`:
+
+- **callee**: `args[0]` MUST be a `SymbolRef` ([§2.1](#21-symbolref)) resolving to
+  a device `PrimFunction` with a CUDA target.
+- **grid / block**: `args[1:7]` are the grid then block extents in the fixed
+  order `grid_x, grid_y, grid_z, block_x, block_y, block_z`. Each is an `Expr`
+  — a `Constant` for a static extent, a `ShapeOf` ([§2.2](#22-shapeof)) for a
+  launch-provided (dynamic) one, or a dim-arithmetic `Call` over those. They are
+  launch configuration, not kernel parameters: the device observes geometry
+  through `gridDim` / `blockIdx` (the codegen `program_dim` / `program_shape`
+  accessors), never as arguments.
+- **forwarded args**: the remaining `args` bind the callee's host-visible
+  parameters in declaration order. They MUST NOT include the hidden
+  `<param>_shape_<axis>` scalar parameters ([§2.2](#22-shapeof)) — the host fills
+  those from a tensor argument's runtime shape.
+- **attributes**: `cluster`, `dynamic_smem`, `stream`, and `attrs` carry the
+  non-grid/block launch configuration. A `cluster` / `stream` / `attrs` value
+  the active CUDA target does not support MUST be rejected in target lowering.
+
+#### MMA atom and the hand-written calling convention
+
+A hand-written kernel issues an MMA through an explicit **atom** — a
+realized instruction descriptor — instead of the bare `Mma` op whose
+fragment layouts the per-target lowering chooses
+([hir §1.3](./hir.md#irhirnn), [passes](./passes.md)). An MMA atom fixes a
+concrete hardware instruction, so the whole MMA surface is **target-owned**:
+the `Mma` op and the `MmaOpSpec` / `MmaAtom` descriptors
+(`tilefoundry.ir.tir.cuda.nn`, mirroring the CuTe `MMA_Op` → `MMA_Atom`
+layering), the concrete instructions, and their fragment layouts all live
+under `tilefoundry.ir.tir.cuda.nn.mma` / `mma_atom`, following IR's dialect-first
+layout `ir/{dialect}/{target}/{category}`.
+
+##### `MmaOpSpec`
+
+A named, fully-specified MMA instruction (the CuTe `MMA_Op` analog).
 
 ```python
 @dataclass(frozen=True)
-class SymbolRef(Expr):
+class MmaOpSpec:
     name: str
-    nested: tuple[str, ...] = ()
-    # type: CallableType — the resolved callee's IR-level CallableType
+    shape_mnk: tuple[int, int, int]
+    dtype_a: DType
+    dtype_b: DType
+    dtype_c: DType
+    operand_layout: str
 ```
 
-`SymbolRef` is a leaf `Expr` naming a callee `PrimFunction` as a call
-target: the `callable` of an `Evaluate(SymbolRef, args)`
-([§2.2](#22-evaluate)) function invocation and `args[0]` of a `Launch`
-([§3.6](#36-launch)).
+###### `name`
 
-#### `name`
-- MUST be the canonical name of a `PrimFunction` in the enclosing
-  `Module` ([core-ir.md §1](./core-ir.md#1-module)), exactly as stored
-  in `PrimFunction.name`. It MAY be a generated / mangled
-  specialization name.
+- MUST uniquely identify the instruction. dtype / shape / source layout
+  are fixed by it; the remaining fields mirror the name so verify and
+  codegen do not re-parse the string.
 
-#### `nested`
-- MUST be empty: the `Module` holds only top-level functions, so a
-  non-empty `nested` is rejected.
+###### `shape_mnk`
 
-#### `type`
-- MUST be the resolved callee's IR-level `CallableType`
-  ([types §7](./types.md#7-callabletype)): `parameters` are the callee
-  `params` types in order; `return_type` is `UnitType`
-  ([types §6](./types.md#6-unittype)) — a TIR `PrimFunction` returns
-  no value, its outputs are trailing params ([§2.2](#22-evaluate)).
-- MUST be set at construction from the callee in hand; a `SymbolRef`
-  with a deferred or unresolved type MUST NOT enter constructed IR.
-  `Expr` is frozen and verify MUST NOT mutate IR, so verify only
-  checks `type` against the resolved callee ([§4](#4-verify-rules)) —
-  it never back-fills.
+- MUST be the instruction's `(M, N, K)` tuple; every entry MUST be a
+  static int.
 
-Resolution is module level: a unique lookup over the `Module`
-([core-ir.md §1](./core-ir.md#1-module)) MUST map `name` to exactly
-one `PrimFunction`; zero or more than one match is an error.
-Specialization variants each carry a distinct canonical
-`PrimFunction.name`, so a `SymbolRef` to a variant resolves
-unambiguously; the unmangled dispatcher name lives on
-`DispatchCall.callee_name` ([§6](#6-dispatchcall)), not on a
-`SymbolRef`. Local typeinfer does not resolve a `SymbolRef`; it
-carries its `type` directly.
+###### `dtype_a`
+
+- MUST be the `lhs` operand element type (`DType`).
+
+###### `dtype_b`
+
+- MUST be the `rhs` operand element type (`DType`); it MAY differ from
+  `dtype_a`.
+
+###### `dtype_c`
+
+- MUST be the accumulator element type (`DType`); it MAY differ from the
+  operand types (e.g. `f32` accumulation over `bf16` operands).
+
+###### `operand_layout`
+
+- MUST encode the source operand order as a string, e.g. `"TN"` (A
+  row-major, B col-major). An `MmaOpSpec` MUST NOT carry fragment-layout
+  knowledge.
+
+##### `MmaAtom`
+
+The realized atom for an `op` (the CuTe `MMA_Atom` analog), built by
+`T.cuda.mma.atom(op=...)`
+([parser §2.6](./parser.md#26-platform-sub-namespaces)).
+
+```python
+@dataclass(frozen=True)
+class MmaAtom:
+    op: MmaOpSpec
+    A: ShardLayout
+    B: ShardLayout
+    C: ShardLayout
+    required_scope: Mesh
+```
+
+###### `op`
+
+- MUST be the `MmaOpSpec` this atom realizes.
+
+###### `A`
+
+- MUST be the `lhs` operand fragment `ShardLayout` contract — the
+  lane→value layout the instruction reads. It MUST be returned **as-is**
+  at a use site and MUST NOT be rebound onto the caller's mesh.
+
+###### `B`
+
+- MUST be the `rhs` operand fragment `ShardLayout` contract; the same
+  as-is / no-rebind rule as `A` applies.
+
+###### `C`
+
+- MUST be the accumulator fragment `ShardLayout` contract; the same
+  as-is / no-rebind rule as `A` applies.
+
+###### `required_scope`
+
+- MUST be the thread-participation contract the atom needs, carried as
+  its own `Mesh` (for the SM80 `16x8x16` instruction, 32 lanes arranged
+  as a `(4, 8)` thread mesh). It MUST NOT be the caller's mesh; the
+  caller's enclosing scope MUST be checked against it at verify (below).
+
+##### Calling convention
+
+Load, compute, and store are **three separate** effect statements under
+an enclosing `MeshScope` ([§1.2](#12-structural-stmts-tirstmts)); `T.mma` is
+verify-only and MUST NOT fuse the loads or the store.
+
+```python
+atom = T.cuda.mma.atom(op=T.cuda.mma.SM80_16x8x16_F32BF16BF16F32_TN)
+with Mesh(Topology("thread", 32), Layout(shape=(4, 8), strides=(1, 4))) as warp:
+    a_frag = T.alloc_tensor(TensorType(..., layout=atom.A, storage=rmem))
+    acc    = T.alloc_tensor(TensorType(..., layout=atom.C, storage=rmem))
+    T.copy(T.tensor_view(a, layout=atom.A), a_frag)   # load
+    T.fill(acc, 0.0)
+    T.mma(acc, a_frag, b_frag, atom=atom)             # compute
+    T.copy(acc, T.tensor_view(c, layout=atom.C))      # store
+```
+
+- The author allocates each register fragment with the matching
+  `atom.A/B/C` layout and fills it with its own `T.copy`. The
+  accumulator is initialised with `Fill` and then read-modify-written.
+- `atom` is a compile-time attribute on the `Mma` Op
+  ([parser §2.6](./parser.md#26-platform-sub-namespaces)), not a runtime
+  operand. When absent, lowering takes the bare-`Mma` per-target path.
+
+##### Verify
+
+A `T.mma` carrying an `atom` MUST satisfy:
+
+- **operand contracts**: `acc.layout == atom.C`, `lhs.layout == atom.A`,
+  `rhs.layout == atom.B`.
+- **scope**: some mesh on the active `MeshScope` stack provides the
+  atom's required thread scope —
+  `mesh_scope_matches_required_scope(mesh, atom.required_scope)`. The
+  match is identity- and name-independent (mesh object identity, the
+  binding-var name, and axis names are not compared); it holds iff:
+  - the two meshes share the same program topology level — a `cta`
+    scope is never a `thread` / warp scope, even when its layout carries
+    the same shape;
+  - both topology domains (the product of the topology extents) are
+    statically known;
+  - each mesh is self-consistent (`topology domain == layout extent`),
+    and the enclosing mesh is inverse-projectable;
+  - the thread-value decomposition matches **exactly** — same layout
+    shape and strides. A flat lane layout cannot host the atom's
+    multi-axis fragment `Split` and is rejected.
+
+Per-target PTX emission dispatches on the atom ([target](./target.md)).
+
+#### Async copy Ops (`tir.async.*`)
+
+Non-blocking `cp.async` gmem→smem staging for warp-specialized pipelines: a
+producer issues copies, groups them, and a consumer waits on the group queue.
+
+##### CopyAsync
+
+```text
+CopyAsync(src, dst)
+```
+- kind: TIR op
+- fields:
+  - src / dst: async staging operands
+- constraints:
+  - Lowers to `tilefoundry::ops::copy_async(src, dst)`.
+  - A later read of `dst` is ordered by `CpAsyncCommit` followed by
+    `CpAsyncWait`.
+
+##### CpAsyncCommit
+
+```text
+CpAsyncCommit()
+```
+- kind: TIR op
+- fields:
+  - effect: closes the current in-flight async-copy group
+- constraints:
+  - Later `CpAsyncWait` counts committed groups.
+
+##### CpAsyncWait
+
+```text
+CpAsyncWait(n)
+```
+- kind: TIR op
+- fields:
+  - n: most-recent committed groups allowed to remain in flight
+- constraints:
+  - `n` is a non-negative compile-time count.
+  - `n = 0` drains every outstanding committed group.

--- a/docs/spec/types.md
+++ b/docs/spec/types.md
@@ -88,7 +88,7 @@ class TensorType(IRType):
   shape-element form; a rank-0 tensor with a memory `StorageKind` is an
   ordinary scalar holding one element.
 
-Enforcement is owned by [tir §4](./tir.md) / [hir §1.3](./hir.md);
+Enforcement is owned by [tir §1.3](./tir.md#13-primfunction) / [hir §1.3](./hir.md);
 dispatch is described in
 [visitor-registry](./visitor-registry.md).
 
@@ -197,7 +197,7 @@ class UnitType(IRType):
 `UnitType` is the result type of an effect-form Op (such as
 `tir.cuda.nn.Mma`, `tir.memory.Copy`), which produces no value its
 consumers can read; in Stmt position such an Op appears as
-`Evaluate(op, args)` ([tir §2.2](./tir.md#22-evaluate)). The
+`Evaluate(op, args)` ([tir §1.4](./tir.md#14-evaluate)). The
 effect-form vs value-form classification is owned by
 [core-ir §2.3](./core-ir.md).
 

--- a/docs/spec/types.md
+++ b/docs/spec/types.md
@@ -27,10 +27,15 @@ flowchart TB
 
 ## 1. `IRType`
 
-```python
-class IRType:
-    """Abstract base of every TileFoundry IR type."""
+```text
+IRType()
 ```
+
+- kind: Python class
+- fields: none — abstract base
+- constraints:
+  - every `core_ir.Expr.type` is one of its derivations (`TensorType` /
+    `TupleType` / `UnitType` / `CallableType`).
 
 `IRType` is the abstract base. Every `core_ir.Expr.type` is one of
 its derivations: `TensorType` / `TupleType` / `UnitType` /
@@ -40,53 +45,48 @@ its derivations: `TensorType` / `TupleType` / `UnitType` /
 
 ## 2. `TensorType`
 
-```python
-@dataclass(frozen=True)
-class TensorType(IRType):
-    shape: tuple[ShapeDim, ...]  # ShapeDim = int | DimVar | Expr
-    dtype: DType                 # f32 / f16 / bf16 / i32 / i64 / bool / ...
-    layout: Layout | ShardLayout | ComposedLayout    # see shard
-    storage: StorageKind | None  # gmem / smem / rmem / host / tmem, or None
+```text
+TensorType(shape: tuple[ShapeDim, ...], dtype: DType, layout: Layout | ShardLayout | ComposedLayout, storage: StorageKind | None)
 ```
 
-**Key**:
-- Each `shape` element is a `ShapeDim` — one of: a raw Python
-  `int` (static dim), a `DimVar` `Op` instance (bounded named
-  symbolic dim placed directly into `shape`), or a dim-arithmetic
-  `Expr` (a `Call` over `DimAdd` / `DimMul` / ... whose leaves are
-  `Constant(int)` / `DimVar` / `DimConst`).
-- `shape` is the tensor's **logical shape**; it is invariant under
-  sharding, storage, and per-shard physical layout.
-- A *scalar* is `TensorType(shape=(), ...)` — a rank-0 tensor. There
-  is no separate `Scalar` type.
-- `layout` is a member of the `Layout` family
-  (`Layout` / `ComposedLayout` / `ShardLayout`); see [shard](./shard.md).
-- `storage` is a `StorageKind` (`gmem` / `smem` / `rmem` / `host` / `tmem` /
-  `umat`) or `None`. A concrete level (`gmem` / `smem` / `rmem` / `host` /
-  `tmem`) is the value's **abstract result residency** — where the result tensor
-  logically lives — not the transient register/ALU staging any individual step
-  happens to use. `umat` marks an **unmaterialized** (placement-polymorphic)
-  value: one present in the abstract IR that has not yet been committed to a
-  concrete residency. A source value literal carries `storage=umat`. An
-  unmaterialized value MUST be resolved to a concrete residency (or otherwise
-  materialized) before codegen consumes it. `None` is unchanged — a tensor with
-  no memory space (a shape-element scalar), distinct from `umat`.
-
-**Constraints**:
-- For plain `Layout` / `ComposedLayout`, `len(shape)` MUST equal the
-  layout's logical axis count; for `ComposedLayout` this is the
-  outer-layout's axis count after expansion.
-- For `ShardLayout`, `TensorType.shape` remains the logical shape;
-  `ShardLayout.layout.shape` is the sharding-internal / per-shard
-  layout shape and need not match `shape` axis-by-axis. `Reshard`
-  preserves the logical shape; logical-shape rewrites go through
-  `hir.tensor.Reshape`.
-- `Layout` / `ComposedLayout` MUST describe an injective mapping
-  ([shard §8.7](./shard.md)). Padding-style non-injective layouts are
-  not supported.
-- A rank-0 tensor is well-formed. A rank-0 tensor with `storage=None` is the
-  shape-element form; a rank-0 tensor with a memory `StorageKind` is an
-  ordinary scalar holding one element.
+- kind: Python class
+- fields:
+  - Each `shape` element is a `ShapeDim` — one of: a raw Python
+    `int` (static dim), a `DimVar` `Op` instance (bounded named
+    symbolic dim placed directly into `shape`), or a dim-arithmetic
+    `Expr` (a `Call` over `DimAdd` / `DimMul` / ... whose leaves are
+    `Constant(int)` / `DimVar` / `DimConst`).
+  - `shape` is the tensor's **logical shape**; it is invariant under
+    sharding, storage, and per-shard physical layout.
+  - A *scalar* is `TensorType(shape=(), ...)` — a rank-0 tensor. There
+    is no separate `Scalar` type.
+  - `layout` is a member of the `Layout` family
+    (`Layout` / `ComposedLayout` / `ShardLayout`); see [shard](./shard.md).
+  - `storage` is a `StorageKind` (`gmem` / `smem` / `rmem` / `host` / `tmem` /
+    `umat`) or `None`. A concrete level (`gmem` / `smem` / `rmem` / `host` /
+    `tmem`) is the value's **abstract result residency** — where the result tensor
+    logically lives — not the transient register/ALU staging any individual step
+    happens to use. `umat` marks an **unmaterialized** (placement-polymorphic)
+    value: one present in the abstract IR that has not yet been committed to a
+    concrete residency. A source value literal carries `storage=umat`. An
+    unmaterialized value MUST be resolved to a concrete residency (or otherwise
+    materialized) before codegen consumes it. `None` is unchanged — a tensor with
+    no memory space (a shape-element scalar), distinct from `umat`.
+- constraints:
+  - For plain `Layout` / `ComposedLayout`, `len(shape)` MUST equal the
+    layout's logical axis count; for `ComposedLayout` this is the
+    outer-layout's axis count after expansion.
+  - For `ShardLayout`, `TensorType.shape` remains the logical shape;
+    `ShardLayout.layout.shape` is the sharding-internal / per-shard
+    layout shape and need not match `shape` axis-by-axis. `Reshard`
+    preserves the logical shape; logical-shape rewrites go through
+    `hir.tensor.Reshape`.
+  - `Layout` / `ComposedLayout` MUST describe an injective mapping
+    ([shard §8.7](./shard.md)). Padding-style non-injective layouts are
+    not supported.
+  - A rank-0 tensor is well-formed. A rank-0 tensor with `storage=None` is the
+    shape-element form; a rank-0 tensor with a memory `StorageKind` is an
+    ordinary scalar holding one element.
 
 Enforcement is owned by [tir §1.3](./tir.md#13-primfunction) / [hir §1.3](./hir.md);
 dispatch is described in
@@ -96,16 +96,13 @@ dispatch is described in
 
 ## 3. `DType`
 
-```python
-class DType(enum.Enum):
-    f32 = "f32"
-    f16 = "f16"
-    bf16 = "bf16"
-    i32 = "i32"
-    i64 = "i64"
-    bool = "bool"
-    # extended on demand
+```text
+DType(enum.Enum): f32 | f16 | bf16 | i32 | i64 | bool | ...   # extended on demand
 ```
+
+- kind: Python class
+- fields: enumerated dtype values (`f32` / `f16` / `bf16` / `i32` / `i64` / `bool`, extended on demand)
+- constraints: none — a value enumeration, independent of `layout` / `storage`
 
 `DType` is a value enumeration, independent of `layout` / `storage`.
 
@@ -167,32 +164,38 @@ optimisation.
 
 ## 5. `TupleType`
 
-```python
-@dataclass(frozen=True)
-class TupleType(IRType):
-    """Result type of a multi-output Op. Nested TupleType is uncommon."""
-    fields: tuple[IRType, ...]
+```text
+TupleType(fields: tuple[IRType, ...])
 ```
 
-- A multi-output Op (e.g. [hir](./hir.md) `tensor.Split`) has
-  `Call.type: TupleType` whose fields correspond to the outputs. A
-  single-output Op has `Call.type: TensorType`. The typeinfer rule
-  decides; see [visitor-registry §4](./visitor-registry.md).
-- `TupleType` MUST NOT appear as the input type of any other Op. A
-  tuple is consumed only via the `tuple_get_item` Op
-  ([core-ir](./core-ir.md)). The exception for tuple-of-`Expr` formal
-  parameters (e.g. `Concat`, `Stack`) is owned by
-  [hir §1.3](./hir.md).
+- kind: Python class
+- fields:
+  - fields: the tuple's field types; the result type of a multi-output Op
+    (nested `TupleType` is uncommon)
+- constraints:
+  - A multi-output Op (e.g. [hir](./hir.md) `tensor.Split`) has
+    `Call.type: TupleType` whose fields correspond to the outputs. A
+    single-output Op has `Call.type: TensorType`. The typeinfer rule
+    decides; see [visitor-registry §4](./visitor-registry.md).
+  - `TupleType` MUST NOT appear as the input type of any other Op. A
+    tuple is consumed only via the `tuple_get_item` Op
+    ([core-ir](./core-ir.md)). The exception for tuple-of-`Expr` formal
+    parameters (e.g. `Concat`, `Stack`) is owned by
+    [hir §1.3](./hir.md).
 
 ---
 
 ## 6. `UnitType`
 
-```python
-@dataclass(frozen=True)
-class UnitType(IRType):
-    """Result type of an effect-form Call; no payload."""
+```text
+UnitType()
 ```
+
+- kind: Python class
+- fields: none — no payload
+- constraints:
+  - the result type of an effect-form Op; produces no readable value and
+    appears in Stmt position as `Evaluate(op, args)`.
 
 `UnitType` is the result type of an effect-form Op (such as
 `tir.cuda.nn.Mma`, `tir.memory.Copy`), which produces no value its
@@ -205,22 +208,23 @@ effect-form vs value-form classification is owned by
 
 ## 7. `CallableType`
 
-```python
-@dataclass(frozen=True)
-class CallableType(IRType):
-    """IR-level type of a callable Expr (e.g. ``hir.Function``)."""
-    return_type: IRType
-    parameters: tuple[IRType, ...]
+```text
+CallableType(return_type: IRType, parameters: tuple[IRType, ...])
 ```
 
-- `CallableType` is the type of any Expr that represents a callable
-  value. Today the only producer is [hir §1.1](./hir.md) `Function`.
-- `parameters` is a tuple of parameter **types**; parameter names
-  are not part of the type. Names live on `Function.params`
-  (`Var.name`) at the IR level.
-- The host-ABI counterpart in
-  [runtime §1.1](./runtime.md#11-runtimemodule) is a separate
-  construct (also named `CallableType` in `tilefoundry.runtime.module`)
-  that carries `ParamABI` records with dtype / shape / storage /
-  output_count for the loader. The two live in different layers
-  and are disambiguated by import path; do not conflate them.
+- kind: Python class
+- fields:
+  - return_type: the callable's result type
+  - parameters: a tuple of parameter types (parameter names are not part of the type)
+- constraints:
+  - `CallableType` is the type of any Expr that represents a callable
+    value. Today the only producer is [hir §1.1](./hir.md) `Function`.
+  - `parameters` is a tuple of parameter **types**; parameter names
+    are not part of the type. Names live on `Function.params`
+    (`Var.name`) at the IR level.
+  - The host-ABI counterpart in
+    [runtime §1.1](./runtime.md#11-runtimemodule) is a separate
+    construct (also named `CallableType` in `tilefoundry.runtime.module`)
+    that carries `ParamABI` records with dtype / shape / storage /
+    output_count for the loader. The two live in different layers
+    and are disambiguated by import path; do not conflate them.

--- a/docs/spec/types.md
+++ b/docs/spec/types.md
@@ -27,12 +27,11 @@ flowchart TB
 
 ## 1. `IRType`
 
-```text
-IRType()
+```python
+class IRType:      # abstract base; concrete IR types derive from it
+    ...
 ```
 
-- kind: Python class
-- fields: none — abstract base
 - constraints:
   - every `core_ir.Expr.type` is one of its derivations (`TensorType` /
     `TupleType` / `UnitType` / `CallableType`).
@@ -45,23 +44,18 @@ its derivations: `TensorType` / `TupleType` / `UnitType` /
 
 ## 2. `TensorType`
 
-```text
-TensorType(shape: tuple[ShapeDim, ...], dtype: DType, layout: Layout | ShardLayout | ComposedLayout, storage: StorageKind | None)
+```python
+# ShapeDim = int | DimVar | Expr — a static int, a bounded `DimVar` Op, or a dim-arithmetic `Expr` (see §4)
+class TensorType(IRType):
+    shape: tuple[ShapeDim, ...]                      # logical shape; invariant under sharding / storage / layout
+    dtype: DType                                     # element dtype
+    layout: Layout | ShardLayout | ComposedLayout    # member of the Layout family (see shard)
+    storage: StorageKind | None                      # abstract result residency, or umat / None
 ```
 
-- kind: Python class
-- fields:
-  - Each `shape` element is a `ShapeDim` — one of: a raw Python
-    `int` (static dim), a `DimVar` `Op` instance (bounded named
-    symbolic dim placed directly into `shape`), or a dim-arithmetic
-    `Expr` (a `Call` over `DimAdd` / `DimMul` / ... whose leaves are
-    `Constant(int)` / `DimVar` / `DimConst`).
-  - `shape` is the tensor's **logical shape**; it is invariant under
-    sharding, storage, and per-shard physical layout.
+- constraints:
   - A *scalar* is `TensorType(shape=(), ...)` — a rank-0 tensor. There
     is no separate `Scalar` type.
-  - `layout` is a member of the `Layout` family
-    (`Layout` / `ComposedLayout` / `ShardLayout`); see [shard](./shard.md).
   - `storage` is a `StorageKind` (`gmem` / `smem` / `rmem` / `host` / `tmem` /
     `umat`) or `None`. A concrete level (`gmem` / `smem` / `rmem` / `host` /
     `tmem`) is the value's **abstract result residency** — where the result tensor
@@ -72,7 +66,6 @@ TensorType(shape: tuple[ShapeDim, ...], dtype: DType, layout: Layout | ShardLayo
     unmaterialized value MUST be resolved to a concrete residency (or otherwise
     materialized) before codegen consumes it. `None` is unchanged — a tensor with
     no memory space (a shape-element scalar), distinct from `umat`.
-- constraints:
   - For plain `Layout` / `ComposedLayout`, `len(shape)` MUST equal the
     layout's logical axis count; for `ComposedLayout` this is the
     outer-layout's axis count after expansion.
@@ -96,12 +89,16 @@ dispatch is described in
 
 ## 3. `DType`
 
-```text
-DType(enum.Enum): f32 | f16 | bf16 | i32 | i64 | bool | ...   # extended on demand
+```python
+class DType(enum.Enum):    # enumerated dtype values, extended on demand
+    f32 = auto()
+    f16 = auto()
+    bf16 = auto()
+    i32 = auto()
+    i64 = auto()
+    bool = auto()
 ```
 
-- kind: Python class
-- fields: enumerated dtype values (`f32` / `f16` / `bf16` / `i32` / `i64` / `bool`, extended on demand)
 - constraints: none — a value enumeration, independent of `layout` / `storage`
 
 `DType` is a value enumeration, independent of `layout` / `storage`.
@@ -164,14 +161,11 @@ optimisation.
 
 ## 5. `TupleType`
 
-```text
-TupleType(fields: tuple[IRType, ...])
+```python
+class TupleType(IRType):
+    fields: tuple[IRType, ...]    # the tuple's field types; result type of a multi-output Op (nested TupleType is uncommon)
 ```
 
-- kind: Python class
-- fields:
-  - fields: the tuple's field types; the result type of a multi-output Op
-    (nested `TupleType` is uncommon)
 - constraints:
   - A multi-output Op (e.g. [hir](./hir.md) `tensor.Split`) has
     `Call.type: TupleType` whose fields correspond to the outputs. A
@@ -187,12 +181,11 @@ TupleType(fields: tuple[IRType, ...])
 
 ## 6. `UnitType`
 
-```text
-UnitType()
+```python
+class UnitType(IRType):    # no payload; result type of an effect-form Op
+    ...
 ```
 
-- kind: Python class
-- fields: none — no payload
 - constraints:
   - the result type of an effect-form Op; produces no readable value and
     appears in Stmt position as `Evaluate(op, args)`.
@@ -208,14 +201,12 @@ effect-form vs value-form classification is owned by
 
 ## 7. `CallableType`
 
-```text
-CallableType(return_type: IRType, parameters: tuple[IRType, ...])
+```python
+class CallableType(IRType):
+    return_type: IRType                # the callable's result type
+    parameters: tuple[IRType, ...]     # parameter types (names are not part of the type)
 ```
 
-- kind: Python class
-- fields:
-  - return_type: the callable's result type
-  - parameters: a tuple of parameter types (parameter names are not part of the type)
 - constraints:
   - `CallableType` is the type of any Expr that represents a callable
     value. Today the only producer is [hir §1.1](./hir.md) `Function`.

--- a/docs/spec/types.md
+++ b/docs/spec/types.md
@@ -88,7 +88,7 @@ class TensorType(IRType):
   shape-element form; a rank-0 tensor with a memory `StorageKind` is an
   ordinary scalar holding one element.
 
-Enforcement is owned by [tir §4](./tir.md) / [hir §3](./hir.md);
+Enforcement is owned by [tir §4](./tir.md) / [hir §1.3](./hir.md);
 dispatch is described in
 [visitor-registry](./visitor-registry.md).
 
@@ -182,7 +182,7 @@ class TupleType(IRType):
   tuple is consumed only via the `tuple_get_item` Op
   ([core-ir](./core-ir.md)). The exception for tuple-of-`Expr` formal
   parameters (e.g. `Concat`, `Stack`) is owned by
-  [hir §2.2](./hir.md).
+  [hir §1.3](./hir.md).
 
 ---
 
@@ -199,7 +199,7 @@ class UnitType(IRType):
 consumers can read; in Stmt position such an Op appears as
 `Evaluate(op, args)` ([tir §2.2](./tir.md#22-evaluate)). The
 effect-form vs value-form classification is owned by
-[core-ir §4](./core-ir.md).
+[core-ir §2.3](./core-ir.md).
 
 ---
 
@@ -214,7 +214,7 @@ class CallableType(IRType):
 ```
 
 - `CallableType` is the type of any Expr that represents a callable
-  value. Today the only producer is [hir §1](./hir.md) `Function`.
+  value. Today the only producer is [hir §1.1](./hir.md) `Function`.
 - `parameters` is a tuple of parameter **types**; parameter names
   are not part of the type. Names live on `Function.params`
   (`Var.name`) at the IR level.

--- a/docs/spec/visitor-mutator.md
+++ b/docs/spec/visitor-mutator.md
@@ -44,13 +44,8 @@ is injected by overriding `visit_<ClassName>` in subclasses.
 - `visit_Evaluate(self, stmt: Evaluate) -> Stmt` for `Evaluate`,
 - and so on.
 
-```python
-def visit(self, node):
-    method = getattr(self, f"visit_{type(node).__name__}", None)
-    if method is not None:
-        return method(node)
-    return self.generic_visit(node)
-```
+`visit(node)` looks up `visit_<type(node).__name__>` on the subclass and calls
+it, falling back to `generic_visit(node)` when no such override exists.
 
 - **Most-specific wins.** `Call` is a subclass of `Expr`, but with
   both `visit_Call` and `visit_Expr` defined, `visit_Call` wins —
@@ -128,17 +123,6 @@ Identity preservation matters for three reasons:
    downstream work via `new_expr is old_expr`.
 3. **Cache validity.** `typeinfer` / cost caches keyed on Expr
    identity remain valid for unchanged nodes.
-
-Example — rewrite every `Add` to `Sub`:
-
-```python
-class AddToSub(ExprMutator):
-    def visit_Call(self, call: Call) -> Expr:
-        if isinstance(call.target, hir.math.Add):
-            new_args = tuple(self.visit(a) for a in call.args)
-            return Call(target=hir.math.Sub(), args=new_args, type=call.type)
-        return self.generic_visit(call)
-```
 
 A `visit_Call` override MUST itself respect identity preservation:
 the unchanged branch routes through `generic_visit(call)` rather
@@ -225,14 +209,8 @@ Stmt position they appear as `Evaluate(callable=op, args)` so the
 invocation can sit in `Sequential` body position. Passes and visitors
 MUST match on `Evaluate` and dispatch on `type(callable)`:
 
-```python
-from tilefoundry.ir.tir.stmts import Evaluate
-from tilefoundry.ir.tir.memory.copy import Copy
-
-def visit_Evaluate(self, stmt):
-    if isinstance(stmt.callable, Copy):
-        ...
-```
+a `visit_Evaluate(self, stmt)` override branches on `type(stmt.callable)`
+(e.g. `Copy`).
 
 `StmtVisitor` / `StmtMutator` recognise `Evaluate` as a
 leaf-in-stmt-tree — `_stmt_children(Evaluate)` is empty.

--- a/docs/spec/visitor-mutator.md
+++ b/docs/spec/visitor-mutator.md
@@ -70,6 +70,16 @@ does not depend on Python-version-specific dispatch behaviour.
 Read-only Expr-tree traversal. `T` is user-chosen (`None` for
 side-effect collection, `set[Var]` for free-var analysis, etc.).
 
+```text
+ExprVisitor[T]:  visit(expr: Expr) -> T;  generic_visit(expr: Expr) -> T
+```
+
+- kind: Python class
+- fields: none — read-only Expr traversal; `T` is the user-chosen visit result type
+- constraints:
+  - `generic_visit` recurses into all child Exprs and returns `None` by default;
+    subclasses MAY override to aggregate.
+
 ```python
 from typing import Generic, TypeVar
 from tilefoundry.ir.core import Expr, Call, Var, Constant, Tuple
@@ -120,6 +130,16 @@ Recursive Expr rewrite returning the same node kind. Core invariant:
 **when no child changed, return the original node** (identity
 preservation).
 
+```text
+ExprMutator:  visit(expr: Expr) -> Expr;  generic_visit(expr: Expr) -> Expr
+```
+
+- kind: Python class
+- fields: none — identity-preserving Expr rewrite
+- constraints:
+  - When no child changed, `generic_visit` returns the original node (identity
+    preservation).
+
 ```python
 class ExprMutator:
     """Identity-preserving Expr rewrite."""
@@ -168,6 +188,18 @@ than `return call`, so child Exprs are still recursed.
 
 Same shape as the Expr family, but for the Stmt tree.
 
+```text
+StmtVisitor[T]:  visit(stmt: Stmt) -> T
+StmtMutator:     visit(stmt: Stmt) -> Stmt
+```
+
+- kind: Python class
+- fields: none — Stmt-tree traversal (`StmtVisitor`) / identity-preserving Stmt rewrite (`StmtMutator`)
+- constraints:
+  - `StmtMutator`'s identity-preservation invariant is identical to `ExprMutator`.
+  - `StmtVisitor` / `StmtMutator` do not descend into Expr fields embedded in
+    Stmts; those are visited only through `StmtExprMutator` (§6).
+
 ```python
 from tilefoundry.ir.tir import Stmt, Sequential, PrimFunction
 from tilefoundry.ir.tir.stmts import LetStmt, For, While, If, MeshScope, Return, Evaluate
@@ -208,6 +240,15 @@ embedded in Stmts — `For.start` / `For.stop` / `For.step` /
 Composite: rewrite the Stmt tree **and** descend into the Expr
 fields embedded in Stmts. This is the most common combination
 (every lowering / simplification / structural rewrite needs it).
+
+```text
+StmtExprMutator(StmtMutator, ExprMutator):  visit_stmt(stmt: Stmt) -> Stmt;  visit_expr(expr: Expr) -> Expr
+```
+
+- kind: Python class
+- fields: none — rewrites Stmts and the Exprs embedded in their Expr-typed fields
+- constraints:
+  - The rewrite scope is **embedded value Exprs**, not binding `Var`s.
 
 ```python
 class StmtExprMutator(StmtMutator, ExprMutator):

--- a/docs/spec/visitor-mutator.md
+++ b/docs/spec/visitor-mutator.md
@@ -70,38 +70,15 @@ does not depend on Python-version-specific dispatch behaviour.
 Read-only Expr-tree traversal. `T` is user-chosen (`None` for
 side-effect collection, `set[Var]` for free-var analysis, etc.).
 
-```text
-ExprVisitor[T]:  visit(expr: Expr) -> T;  generic_visit(expr: Expr) -> T
+```python
+class ExprVisitor(Generic[T]):                     # read-only Expr traversal; T is the user-chosen visit result type
+    def visit(self, expr: Expr) -> T: ...          # dispatch to visit_<Type> else generic_visit
+    def generic_visit(self, expr: Expr) -> T: ...  # recurse child Exprs; returns None by default
 ```
 
-- kind: Python class
-- fields: none — read-only Expr traversal; `T` is the user-chosen visit result type
 - constraints:
   - `generic_visit` recurses into all child Exprs and returns `None` by default;
     subclasses MAY override to aggregate.
-
-```python
-from typing import Generic, TypeVar
-from tilefoundry.ir.core import Expr, Call, Var, Constant, Tuple
-
-T = TypeVar("T")
-
-class ExprVisitor(Generic[T]):
-    """Read-only Expr traversal. Subclasses override visit_<ClassName>."""
-
-    def visit(self, expr: Expr) -> T:
-        method = getattr(self, f"visit_{type(expr).__name__}", None)
-        if method is not None:
-            return method(expr)
-        return self.generic_visit(expr)
-
-    def generic_visit(self, expr: Expr) -> T:
-        """Default: recurse into all child Exprs; return None.
-        Subclasses MAY override to aggregate."""
-        for child in _expr_children(expr):
-            self.visit(child)
-        return None  # type: ignore[return-value]
-```
 
 `_expr_children(expr)` enumerates child Exprs of any Expr node by
 fixed field order. The mapping is module-local and is the single
@@ -130,32 +107,15 @@ Recursive Expr rewrite returning the same node kind. Core invariant:
 **when no child changed, return the original node** (identity
 preservation).
 
-```text
-ExprMutator:  visit(expr: Expr) -> Expr;  generic_visit(expr: Expr) -> Expr
+```python
+class ExprMutator:                                    # identity-preserving Expr rewrite
+    def visit(self, expr: Expr) -> Expr: ...          # dispatch to visit_<Type> else generic_visit
+    def generic_visit(self, expr: Expr) -> Expr: ...  # recurse children; return original node when no child changed (identity preservation)
 ```
 
-- kind: Python class
-- fields: none — identity-preserving Expr rewrite
 - constraints:
   - When no child changed, `generic_visit` returns the original node (identity
     preservation).
-
-```python
-class ExprMutator:
-    """Identity-preserving Expr rewrite."""
-
-    def visit(self, expr: Expr) -> Expr:
-        method = getattr(self, f"visit_{type(expr).__name__}", None)
-        if method is not None:
-            return method(expr)
-        return self.generic_visit(expr)
-
-    def generic_visit(self, expr: Expr) -> Expr:
-        new_children = tuple(self.visit(c) for c in _expr_children(expr))
-        if all(nc is oc for nc, oc in zip(new_children, _expr_children(expr))):
-            return expr                     # identity preservation
-        return _rebuild_expr(expr, new_children)
-```
 
 `_rebuild_expr(expr, new_children)` constructs a new Expr of the
 same subclass while preserving non-child fields (`type`, `source`).
@@ -188,32 +148,20 @@ than `return call`, so child Exprs are still recursed.
 
 Same shape as the Expr family, but for the Stmt tree.
 
-```text
-StmtVisitor[T]:  visit(stmt: Stmt) -> T
-StmtMutator:     visit(stmt: Stmt) -> Stmt
+```python
+class StmtVisitor(Generic[T]):                     # read-only Stmt-tree traversal
+    def visit(self, stmt: Stmt) -> T: ...          # dispatch to visit_<Type> else generic_visit
+    def generic_visit(self, stmt: Stmt) -> T: ...  # recurse child Stmts
+
+class StmtMutator:                                    # identity-preserving Stmt rewrite
+    def visit(self, stmt: Stmt) -> Stmt: ...          # dispatch to visit_<Type> else generic_visit
+    def generic_visit(self, stmt: Stmt) -> Stmt: ...  # recurse child Stmts; invariant identical to ExprMutator
 ```
 
-- kind: Python class
-- fields: none — Stmt-tree traversal (`StmtVisitor`) / identity-preserving Stmt rewrite (`StmtMutator`)
 - constraints:
   - `StmtMutator`'s identity-preservation invariant is identical to `ExprMutator`.
   - `StmtVisitor` / `StmtMutator` do not descend into Expr fields embedded in
     Stmts; those are visited only through `StmtExprMutator` (§6).
-
-```python
-from tilefoundry.ir.tir import Stmt, Sequential, PrimFunction
-from tilefoundry.ir.tir.stmts import LetStmt, For, While, If, MeshScope, Return, Evaluate
-
-class StmtVisitor(Generic[T]):
-    def visit(self, stmt: Stmt) -> T: ...
-    def generic_visit(self, stmt: Stmt) -> T: ...
-    # visit_Sequential / visit_For / visit_If / visit_Evaluate / ...
-
-class StmtMutator:
-    def visit(self, stmt: Stmt) -> Stmt: ...
-    def generic_visit(self, stmt: Stmt) -> Stmt: ...
-    # identity-preservation invariant identical to ExprMutator
-```
 
 `_stmt_children(stmt)` enumerates child Stmts only (Expr fields
 come back via `StmtExprMutator`):
@@ -241,29 +189,15 @@ Composite: rewrite the Stmt tree **and** descend into the Expr
 fields embedded in Stmts. This is the most common combination
 (every lowering / simplification / structural rewrite needs it).
 
-```text
-StmtExprMutator(StmtMutator, ExprMutator):  visit_stmt(stmt: Stmt) -> Stmt;  visit_expr(expr: Expr) -> Expr
+```python
+class StmtExprMutator(StmtMutator, ExprMutator):      # rewrite Stmts and the Exprs embedded in their Expr-typed fields
+    def visit_stmt(self, stmt: Stmt) -> Stmt: ...     # rewrite the Stmt tree via StmtMutator
+    def visit_expr(self, expr: Expr) -> Expr: ...     # rewrite embedded value Exprs via ExprMutator
+    def generic_visit(self, stmt: Stmt) -> Stmt: ...  # StmtMutator recurse, then rewrite each Stmt's Expr fields
 ```
 
-- kind: Python class
-- fields: none — rewrites Stmts and the Exprs embedded in their Expr-typed fields
 - constraints:
   - The rewrite scope is **embedded value Exprs**, not binding `Var`s.
-
-```python
-class StmtExprMutator(StmtMutator, ExprMutator):
-    """Rewrite Stmts and the Exprs embedded in their Expr-typed fields."""
-
-    def visit_stmt(self, stmt: Stmt) -> Stmt:
-        return StmtMutator.visit(self, stmt)
-
-    def visit_expr(self, expr: Expr) -> Expr:
-        return ExprMutator.visit(self, expr)
-
-    def generic_visit(self, stmt: Stmt) -> Stmt:
-        new_stmt = StmtMutator.generic_visit(self, stmt)
-        return _rewrite_stmt_exprs(new_stmt, self.visit_expr)
-```
 
 `_rewrite_stmt_exprs(stmt, fn)` enumerates the Expr fields of each
 Stmt subclass, applies `fn` with identity preservation, and rebuilds

--- a/docs/spec/visitor-mutator.md
+++ b/docs/spec/visitor-mutator.md
@@ -265,7 +265,7 @@ leaf-in-stmt-tree — `_stmt_children(Evaluate)` is empty.
 that is a `SymbolRef`) as Expr fields, so Expr-level rewrites still
 reach them. A value-form `Call` to a TIR effect-form Op in Stmt
 position, instead of `Evaluate(op, args)`, is malformed IR
-([tir §2.2](./tir.md#22-evaluate)).
+([tir §1.4](./tir.md#14-evaluate)).
 
 ## 8. Implementation location
 

--- a/docs/spec/visitor-registry.md
+++ b/docs/spec/visitor-registry.md
@@ -364,17 +364,6 @@ def register_codegen_<target>(cls: type[Op] | type[Stmt]): ...   # decorator: re
   - each target has its own registry; keys may be `type[Op]` (TIR-owned Expr Op
     handlers) or `type[Stmt]`.
 
-```python
-codegen_cuda_registry: AnalysisRegistry[type] = AnalysisRegistry("codegen_cuda")
-codegen_cpu_registry:  AnalysisRegistry[type] = AnalysisRegistry("codegen_cpu")
-
-def register_codegen_cuda(cls: type[Op] | type[Stmt]):
-    def decorator(fn):
-        codegen_cuda_registry.register(cls, fn)
-        return fn
-    return decorator
-```
-
 Each target has its own registry. Keys may be `type[Op]` (TIR-owned
 Expr Op handlers — `tir.memory.AllocTensor` /
 `tir.memory.{PtrOf,MemorySpan,TensorView}` / `tir.scalar.*`) or

--- a/docs/spec/visitor-registry.md
+++ b/docs/spec/visitor-registry.md
@@ -150,6 +150,24 @@ through any registry — their semantic rules are owned by
 All four instances share one registry implementation. It is a
 class-keyed dict with a duplicate-registration guard.
 
+```text
+AnalysisRegistry[Key](name: str):  register(cls, fn) -> None;  lookup(cls) -> Callable | None;  has(cls) -> bool
+```
+
+- kind: Python class
+- fields:
+  - name: the registry name (used in duplicate-registration errors)
+- constraints:
+  - A registry MUST raise on double registration of the same class;
+    subclasses do not inherit a parent's handler. Each concrete
+    `Op` / `Stmt` subclass either registers itself explicitly or is
+    caught by the visitor's `generic_visit` fallback.
+  - `lookup` returns `None` on a miss. The caller decides whether a
+    miss is an error or a fallback. `VerifyVisitor` falls back to
+    `generic_visit` on a miss (an unregistered Stmt simply has no
+    custom verify rule); `TypeInferContext` raises (every Op call
+    MUST have a typeinfer rule).
+
 ```python
 from typing import Callable, Generic, TypeVar
 from tilefoundry.ir.core import Op
@@ -176,18 +194,6 @@ class AnalysisRegistry(Generic[Key]):
     def has(self, cls: Key) -> bool:
         return cls in self._map
 ```
-
-Invariants:
-
-- A registry MUST raise on double registration of the same class;
-  subclasses do not inherit a parent's handler. Each concrete
-  `Op` / `Stmt` subclass either registers itself explicitly or is
-  caught by the visitor's `generic_visit` fallback.
-- `lookup` returns `None` on a miss. The caller decides whether a
-  miss is an error or a fallback. `VerifyVisitor` falls back to
-  `generic_visit` on a miss (an unregistered Stmt simply has no
-  custom verify rule); `TypeInferContext` raises (every Op call
-  MUST have a typeinfer rule).
 
 ## 4. Instance 1 — `typeinfer`
 
@@ -282,12 +288,17 @@ expression structure and needs to recompute types, it calls
 A second registry exposes each op's access relation as a **forward**
 service that typeinfer consumes. Its result carrier is:
 
-```python
-@dataclass(frozen=True)
-class AccessRelationResult:
-    domain: isl.set
-    maps: tuple[isl.map, ...]
+```text
+AccessRelationResult(domain: isl.set, maps: tuple[isl.map, ...])
 ```
+
+- kind: Python class
+- fields:
+  - domain: the op's bounded iteration domain as an `isl.set`
+  - maps: one access `isl.map` per boundary value, in boundary order (inputs then outputs)
+- constraints:
+  - the carrier holds **no** tensor shape; the output shape is typeinfer-side
+    data (see [analysis §1.1](./analysis.md#11-relation-derived-type-behavior)).
 
 #### `domain`
 

--- a/docs/spec/visitor-registry.md
+++ b/docs/spec/visitor-registry.md
@@ -135,7 +135,7 @@ instances split as follows:
 | Instance | Op-branch handler | Stmt-branch handler | Notes |
 |---|---|---|---|
 | **typeinfer** | `(Call, TypeInferContext) -> TensorType \| TupleType` | — | Value-producing only |
-| **verify** | — | `(Stmt, VerifyContext) -> None` | Effect-side constraints; for `Evaluate(op, args)`, dispatch keys on the Op class — see [§4](#4-instance-2--verify) |
+| **verify** | — | `(Stmt, VerifyContext) -> None` | Effect-side constraints; for `Evaluate(op, args)`, dispatch keys on the Op class — see [§5](#5-instance-2--verify) |
 | **codegen_\<target\>** | `(Call, CodegenContext) -> str` | `(Stmt, CodegenContext) -> None` | Both sides are emitted |
 | **cost** (placeholder) | `(Call, CostContext) -> Cost` | `(Stmt, CostContext) -> Cost` (optional) | Not implemented in MVP |
 

--- a/docs/spec/visitor-registry.md
+++ b/docs/spec/visitor-registry.md
@@ -363,7 +363,7 @@ registry implementation. The stable IR shape is `Evaluate(op, args)`;
 the stable IR does not wrap a value-form `Call` inside `Evaluate`. See
 [visitor-mutator §7](./visitor-mutator.md)
 for the matching visitor entry-form contract and
-[tir §2.2](./tir.md#22-evaluate) for the wrapper definition.
+[tir §1.4](./tir.md#14-evaluate) for the wrapper definition.
 
 ```python
 # src/tilefoundry/ir/tir/memory/copy.py

--- a/docs/spec/visitor-registry.md
+++ b/docs/spec/visitor-registry.md
@@ -302,7 +302,7 @@ One access `isl.map` per boundary value, in boundary order — inputs
 first, then outputs — each mapping the iteration domain to that tensor's
 index space. The carrier holds **no** tensor shape: the output shape is
 typeinfer-side data, not part of the relation (see
-[hir §3.1](./hir.md#31-relation-driven-type-validity)).
+[analysis §1.1](./analysis.md#11-relation-derived-type-behavior)).
 
 Registry + decorator:
 

--- a/docs/spec/visitor-registry.md
+++ b/docs/spec/visitor-registry.md
@@ -85,15 +85,8 @@ class StmtVisitor(Generic[T]):
 
 # VerifyVisitor is the derived class that holds a registry reference:
 class VerifyVisitor(StmtVisitor[None]):
-    def __init__(self, ctx: VerifyContext, registry=verify_stmt_registry):
-        self.ctx = ctx
-        self.registry = registry          # explicit binding point
-
-    def generic_visit(self, stmt: Stmt) -> None:
-        fn = self.registry.lookup(type(stmt))
-        if fn is not None:
-            fn(stmt, self.ctx)
-        super().generic_visit(stmt)
+    def __init__(self, ctx: VerifyContext, registry=verify_stmt_registry): ...   # explicit binding point
+    def generic_visit(self, stmt: Stmt) -> None: ...   # look up type(stmt) in the registry, then recurse
 ```
 
 `@register_verify_stmt(Copy)` writes a handler into
@@ -150,13 +143,14 @@ through any registry — their semantic rules are owned by
 All four instances share one registry implementation. It is a
 class-keyed dict with a duplicate-registration guard.
 
-```text
-AnalysisRegistry[Key](name: str):  register(cls, fn) -> None;  lookup(cls) -> Callable | None;  has(cls) -> bool
+```python
+class AnalysisRegistry(Generic[Key]):          # Key = type[Op] or type[Stmt]
+    def __init__(self, name: str): ...
+    def register(self, cls: Key, fn: Callable) -> None: ...   # raises on duplicate
+    def lookup(self, cls: Key) -> Callable | None: ...        # None on miss
+    def has(self, cls: Key) -> bool: ...
 ```
 
-- kind: Python class
-- fields:
-  - name: the registry name (used in duplicate-registration errors)
 - constraints:
   - A registry MUST raise on double registration of the same class;
     subclasses do not inherit a parent's handler. Each concrete
@@ -168,112 +162,53 @@ AnalysisRegistry[Key](name: str):  register(cls, fn) -> None;  lookup(cls) -> Ca
     custom verify rule); `TypeInferContext` raises (every Op call
     MUST have a typeinfer rule).
 
-```python
-from typing import Callable, Generic, TypeVar
-from tilefoundry.ir.core import Op
-from tilefoundry.ir.tir import Stmt
-
-Key = TypeVar("Key")            # type[Op] or type[Stmt]
-
-class AnalysisRegistry(Generic[Key]):
-    """Class → handler dict. Double registration raises;
-    lookup miss returns None."""
-
-    def __init__(self, name: str):
-        self.name = name
-        self._map: dict[Key, Callable] = {}
-
-    def register(self, cls: Key, fn: Callable) -> None:
-        if cls in self._map:
-            raise RuntimeError(f"{self.name}: {cls.__name__} already registered")
-        self._map[cls] = fn
-
-    def lookup(self, cls: Key) -> Callable | None:
-        return self._map.get(cls)
-
-    def has(self, cls: Key) -> bool:
-        return cls in self._map
-```
-
 ## 4. Instance 1 — `typeinfer`
 
 Context:
 
 ```python
-from dataclasses import dataclass, field
-from tilefoundry.ir.core import Module, Expr, Call, Var, Constant, Tuple
-from tilefoundry.ir.types import TensorType, TupleType
-
 @dataclass
 class TypeInferContext:
-    module: Module
-    cache: dict[Expr, TensorType | TupleType] = field(default_factory=dict)
-
-    def type_of(self, expr: Expr) -> TensorType | TupleType:
-        """Lazy compute + cache; supports recursive child queries."""
-        if expr not in self.cache:
-            self.cache[expr] = self._compute(expr)
-        return self.cache[expr]
-
-    def _compute(self, expr: Expr) -> TensorType | TupleType:
-        if isinstance(expr, Constant):
-            return _constant_type(expr.value)
-        if isinstance(expr, Var):
-            return expr.type
-        if isinstance(expr, Call):
-            fn = typeinfer_registry.lookup(type(expr.target))
-            if fn is None:
-                self.error(expr, f"no typeinfer registered for {type(expr.target).__name__}")
-            return fn(expr, self)
-        if isinstance(expr, Tuple):
-            return TupleType(fields=tuple(self.type_of(f) for f in expr.fields))
-        raise AssertionError(f"unreachable Expr subclass {type(expr).__name__}")
-
-    def error(self, node, msg: str): ...   # see §7
+    module: Module                              # the Module being type-checked
+    cache: dict[Expr, TensorType | TupleType]   # memoized Expr → TensorType | TupleType
+    def type_of(self, expr: Expr) -> TensorType | TupleType: ...   # lazy-compute + cache a node's type; supports recursive child queries
+    def error(self, node, msg: str): ...        # raise a constraint failure — see §7
 ```
+
+- constraints:
+  - a `Call`'s type comes from `typeinfer_registry.lookup(type(target))`; an
+    unregistered Op call routes through `ctx.error`.
 
 Registry + decorator:
 
 ```python
-typeinfer_registry: AnalysisRegistry[type[Op]] = AnalysisRegistry("typeinfer")
-
-def register_typeinfer(op_cls: type[Op]):
-    def decorator(fn):
-        typeinfer_registry.register(op_cls, fn)
-        return fn
-    return decorator
+typeinfer_registry: AnalysisRegistry[type[Op]]   # module-level registry keyed by type[Op]
+def register_typeinfer(op_cls: type[Op]): ...     # decorator: register a typeinfer handler for one Op class
 ```
+
+- constraints:
+  - handler signature is `(call: Call, ctx: TypeInferContext) -> TensorType | TupleType`.
 
 Handler signature: `(call: Call, ctx: TypeInferContext) -> TensorType | TupleType`.
 
 ```python
-# src/tilefoundry/ir/hir/math/binary.py
+# a typeinfer handler pins the (call, ctx) -> type shape:
 @register_typeinfer(Binary)
-def _(call: Call, ctx: TypeInferContext) -> TensorType:
-    lhs = ctx.type_of(call.args[0])
-    rhs = ctx.type_of(call.args[1])
-    if lhs.dtype != rhs.dtype:
-        ctx.error(call, "dtype mismatch")
-    return TensorType(
-        shape=_broadcast(lhs.shape, rhs.shape),
-        dtype=lhs.dtype,
-        layout=_merge_layout(lhs.layout, rhs.layout),
-        storage=_merge_storage(lhs.storage, rhs.storage),
-    )
+def _(call: Call, ctx: TypeInferContext) -> TensorType: ...
 ```
 
 Visitor:
 
 ```python
-from tilefoundry.ir.visitor import ExprVisitor
-
 class TypeInferVisitor(ExprVisitor[TensorType | TupleType]):
-    """Walks an HIR Function body, delegates to ctx.type_of for each Expr,
-    fills Expr.type along the way."""
-    def __init__(self, ctx: TypeInferContext): self.ctx = ctx
-    def visit_Call(self, call: Call): return self.ctx.type_of(call)
-    def visit_Var(self, var: Var):    return var.type
+    def __init__(self, ctx: TypeInferContext): ...   # ctx carries the cache and helpers
+    def visit_Call(self, call: Call): ...            # delegate to ctx.type_of
+    def visit_Var(self, var: Var): ...               # return the Var's type
 ```
+
+- constraints:
+  - walks an HIR `Function` body, delegates each `Expr` to `ctx.type_of`, and
+    fills `Expr.type` along the way.
 
 Lifecycle: parser builds a `TypeInferContext` and runs eager
 typeinfer at parse time (see [parser](./parser.md)). A `Module`
@@ -288,14 +223,13 @@ expression structure and needs to recompute types, it calls
 A second registry exposes each op's access relation as a **forward**
 service that typeinfer consumes. Its result carrier is:
 
-```text
-AccessRelationResult(domain: isl.set, maps: tuple[isl.map, ...])
+```python
+@dataclass
+class AccessRelationResult:
+    domain: isl.set             # the op's bounded iteration domain as an isl.set
+    maps: tuple[isl.map, ...]   # one access isl.map per boundary value, in boundary order (inputs then outputs)
 ```
 
-- kind: Python class
-- fields:
-  - domain: the op's bounded iteration domain as an `isl.set`
-  - maps: one access `isl.map` per boundary value, in boundary order (inputs then outputs)
 - constraints:
   - the carrier holds **no** tensor shape; the output shape is typeinfer-side
     data (see [analysis §1.1](./analysis.md#11-relation-derived-type-behavior)).
@@ -318,13 +252,8 @@ typeinfer-side data, not part of the relation (see
 Registry + decorator:
 
 ```python
-type_relation_registry: AnalysisRegistry[type[Op]] = AnalysisRegistry("type_relation")
-
-def register_type_relation(op_cls: type[Op]):
-    def decorator(fn):
-        type_relation_registry.register(op_cls, fn)
-        return fn
-    return decorator
+type_relation_registry: AnalysisRegistry[type[Op]]     # forward relation registry keyed by type[Op]
+def register_type_relation(op_cls: type[Op]): ...       # decorator: register a type_relation handler for one Op class
 ```
 
 Handler signature:
@@ -342,22 +271,23 @@ Context (extends `TypeInferContext` to share the type-of cache):
 
 ```python
 @dataclass
-class VerifyContext(TypeInferContext):
-    """Verify shares typeinfer's cache and adds a mesh-scope stack."""
-    mesh_stack: list = field(default_factory=list)
+class VerifyContext(TypeInferContext):   # inherits module / cache / type_of
+    mesh_stack: list                     # active mesh-scope stack maintained during the walk
 ```
+
+- constraints:
+  - shares typeinfer's type-of cache; adds a mesh-scope stack.
 
 Registry + decorator:
 
 ```python
-verify_stmt_registry: AnalysisRegistry[type] = AnalysisRegistry("verify_stmt")
-
-def register_verify_stmt(cls: type):
-    def decorator(fn):
-        verify_stmt_registry.register(cls, fn)
-        return fn
-    return decorator
+verify_stmt_registry: AnalysisRegistry[type]   # module-level registry keyed by Stmt/Op class
+def register_verify_stmt(cls: type): ...        # decorator: register a verify handler keyed on the Stmt/Op class
 ```
+
+- constraints:
+  - handler signature is `(node, ctx: VerifyContext) -> None`; failure routes
+    through `ctx.error(node, msg)`, which raises `VerifyError`.
 
 Handler signature: `(node, ctx: VerifyContext) -> None`. Failure
 routes through `ctx.error(node, msg)` which raises `VerifyError`.
@@ -377,15 +307,9 @@ for the matching visitor entry-form contract and
 [tir §1.4](./tir.md#14-evaluate) for the wrapper definition.
 
 ```python
-# src/tilefoundry/ir/tir/memory/copy.py
+# a verify handler keys on the Op class and returns None:
 @register_verify_stmt(Copy)
-def _(call: Call, ctx: VerifyContext) -> None:
-    src = ctx.type_of(call.args[0])
-    dst = ctx.type_of(call.args[1])
-    if src.shape != dst.shape:
-        ctx.error(call, "shape mismatch in Copy")
-    if src.dtype != dst.dtype:
-        ctx.error(call, "dtype mismatch in Copy")
+def _(call: Call, ctx: VerifyContext) -> None: ...
 ```
 
 Per-stmt rules (shape / dtype / layout constraints) belong in
@@ -394,32 +318,16 @@ Per-stmt rules (shape / dtype / layout constraints) belong in
 Visitor:
 
 ```python
-from tilefoundry.ir.visitor import StmtVisitor
-
 class VerifyVisitor(StmtVisitor[None]):
-    """Recursively walks PrimFunction.body; per Stmt subclass tries the registry.
-    The registry is injected via __init__, not baked into StmtVisitor (§1.1)."""
-
-    def __init__(self, ctx: VerifyContext, registry: AnalysisRegistry = verify_stmt_registry):
-        self.ctx = ctx
-        self.registry = registry
-
-    def generic_visit(self, stmt: Stmt) -> None:
-        fn = self.registry.lookup(type(stmt))
-        if fn is not None:
-            fn(stmt, self.ctx)
-        # Unregistered Stmts (control flow / LetStmt / Sequential / …) just
-        # recurse via the base class. Adding a custom verify rule for one of
-        # them is a register_verify_stmt call away.
-        super().generic_visit(stmt)
-
-    def visit_MeshScope(self, stmt):
-        self.ctx.mesh_stack.append(stmt.mesh)
-        try:
-            super().generic_visit(stmt)
-        finally:
-            self.ctx.mesh_stack.pop()
+    def __init__(self, ctx: VerifyContext, registry: AnalysisRegistry = verify_stmt_registry): ...   # ctx + injected verify registry
+    def generic_visit(self, stmt: Stmt) -> None: ...   # try the registry, fall back to base recursion on a miss
+    def visit_MeshScope(self, stmt): ...               # push/pop the mesh-scope stack around recursion
 ```
+
+- constraints:
+  - recurses `PrimFunction.body`; per Stmt subclass tries the registry, falling
+    back to `generic_visit` on a miss. The registry is injected via `__init__`,
+    not baked into `StmtVisitor` (see [§1.1](#11-registry-is-not-a-property-of-stmtvisitor--exprvisitor)).
 
 **Unregistered semantics.** A Stmt subclass without
 `register_verify_stmt` does not error — `VerifyVisitor` simply
@@ -435,14 +343,26 @@ Context (skeleton; per-target fields live in [target](./target.md)):
 ```python
 @dataclass
 class CodegenContext:
-    module: Module
+    module: Module              # the Module being emitted
     output: list[str]           # accumulated code fragments
     symbol_table: dict          # Var → emitted identifier
-    indent: int = 0
+    indent: int = 0             # current indent level
     # target-specific fields owned by target.md
 ```
 
+- constraints:
+  - skeleton only; per-target fields and helpers are owned by [target](./target.md).
+
 Registry per target:
+
+```python
+codegen_<target>_registry: AnalysisRegistry[type]        # one registry per target
+def register_codegen_<target>(cls: type[Op] | type[Stmt]): ...   # decorator: register a per-target handler
+```
+
+- constraints:
+  - each target has its own registry; keys may be `type[Op]` (TIR-owned Expr Op
+    handlers) or `type[Stmt]`.
 
 ```python
 codegen_cuda_registry: AnalysisRegistry[type] = AnalysisRegistry("codegen_cuda")
@@ -469,45 +389,26 @@ Handler signatures:
   one or more lines into `ctx.output`.
 
 ```python
-# src/tilefoundry/codegen/cuda/tir/scalar/relu.py
+# Op-branch handler returns a code fragment; Stmt-branch handler emits lines:
 @register_codegen_cuda(TirScalarReLU)
-def _(call: Call, ctx: CodegenContext) -> str:
-    x = ctx.emit_expr(call.args[0])
-    return f"tilefoundry::ReLUOp{{}}({x})"
-
-# src/tilefoundry/codegen/cuda/tir/memory/copy.py
+def _(call: Call, ctx: CodegenContext) -> str: ...
 @register_codegen_cuda(Copy)
-def _(stmt: Copy, ctx: CodegenContext) -> None:
-    src = ctx.emit_expr(stmt.source)
-    dst = ctx.emit_expr(stmt.destination)
-    ctx.emit_line(f"cute::copy({src}, {dst});")
+def _(stmt: Copy, ctx: CodegenContext) -> None: ...
 ```
 
 Visitor:
 
 ```python
 class CodegenVisitor:
-    """Combines the StmtVisitor + ExprVisitor sides; routes per node class
-    through the per-target registry."""
-
-    def __init__(self, ctx: CodegenContext, target: str):
-        self.ctx = ctx
-        self.registry = _codegen_registry_for(target)
-
-    def emit_stmt(self, stmt: Stmt) -> None:
-        fn = self.registry.lookup(type(stmt))
-        if fn is not None:
-            fn(stmt, self.ctx); return
-        self._emit_default_stmt(stmt)   # control flow, default emit owned by target.md
-
-    def emit_expr(self, expr: Expr) -> str:
-        if isinstance(expr, Call):
-            fn = self.registry.lookup(type(expr.target))
-            if fn is None:
-                raise RuntimeError(f"no codegen for Op {type(expr.target).__name__} on target")
-            return fn(expr, self.ctx)
-        return self._emit_default_expr(expr)
+    def __init__(self, ctx: CodegenContext, target: str): ...   # target selects the per-target registry
+    def emit_stmt(self, stmt: Stmt) -> None: ...   # Stmt-side entry; unregistered Stmt falls back to target default emit
+    def emit_expr(self, expr: Expr) -> str: ...    # Op-side entry; unregistered Op raises
 ```
+
+- constraints:
+  - combines the `StmtVisitor` + `ExprVisitor` sides; routes per node class through
+    the per-target registry; an unregistered Op raises, an unregistered Stmt falls
+    back to the target-owned default emit.
 
 User extension path — adding a new Stmt `MyIntrinsic`:
 
@@ -529,23 +430,21 @@ handlers**.
 ```python
 @dataclass
 class Cost:
-    flops: int
-    bytes: int
+    flops: int     # the cost carrier's flop count
+    bytes: int     # the cost carrier's byte count
 
 @dataclass
-class CostContext(TypeInferContext): ...
+class CostContext(TypeInferContext): ...           # TypeInferContext subclass reserved for cost state
 
-costmodel_registry: AnalysisRegistry[type[Op]] = AnalysisRegistry("costmodel")
+costmodel_registry: AnalysisRegistry[type[Op]]     # the cost registry (MVP registers no handlers)
+def register_costmodel(op_cls: type[Op]): ...       # decorator: register a cost handler for one Op class
 
-def register_costmodel(op_cls: type[Op]):
-    def decorator(fn):
-        costmodel_registry.register(op_cls, fn)
-        return fn
-    return decorator
-
-class CostVisitor(ExprVisitor[Cost]):
-    ...
+class CostVisitor(ExprVisitor[Cost]): ...          # the cost walker
 ```
+
+- constraints:
+  - placeholder: the interface signature is reserved for future extension; MVP
+    registers no handlers and cost-based decision rules are out of scope here.
 
 Only the interface signature is reserved for future extension.
 Cost-based decision rules are not in scope here.
@@ -554,17 +453,13 @@ Cost-based decision rules are not in scope here.
 
 ### 8.1 `ctx.error`
 
-`TypeInferContext` and every Context that inherits it provides a
-single error helper:
-
 ```python
-def error(self, node: Expr | Stmt, msg: str):
-    if isinstance(node, Call):
-        name = node.target.__class__.__name__
-    else:
-        name = node.__class__.__name__
-    raise VerifyError(f"{name}: {msg}\n  at {getattr(node, 'source', '<unknown>')}")
+def error(self, node: Expr | Stmt, msg: str) -> NoReturn: ...   # node: the offending Expr/Stmt (class name used in the message); msg: the constraint-failure message; raises VerifyError with a stable format
 ```
+
+- constraints:
+  - provided by `TypeInferContext` and every Context that inherits it; raises
+    `VerifyError` with a stable format.
 
 Handlers MUST surface constraint failures via `ctx.error(node, msg)`;
 hand-rolled `raise` is not the convention. This keeps the error
@@ -582,20 +477,7 @@ constrained by this spec.
 `@register_*` decorators are import-time side effects.
 `ir/hir/__init__.py`, `ir/tir/__init__.py`, and
 `codegen/<target>/__init__.py` perform a recursive walk so every
-submodule is imported and every `@register_*` runs:
-
-```python
-# src/tilefoundry/ir/hir/__init__.py
-import pkgutil, importlib
-
-def _auto_import(pkg_name: str):
-    pkg = importlib.import_module(pkg_name)
-    for _, modname, _ in pkgutil.walk_packages(pkg.__path__, pkg_name + "."):
-        importlib.import_module(modname)
-
-_auto_import("tilefoundry.ir.hir")              # fires HIR @register_typeinfer / @register_op
-_auto_import("tilefoundry.codegen.cuda.tir")    # fires CUDA @register_codegen_cuda
-```
+submodule is imported and every `@register_*` runs.
 
 `import tilefoundry` triggers the walk once; every registry is fully
 populated. Re-imports are idempotent (Python caches the module;
@@ -618,15 +500,8 @@ class AliasContext(TypeInferContext):
 ### Step 2 — declare a registry + decorator
 
 ```python
-from tilefoundry.visitor_registry import AnalysisRegistry
-
-alias_registry: AnalysisRegistry[type[Op]] = AnalysisRegistry("alias")
-
-def register_alias(op_cls: type[Op]):
-    def deco(fn):
-        alias_registry.register(op_cls, fn)
-        return fn
-    return deco
+alias_registry: AnalysisRegistry[type[Op]]   # the new analysis's registry
+def register_alias(op_cls: type[Op]): ...     # decorator: register a handler for one Op class
 ```
 
 Pick `type[Op]` for an analysis that walks `Call`s, `type[Stmt]` for
@@ -636,28 +511,17 @@ needed.
 ### Step 3 — derive a Visitor that holds the registry explicitly
 
 ```python
-from tilefoundry.ir.visitor import ExprVisitor
-
 class AliasVisitor(ExprVisitor[None]):
-    def __init__(self, ctx: AliasContext, registry: AnalysisRegistry = alias_registry):
-        self.ctx = ctx
-        self.registry = registry        # explicit binding
-
-    def visit_Call(self, call: Call) -> None:
-        fn = self.registry.lookup(type(call.target))
-        if fn is not None:
-            fn(call, self.ctx)
-        super().generic_visit(call)
+    def __init__(self, ctx: AliasContext, registry: AnalysisRegistry = alias_registry): ...   # explicit binding
+    def visit_Call(self, call: Call) -> None: ...   # look up type(call.target), invoke, then recurse
 ```
 
 ### Step 4 — register handlers in the Op files
 
 ```python
-# src/tilefoundry/ir/hir/tensor/reshape.py
+# an alias handler keys on the Op class and returns None:
 @register_alias(Reshape)
-def _(call: Call, ctx: AliasContext) -> None:
-    src = call.args[0]
-    ctx.alias_sets.setdefault(src, {src}).add(call)
+def _(call: Call, ctx: AliasContext) -> None: ...
 ```
 
 These four steps are what every existing instance


### PR DESCRIPTION
Spec-only reorganization per the reorg plan (local `docs/plans/spec-unified-entry-reorg.md`): nest by class inheritance, role-prose at top, dedicated analysis owner, apply Unified Entry Format. Milestone-gated; each milestone verified by a preservation ledger (global normative-sentence + fields/constraints-bullet sets stay invariant under moves).

Landed:
- M1: add `docs/spec/analysis.md` (type propagation / access relation / shard propagation service semantics); relocate relation-driven type validity + multi-input output storage + operand layout/mesh ownership out of hir §3, and logical-shape-to-layout-domain + relation-driven shard propagation out of shard §8/§9, into analysis; hir/shard link out; architecture ownership table + visitor-registry relation ref updated. Preservation ledger invariant (192 normative / 179 bullets unchanged); æ 11→10.

Pending (milestone-gated): M2 HIR Expr constructs + specialization; M3 TIR Expr/Stmt; M4 Unified Entry Format sweep (incl. codegen→target emitter boundary, runtime wide-load removal); M5 link/anchor + æ-empty audit.