### PR TITLE
ci: gate main with lint + full GPU pytest (self-hosted H200)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: ci
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+# Jobs run directly inside the self-hosted runner container, which carries the
+# toolchain (torch, CUDA, cutlass headers at /opt/cutlass/include, ruff,
+# clang-format, pre-commit). The runner container is launched pinned to one GPU
+# (e.g. --gpus device=4), so no per-job GPU selection is needed. `tilefoundry`
+# is the runner label — set it in the runner's RUNNER_LABELS at launch.
+jobs:
+  lint:
+    runs-on: [self-hosted, tilefoundry]
+    steps:
+      - uses: actions/checkout@v4
+      - name: pre-commit run --all-files
+        run: pre-commit run --all-files
+
+  test:
+    needs: lint
+    runs-on: [self-hosted, tilefoundry]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Link baked cutlass headers
+        run: mkdir -p third_party/cutlass && ln -sf /opt/cutlass/include third_party/cutlass/include
+      - name: Install tilefoundry (editable, deps already in the image)
+        run: pip install -e '.[test]' --no-build-isolation
+      - name: pytest tests/
+        run: pytest tests/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,11 @@
 repos:
   - repo: local
     hooks:
+      - id: ruff
+        name: ruff
+        entry: ruff check --fix
+        language: system
+        types_or: [python]
       - id: clang-format
         name: clang-format
         entry: clang-format -i

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,62 @@
+FROM nvidia/cuda:12.9.1-devel-ubuntu22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# System toolchain: Python 3.12 (deadsnakes), build tools, clang-format-18 from LLVM.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        software-properties-common \
+        ca-certificates \
+        gnupg \
+        wget \
+        git \
+        ninja-build \
+        g++ \
+    && add-apt-repository -y ppa:deadsnakes/ppa \
+    && apt-get update && apt-get install -y --no-install-recommends \
+        python3.12 \
+        python3.12-venv \
+        python3.12-dev \
+    && wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /usr/share/keyrings/llvm.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/llvm.gpg] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main" \
+        > /etc/apt/sources.list.d/llvm.list \
+    && apt-get update && apt-get install -y --no-install-recommends \
+        clang-format-18 \
+    && update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-18 100 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Make python/pip resolve to 3.12.
+RUN wget -qO /tmp/get-pip.py https://bootstrap.pypa.io/get-pip.py \
+    && python3.12 /tmp/get-pip.py \
+    && rm /tmp/get-pip.py \
+    && update-alternatives --install /usr/bin/python python /usr/bin/python3.12 100 \
+    && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 100 \
+    && ln -sf /usr/local/bin/pip /usr/bin/pip
+
+# cmake >=3.18 via pip (apt cmake on 22.04 is too old); ninja-build/g++ from apt above.
+RUN pip install --no-cache-dir "cmake>=3.18"
+
+# torch 2.9.1 (cu128): the runtime maps DType.f8e8m0 -> torch.float8_e8m0fnu,
+# which torch 2.5 lacks. cu128 bundles its own CUDA runtime; the devel base's
+# nvcc 12.9 is what JIT-builds the kernels, so the two coexist.
+RUN pip install --no-cache-dir torch==2.9.1 --index-url https://download.pytorch.org/whl/cu128
+
+# tilefoundry runtime deps (mirrors pyproject.toml [project.dependencies]) plus CI tooling.
+# The tilefoundry package itself is NOT installed here; editable install happens at CI runtime.
+RUN pip install --no-cache-dir \
+        "isl-python>=0.1.8" \
+        "jinja2>=3.0" \
+        apache-tvm-ffi \
+        "graphviz>=0.20" \
+        "transformers>=4.57" \
+        "pytest>=8" \
+        "ruff==0.14.13" \
+        "pre-commit>=3"
+
+# isl-python bundles a newer libisl under /usr/local/lib; put it ahead of the
+# older apt libisl23 so `import isl` finds the symbols it needs (mirrors how the
+# conda dev env resolves it). Prepend to keep the CUDA lib paths from the base.
+ENV LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH}
+
+# cutlass headers only, pinned to the submodule SHA (passed as a build-arg).
+ARG CUTLASS_SHA
+RUN git clone --filter=blob:none --no-checkout https://github.com/NVIDIA/cutlass.git /tmp/cutlass && cd /tmp/cutlass && git sparse-checkout init --cone && git sparse-checkout set include && git checkout ${CUTLASS_SHA} && mkdir -p /opt/cutlass && mv /tmp/cutlass/include /opt/cutlass/include && rm -rf /tmp/cutlass

--- a/include/tilefoundry/runtime.h
+++ b/include/tilefoundry/runtime.h
@@ -1,8 +1,8 @@
 // tilefoundry runtime umbrella header.
 //
 // Selects the target-specific runtime by the build-injected target macro.
-// Exactly one of TILEFOUNDRY_TARGET_CUDA / TILEFOUNDRY_TARGET_CPU must be defined
-// (the CMake build sets it per target); both or neither is an error.
+// Exactly one of TILEFOUNDRY_TARGET_CUDA / TILEFOUNDRY_TARGET_CPU must be
+// defined (the CMake build sets it per target); both or neither is an error.
 #pragma once
 
 #if defined(TILEFOUNDRY_TARGET_CUDA) && defined(TILEFOUNDRY_TARGET_CPU)
@@ -13,5 +13,6 @@
 #elif defined(TILEFOUNDRY_TARGET_CPU)
 #include <tilefoundry/runtime/cpu/runtime.h>
 #else
-#error "tilefoundry/runtime.h: define exactly one TILEFOUNDRY_TARGET_* (CUDA or CPU)"
+#error                                                                         \
+    "tilefoundry/runtime.h: define exactly one TILEFOUNDRY_TARGET_* (CUDA or CPU)"
 #endif

--- a/include/tilefoundry/runtime/cuda/ops/binary/binary_impl.h
+++ b/include/tilefoundry/runtime/cuda/ops/binary/binary_impl.h
@@ -87,8 +87,8 @@ template <class Op> struct BinaryBcastScalar {
         using value_type = cute::remove_cvref_t<decltype(d(0))>;
         auto val = static_cast<value_type>(sc(0));
         for (int i = 0; i < N; ++i) {
-            d(i) = static_cast<value_type>(
-                op(static_cast<value_type>(s(i)), val));
+            d(i) =
+                static_cast<value_type>(op(static_cast<value_type>(s(i)), val));
         }
     }
 };

--- a/include/tilefoundry/runtime/cuda/ops/reduce/reduce_common_impl.h
+++ b/include/tilefoundry/runtime/cuda/ops/reduce/reduce_common_impl.h
@@ -147,8 +147,7 @@ CUTE_HOST_DEVICE constexpr reduce_dispatch_info reduce_dispatch() {
 
 // Detector for a nested ``typename T::shard_layout_type``. Selects the sharded
 // tiers vs. the plain (non-sharded) path in the public ``reduce`` entry.
-template <class T, class = void>
-struct has_shard_layout : std::false_type {};
+template <class T, class = void> struct has_shard_layout : std::false_type {};
 template <class T>
 struct has_shard_layout<T, std::void_t<typename T::shard_layout_type>>
     : std::true_type {};

--- a/include/tilefoundry/runtime/cuda/ops/reduce/reduce_cross_warp_impl.h
+++ b/include/tilefoundry/runtime/cuda/ops/reduce/reduce_cross_warp_impl.h
@@ -46,8 +46,9 @@ template <class Op, class Axes> struct CrossWarp {
                 acc = -INFINITY;
                 for (int w = 0; w < warps_per_group; ++w)
                     acc = fmaxf(
-                        acc, static_cast<float>(ws(
-                                 ((group_start + w) * 32 + lane) * n_cells + j)));
+                        acc,
+                        static_cast<float>(
+                            ws(((group_start + w) * 32 + lane) * n_cells + j)));
             } else if constexpr (std::is_same_v<Op, sum_op>) {
                 acc = 0.f;
                 for (int w = 0; w < warps_per_group; ++w)

--- a/include/tilefoundry/runtime/cuda/ops/sync/sync_impl.h
+++ b/include/tilefoundry/runtime/cuda/ops/sync/sync_impl.h
@@ -33,13 +33,13 @@ struct Sync {
         } else if constexpr (Kind == SyncKind::syncwarp_full) {
             __syncwarp();
         } else if constexpr (Kind == SyncKind::syncwarp_masked) {
-            const int tid = int(tilefoundry::program_id<
-                                tilefoundry::TopologyScope::thread>());
+            const int tid = int(
+                tilefoundry::program_id<tilefoundry::TopologyScope::thread>());
             if (tid >= Base && tid < Base + Count)
                 __syncwarp(Mask);
         } else if constexpr (Kind == SyncKind::bar_sync) {
-            const int tid = int(tilefoundry::program_id<
-                                tilefoundry::TopologyScope::thread>());
+            const int tid = int(
+                tilefoundry::program_id<tilefoundry::TopologyScope::thread>());
             if (tid >= Base && tid < Base + Count)
                 asm volatile("bar.sync %0, %1;" ::"r"(BarId), "r"(Count));
         }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "isl-python>=0.1.8",
     "jinja2>=3.0",
     "apache-tvm-ffi",
-    "torch",
+    "torch>=2.7",  # DType.f8e8m0 -> torch.float8_e8m0fnu, added in torch 2.7
     "graphviz>=0.20",
     "transformers>=4.57",
 ]

--- a/src/tilefoundry/codegen/cuda/tir/nn/mma.py
+++ b/src/tilefoundry/codegen/cuda/tir/nn/mma.py
@@ -16,7 +16,6 @@ from tilefoundry.codegen.cuda.context import CodegenContext, register_codegen_cu
 from tilefoundry.ir.core import Var
 from tilefoundry.ir.tir.cuda.nn.mma import Mma
 
-
 # MmaOpSpec.name → runtime entry. One handler today; a new instruction adds a
 # row here, no change to the Mma op / T.mma surface.
 _MMA_RUNTIME = {

--- a/src/tilefoundry/codegen/cuda/tir/sync.py
+++ b/src/tilefoundry/codegen/cuda/tir/sync.py
@@ -7,7 +7,7 @@ parameters to ``tilefoundry::ops::sync``.
 from __future__ import annotations
 
 from tilefoundry.codegen.cuda.context import CodegenContext, register_codegen_cuda
-from tilefoundry.ir.tir.sync import SyncBarrier, Sync, classify, participation
+from tilefoundry.ir.tir.sync import Sync, SyncBarrier, classify, participation
 
 _SYNC = "tilefoundry::ops::sync"
 _KIND = "tilefoundry::ops::SyncKind"

--- a/src/tilefoundry/codegen/linker.py
+++ b/src/tilefoundry/codegen/linker.py
@@ -31,7 +31,7 @@ class LinkedModule:
     kernels: tuple[KernelInfo, ...]
 
 
-def _render_cmakelists(*, name: str, includes: list[str], device_options: str) -> str:
+def _render_cmakelists(*, name: str, includes: list[str], device_options: str, cuda_arch: str) -> str:
     """Render the split-pipeline CMake project from its Jinja template."""
     # noqa lazy: jinja2 is already a codegen dep; import here keeps the linker
     # load path light and avoids a hard import at module load.
@@ -47,7 +47,7 @@ def _render_cmakelists(*, name: str, includes: list[str], device_options: str) -
         keep_trailing_newline=True,
     )
     return env.get_template("CMakeLists.txt.j2").render(
-        name=name, includes=includes, device_options=device_options
+        name=name, includes=includes, device_options=device_options, cuda_arch=cuda_arch
     )
 
 
@@ -69,6 +69,7 @@ def link_modules(
     nvcc: str = "nvcc",
     host_cxx: str = "g++",
     extra_nvcc_flags: tuple[str, ...] = (),
+    cuda_arch: str = "90",
     include_dirs: tuple[Path, ...] = (),
 ) -> LinkedModule:
     """Separately compile a device ``cu`` module and a host ``cpp`` module, then
@@ -97,8 +98,9 @@ def link_modules(
     (workdir / "device.cu").write_text(cu[0].source)
     (workdir / "host.cpp").write_text(cpp[0].source)
 
-    # Device include set + nvcc flags. ``-arch=sm_80`` is supplied by the CMake
-    # target's ``CUDA_ARCHITECTURES 80``; ``-fPIC`` by ``POSITION_INDEPENDENT_CODE``;
+    # Device include set + nvcc flags. The arch is parameterized: the CMake
+    # target's ``CUDA_ARCHITECTURES {cuda_arch}`` emits both ``compute_<arch>``
+    # PTX and ``sm_<arch>`` SASS; ``-fPIC`` by ``POSITION_INDEPENDENT_CODE``;
     # ``-static-libstdc++`` by the template's link options. The host compiler
     # reuses the same include set.
     tvm_inc = _tvm_ffi_include()
@@ -108,6 +110,7 @@ def link_modules(
         name=lib_name,
         includes=[str(p) for p in includes],
         device_options=device_options,
+        cuda_arch=cuda_arch,
     )
     (workdir / "CMakeLists.txt").write_text(cmake_text)
 

--- a/src/tilefoundry/codegen/templates/cmake/CMakeLists.txt.j2
+++ b/src/tilefoundry/codegen/templates/cmake/CMakeLists.txt.j2
@@ -17,7 +17,7 @@ add_library({{ name }} SHARED device.cu host.cpp)
 set_target_properties({{ name }} PROPERTIES
   PREFIX "lib"
   OUTPUT_NAME "{{ name }}"
-  CUDA_ARCHITECTURES "80")
+  CUDA_ARCHITECTURES "{{ cuda_arch }}")
 
 # Per-source target macro: device gets CUDA, host gets CPU. Never both in one TU.
 set_source_files_properties(device.cu PROPERTIES COMPILE_DEFINITIONS TILEFOUNDRY_TARGET_CUDA)

--- a/src/tilefoundry/compile.py
+++ b/src/tilefoundry/compile.py
@@ -220,6 +220,7 @@ def _build_split_runtime_module(mod: Module, *, workdir: str) -> "RuntimeModule"
     # here rather than raising.
     grid, block = _derive_launch_config(kernel_fns[0].body)
 
+    cuda_arch = cuda_group[0].target.arch.removeprefix("sm_")
     linked_module = link_modules(
         (device_module, host_module),
         workdir=workdir,
@@ -227,6 +228,7 @@ def _build_split_runtime_module(mod: Module, *, workdir: str) -> "RuntimeModule"
         entry=entry_type,
         launch_config=LaunchConfig(grid=grid, block=block),
         kernels=kernels,
+        cuda_arch=cuda_arch,
     )
     return load_linked_module(linked_module)
 

--- a/src/tilefoundry/parser/tir_parser.py
+++ b/src/tilefoundry/parser/tir_parser.py
@@ -11,6 +11,7 @@ from tilefoundry.ir.target import CudaTarget
 from tilefoundry.ir.target.launch import LaunchAttrs
 from tilefoundry.ir.tir.launch import launch_call
 from tilefoundry.ir.tir.prim_function import PrimFunction
+from tilefoundry.ir.tir.shape import shape_var_name
 from tilefoundry.ir.tir.stmt import Stmt
 from tilefoundry.ir.tir.stmts import (
     Evaluate,
@@ -22,7 +23,6 @@ from tilefoundry.ir.tir.stmts import (
     Sequential,
     While,
 )
-from tilefoundry.ir.tir.shape import shape_var_name
 from tilefoundry.ir.tir.symbol_ref import symbol_call
 from tilefoundry.ir.types import DType, TensorType, UnitType
 from tilefoundry.ir.types.dim import (

--- a/tests/core/test_custom_op_register.py
+++ b/tests/core/test_custom_op_register.py
@@ -21,8 +21,8 @@ from tilefoundry.ir.core import Op
 from tilefoundry.ir.core.op_registry import (
     _schemas_by_dialect_name,
     get_op_by_name,
-    get_tf_by_category_name,
     get_schemas,
+    get_tf_by_category_name,
 )
 from tilefoundry.ir.core.param_def import ParamDef
 from tilefoundry.ir.core.pattern import Tensor

--- a/tests/core/test_op_registry.py
+++ b/tests/core/test_op_registry.py
@@ -7,8 +7,8 @@ from tilefoundry.ir.core import VerifyError
 from tilefoundry.ir.core.op_registry import (
     _first_schema,
     get_op_by_name,
-    get_tf_by_category_name,
     get_stmt_by_name,
+    get_tf_by_category_name,
     iter_schemas,
 )
 from tilefoundry.ir.tir.prim_function import PrimFunction

--- a/tests/dsl/test_module_decorator.py
+++ b/tests/dsl/test_module_decorator.py
@@ -23,7 +23,7 @@ from tilefoundry.ir.core import Call
 from tilefoundry.ir.core.errors import VerifyError
 from tilefoundry.ir.core.module import Module
 from tilefoundry.ir.hir.function import Function as HirFunction
-from tilefoundry.ir.types.shard import Mesh, Layout, Topology
+from tilefoundry.ir.types.shard import Layout, Mesh, Topology
 
 
 @module(entry="composed")

--- a/tests/e2e/test_dynamic_cta_tir_handwritten.py
+++ b/tests/e2e/test_dynamic_cta_tir_handwritten.py
@@ -16,7 +16,7 @@ import torch
 
 import tilefoundry
 from tilefoundry import module, prim_func
-from tilefoundry.dsl import DimVar, Tensor, T
+from tilefoundry.dsl import DimVar, T, Tensor
 from tilefoundry.ir.core.kinds import BinaryKind
 from tilefoundry.ir.target.storage import StorageKind
 from tilefoundry.ir.types import DType, TensorType

--- a/tests/e2e/test_host_launch.py
+++ b/tests/e2e/test_host_launch.py
@@ -20,8 +20,8 @@ import torch
 import tilefoundry
 from tilefoundry import func, prim_func
 from tilefoundry.dsl import DimVar, ReduceKind, Tensor, tf
-from tilefoundry.dsl.tf import *  # noqa: F401,F403  -- bind bare op names (reshard, relu, ...)
 from tilefoundry.dsl.storage import gmem, rmem
+from tilefoundry.dsl.tf import *  # noqa: F401,F403  -- bind bare op names (reshard, relu, ...)
 from tilefoundry.ir.core.module import Module
 from tilefoundry.ir.types.shard import Layout, Mesh, S, ShardLayout, Topology
 

--- a/tests/e2e/test_mma_tir_handwritten.py
+++ b/tests/e2e/test_mma_tir_handwritten.py
@@ -16,9 +16,9 @@ import torch
 import tilefoundry
 from tilefoundry import module, prim_func
 from tilefoundry.dsl import T, Tensor
-from tilefoundry.ir.types import DType, TensorType
 from tilefoundry.ir.target.storage import StorageKind
-from tilefoundry.ir.types.shard import Mesh, Layout, Topology
+from tilefoundry.ir.types import DType, TensorType
+from tilefoundry.ir.types.shard import Layout, Mesh, Topology
 
 _OP = T.cuda.mma.SM80_16x8x16_F32BF16BF16F32_TN
 
@@ -32,7 +32,7 @@ class MmHandwritten:
         c: Tensor[(16, 8), "f32"],
     ):
         atom = T.cuda.mma.atom(op=_OP)
-        with Mesh(Topology("thread", 32), Layout(shape=(4, 8), strides=(1, 4))) as warp:
+        with Mesh(Topology("thread", 32), Layout(shape=(4, 8), strides=(1, 4))) as warp:  # noqa: F841
             # gmem → register fragments (distributed load, like HIR reshard).
             a_view = T.tensor_view(a, layout=atom.A)
             b_view = T.tensor_view(b, layout=atom.B)

--- a/tests/inspection/test_canonical_roundtrip.py
+++ b/tests/inspection/test_canonical_roundtrip.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
+from tests.fixtures.demo_canonical import build_demo_canonical
 from tilefoundry.inspection import as_script
 from tilefoundry.ir.core import Call, Constant, Var
 from tilefoundry.ir.hir.function import Function
 from tilefoundry.ir.hir.sharding.reshard import Reshard
 from tilefoundry.ir.types import TensorType
 from tilefoundry.parser.hir_parser import parse_script
-from tests.fixtures.demo_canonical import build_demo_canonical
 
 
 def _structural_equal(a, b) -> bool:

--- a/tests/inspection/test_python_printer.py
+++ b/tests/inspection/test_python_printer.py
@@ -3,6 +3,8 @@
 import os
 from math import prod
 
+from tests.fixtures.demo_ir import build_demo
+from tests.fixtures.qwen3_attention_graph import build_qwen3_attention_main_2cta_headnorm
 from tilefoundry.dump import DumpFlags, FileDumper, current_scope, dump
 from tilefoundry.inspection import as_script
 from tilefoundry.ir.core import Call, Constant, Var
@@ -10,8 +12,6 @@ from tilefoundry.ir.hir.function import Function
 from tilefoundry.ir.types import TensorType
 from tilefoundry.ir.types.shard.shard_layout import ShardLayout
 from tilefoundry.parser.hir_parser import parse_script
-from tests.fixtures.demo_ir import build_demo
-from tests.fixtures.qwen3_attention_graph import build_qwen3_attention_main_2cta_headnorm
 
 
 def _structural_equal(a, b, path="") -> bool:

--- a/tests/ir/test_function_call_typeinfer.py
+++ b/tests/ir/test_function_call_typeinfer.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import pytest
 
+from tests.ops.typeinfer_utils import infer_call, mesh, sharded, ten
 from tilefoundry.ir.core import Call, Var
 from tilefoundry.ir.core.errors import VerifyError
 from tilefoundry.ir.core.kinds import BinaryKind
@@ -18,7 +19,6 @@ from tilefoundry.ir.hir.function import Function
 from tilefoundry.ir.hir.math.binary import Binary
 from tilefoundry.ir.types import DType
 from tilefoundry.ir.types.shard.shard_layout import Split
-from tests.ops.typeinfer_utils import infer_call, mesh, sharded, ten
 
 _F = DType.f32
 _M = mesh((4,))

--- a/tests/ir/test_shard_layout_local_shape.py
+++ b/tests/ir/test_shard_layout_local_shape.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 from tilefoundry.ir.types.shard.layout import Layout
 from tilefoundry.ir.types.shard.mesh import Mesh, Topology
-from tilefoundry.ir.types.shard.layout import Layout
 from tilefoundry.ir.types.shard.shard_layout import (
     Broadcast,
     Partial,

--- a/tests/ir/test_simplify_dim.py
+++ b/tests/ir/test_simplify_dim.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import pytest
 
+from tests.parser.hir.test_demo_proj_qkv import proj_qkv_with_mma
 from tilefoundry.ir.core import TypeInferContext
 from tilefoundry.ir.core.expr import Call, Constant, Var
 from tilefoundry.ir.core.kinds import UnaryKind
@@ -22,7 +23,6 @@ from tilefoundry.ir.types.dim import (
     DimVar,
     simplify_dim,
 )
-from tests.parser.hir.test_demo_proj_qkv import proj_qkv_with_mma
 
 
 def _i64(v: int) -> Constant:

--- a/tests/ir/test_visitor.py
+++ b/tests/ir/test_visitor.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from tilefoundry.ir.core import Call, Constant, Expr, Op, Var
 from tilefoundry.ir.hir.grid_region import GridRegionExpr
-from tilefoundry.ir.tir.memory import Copy, Fill
 from tilefoundry.ir.tir.cuda.nn.mma import Mma
+from tilefoundry.ir.tir.memory import Copy, Fill
 from tilefoundry.ir.tir.prim_function import PrimFunction
 from tilefoundry.ir.tir.stmts import (
     Evaluate,
@@ -19,8 +19,8 @@ from tilefoundry.ir.tir.stmts import (
 )
 from tilefoundry.ir.tir.symbol_ref import SymbolRef
 from tilefoundry.ir.types import CallableType, DType, TensorType, UnitType
-from tilefoundry.ir.types.shard.mesh import Mesh, Topology
 from tilefoundry.ir.types.shard.layout import Layout
+from tilefoundry.ir.types.shard.mesh import Mesh, Topology
 from tilefoundry.ir.visitor import (
     ExprMutator,
     ExprVisitor,

--- a/tests/ir_types/test_mma_fragment_layouts.py
+++ b/tests/ir_types/test_mma_fragment_layouts.py
@@ -12,8 +12,8 @@ from __future__ import annotations
 
 from tilefoundry.ir.core import Call, Var
 from tilefoundry.ir.hir.sharding.reshard import Reshard
-from tilefoundry.ir.tir.cuda.nn.mma import SM80_16x8x16_F32BF16BF16F32_TN, make_atom
 from tilefoundry.ir.target.storage import StorageKind
+from tilefoundry.ir.tir.cuda.nn.mma import SM80_16x8x16_F32BF16BF16F32_TN, make_atom
 from tilefoundry.ir.types import DType, TensorType
 from tilefoundry.ir.types.shard import ShardLayout, Split
 from tilefoundry.visitor_registry.contexts import TypeInferContext

--- a/tests/ir_types/test_scope_match.py
+++ b/tests/ir_types/test_scope_match.py
@@ -8,7 +8,7 @@ names, axis names, and mesh object identity.
 from __future__ import annotations
 
 from tilefoundry.ir.tir.cuda.nn.mma import SM80_16x8x16_F32BF16BF16F32_TN, make_atom
-from tilefoundry.ir.types.shard import Mesh, Layout, Topology
+from tilefoundry.ir.types.shard import Layout, Mesh, Topology
 from tilefoundry.ir.types.shard.scope_match import mesh_scope_matches_required_scope
 
 # The required thread scope is read off the realized atom, not a separate export.

--- a/tests/models/qwen3_5_30b_a3b/gqa_online.py
+++ b/tests/models/qwen3_5_30b_a3b/gqa_online.py
@@ -42,7 +42,7 @@ from tilefoundry.dsl import Tensor, tf  # noqa: F401 — tf used by the @func bo
 from tilefoundry.dsl.tf import *  # noqa: F401, F403 — bare op names for the @func body
 from tilefoundry.ir.core.pattern import DimVarRangePat
 from tilefoundry.ir.types.dim import DimVar
-from tilefoundry.ir.types.shard import Mesh, Layout, Topology
+from tilefoundry.ir.types.shard import Layout, Mesh, Topology
 
 # Model dims (match tests/models/qwen3_5_30b_a3b/common.py).
 HEAD_DIM = 128
@@ -149,7 +149,7 @@ def _ctx_partials(
     # block gets its OWN local softmax (m_p, l_p, o_p) over its block axis only —
     # no cross-block reduction here. `with Mesh(cta)` is the CTA-parallel
     # authoring context (NUM_SPLITS is the CTA axis); it emits no IR node.
-    with Mesh(topology="cta", layout=Layout((NUM_CTA,), (1,))) as cta:
+    with Mesh(topology="cta", layout=Layout((NUM_CTA,), (1,))) as cta:  # noqa: F841
         k_f = tf.transpose(
             tf.cast(tf.repeat_interleave(
                 tf.reshape(k_cache, new_shape=(1, NUM_SPLITS, CBLK, _HKV, _D)),
@@ -191,7 +191,7 @@ def _ctx_combine(
     # `with Mesh(cta)` keeps this on the same CTA mesh as `_ctx_partials`: the
     # NUM_SPLITS axis IS the CTA axis, so this reduction is the cross-CTA combine,
     # mapped at lowering to a barrier / gather over the producers (not an IR node).
-    with Mesh(topology="cta", layout=Layout((NUM_CTA,), (1,))) as cta:
+    with Mesh(topology="cta", layout=Layout((NUM_CTA,), (1,))) as cta:  # noqa: F841
         m = tf.reduce(m_p, axes=(-2,), keepdim=True, kind="max")          # global max
         alpha = tf.exp(m_p - m)                                           # rescale per block
         l = tf.reduce(alpha * l_p, axes=(-2,), keepdim=True, kind="sum")  # [1,S,Hq,1,1]

--- a/tests/models/qwen3_5_30b_a3b/qwen3_module.py
+++ b/tests/models/qwen3_5_30b_a3b/qwen3_module.py
@@ -20,9 +20,6 @@ land in the same module as they are ported.
 """
 from __future__ import annotations
 
-from tilefoundry import func, module
-from tilefoundry.dsl import Tensor, tf  # noqa: F401 — tf used by @func bodies
-from tilefoundry.dsl.tf import *  # noqa: F401, F403 — bare op bindings for @func bodies
 from tests.models.qwen3_5_30b_a3b.common import (
     CACHE_CAP,
     GQA_GROUP,
@@ -34,6 +31,9 @@ from tests.models.qwen3_5_30b_a3b.common import (
     Q_PROJ,
     S_CAP,
 )
+from tilefoundry import func, module
+from tilefoundry.dsl import Tensor, tf  # noqa: F401 — tf used by @func bodies
+from tilefoundry.dsl.tf import *  # noqa: F401, F403 — bare op bindings for @func bodies
 
 # Packed q/k/v projection fan-out: one GEMM produces ``[Q_PROJ | KV_PROJ |
 # KV_PROJ]`` (4096 + 512 + 512 = 5120), sliced into q/k/v below.

--- a/tests/models/qwen3_5_30b_a3b/test_attention.py
+++ b/tests/models/qwen3_5_30b_a3b/test_attention.py
@@ -13,8 +13,8 @@ from __future__ import annotations
 import pytest
 import torch
 
-from tilefoundry.evaluator import evaluate
 from tests.models.qwen3_5_30b_a3b import common
+from tilefoundry.evaluator import evaluate
 
 HIDDEN = common.HIDDEN
 HEAD_DIM = common.HEAD_DIM

--- a/tests/models/qwen3_5_30b_a3b/test_decode_step.py
+++ b/tests/models/qwen3_5_30b_a3b/test_decode_step.py
@@ -12,8 +12,8 @@ from __future__ import annotations
 import pytest
 import torch
 
-from tilefoundry.evaluator import evaluate
 from tests.models.qwen3_5_30b_a3b import common
+from tilefoundry.evaluator import evaluate
 
 HIDDEN = common.HIDDEN
 HEAD_DIM = common.HEAD_DIM

--- a/tests/models/qwen3_5_30b_a3b/test_decoder_layer.py
+++ b/tests/models/qwen3_5_30b_a3b/test_decoder_layer.py
@@ -11,9 +11,9 @@ from __future__ import annotations
 import pytest
 import torch
 
-from tilefoundry.evaluator import evaluate
 from tests.models.qwen3_5_30b_a3b import common
 from tests.models.qwen3_5_30b_a3b.test_attention import _hf_pieces
+from tilefoundry.evaluator import evaluate
 
 HIDDEN = common.HIDDEN
 HEAD_DIM = common.HEAD_DIM

--- a/tests/models/qwen3_5_30b_a3b/test_gqa_online.py
+++ b/tests/models/qwen3_5_30b_a3b/test_gqa_online.py
@@ -16,7 +16,6 @@ import math
 import pytest
 import torch
 
-from tilefoundry.evaluator import evaluate
 from tests.models.qwen3_5_30b_a3b.gqa_online import (
     GQA_GROUP,
     HEAD_DIM,
@@ -25,6 +24,7 @@ from tests.models.qwen3_5_30b_a3b.gqa_online import (
     NUM_SPLITS,
     gqa_online_attend,
 )
+from tilefoundry.evaluator import evaluate
 
 Hq, Hkv, D, G = NUM_Q_HEADS, NUM_KV_HEADS, HEAD_DIM, GQA_GROUP
 _SCALE = 1.0 / math.sqrt(D)

--- a/tests/models/qwen3_5_30b_a3b/test_moe.py
+++ b/tests/models/qwen3_5_30b_a3b/test_moe.py
@@ -15,8 +15,8 @@ from __future__ import annotations
 import pytest
 import torch
 
-from tilefoundry.evaluator import evaluate
 from tests.models.qwen3_5_30b_a3b import common
+from tilefoundry.evaluator import evaluate
 
 HIDDEN = common.HIDDEN
 MOE_INTERMEDIATE = common.MOE_INTERMEDIATE

--- a/tests/models/qwen3_5_30b_a3b/test_qwen3_module.py
+++ b/tests/models/qwen3_5_30b_a3b/test_qwen3_module.py
@@ -11,9 +11,9 @@ from __future__ import annotations
 import pytest
 import torch
 
-from tilefoundry.evaluator import evaluate
 from tests.models.qwen3_5_30b_a3b import common
 from tests.models.qwen3_5_30b_a3b.qwen3_module import Qwen3_30B_A3B
+from tilefoundry.evaluator import evaluate
 
 HEAD_DIM = common.HEAD_DIM
 HIDDEN = common.HIDDEN

--- a/tests/ops/test_argmax.py
+++ b/tests/ops/test_argmax.py
@@ -3,14 +3,14 @@ from __future__ import annotations
 
 import pytest
 
-from tilefoundry.ir.hir.tensor.argmax import ArgMax
-from tilefoundry.ir.types import DType
 from tests.ops.typeinfer_utils import (
     ExpectedError,
     TypeInferCase,
     run_typeinfer_case,
     ten,
 )
+from tilefoundry.ir.hir.tensor.argmax import ArgMax
+from tilefoundry.ir.types import DType
 
 _I64 = DType.i64
 

--- a/tests/ops/test_async_copy.py
+++ b/tests/ops/test_async_copy.py
@@ -17,19 +17,18 @@ import torch
 
 import tilefoundry
 import tilefoundry.codegen.cuda  # noqa: F401 — trigger emitter autodiscovery
+from tests.ops.typeinfer_utils import infer_call, ten
 from tilefoundry import module, prim_func
 from tilefoundry.dsl import T, Tensor
-from tilefoundry.ir.core import VerifyError, Var
+from tilefoundry.ir.core import Var, VerifyError
+from tilefoundry.ir.target.storage import StorageKind
 from tilefoundry.ir.tir.async_copy import CopyAsync, CpAsyncCommit, CpAsyncWait
 from tilefoundry.ir.tir.prim_function import PrimFunction
 from tilefoundry.ir.tir.stmts import Evaluate, Return, Sequential
 from tilefoundry.ir.tir.verify import verify_prim_function
-from tilefoundry.ir.target.storage import StorageKind
 from tilefoundry.ir.types import DType, TensorType, UnitType
 from tilefoundry.ir.types.shard import Layout, Mesh, ShardLayout, Split, Topology
 from tilefoundry.ir.types.shard.shard_layout import Broadcast
-from tests.ops.typeinfer_utils import infer_call, ten
-
 
 # ── typeinfer ────────────────────────────────────────────────────────────────
 

--- a/tests/ops/test_cache_update.py
+++ b/tests/ops/test_cache_update.py
@@ -6,6 +6,13 @@ from dataclasses import replace
 import pytest
 import torch
 
+from tests.ops.eval_utils import EvalCase, run_eval_case
+from tests.ops.typeinfer_utils import (
+    ExpectedError,
+    TypeInferCase,
+    run_typeinfer_case,
+    ten,
+)
 from tilefoundry.evaluator import evaluate
 from tilefoundry.evaluator.value import EvalError
 from tilefoundry.ir.core import Call, Var
@@ -14,13 +21,6 @@ from tilefoundry.ir.hir.tensor.cache_update import CacheUpdate
 from tilefoundry.ir.types import DType, TensorType
 from tilefoundry.visitor_registry.contexts import TypeInferContext
 from tilefoundry.visitor_registry.visitors import TypeInferVisitor
-from tests.ops.eval_utils import EvalCase, run_eval_case
-from tests.ops.typeinfer_utils import (
-    ExpectedError,
-    TypeInferCase,
-    run_typeinfer_case,
-    ten,
-)
 
 
 def _ref(cache, cur_pos, s, new):

--- a/tests/ops/test_concat.py
+++ b/tests/ops/test_concat.py
@@ -6,9 +6,6 @@ from __future__ import annotations
 import pytest
 import torch
 
-from tilefoundry.ir.hir.tensor.concat import Concat
-from tilefoundry.ir.types import DType
-from tilefoundry.ir.types.shard.shard_layout import Split
 from tests.ops.eval_utils import EvalCase, run_eval_case
 from tests.ops.typeinfer_utils import (
     TypeInferCase,
@@ -17,6 +14,9 @@ from tests.ops.typeinfer_utils import (
     sharded,
     ten,
 )
+from tilefoundry.ir.hir.tensor.concat import Concat
+from tilefoundry.ir.types import DType
+from tilefoundry.ir.types.shard.shard_layout import Split
 
 _F = DType.f32
 _M = mesh((4,))

--- a/tests/ops/test_full_like.py
+++ b/tests/ops/test_full_like.py
@@ -8,8 +8,8 @@ from __future__ import annotations
 
 import torch
 
-from tilefoundry.ir.hir.tensor.full_like import FullLike
 from tests.ops.eval_utils import EvalCase, run_eval_case
+from tilefoundry.ir.hir.tensor.full_like import FullLike
 
 
 def test_full_like_evaluate():

--- a/tests/ops/test_matmul.py
+++ b/tests/ops/test_matmul.py
@@ -13,17 +13,6 @@ from __future__ import annotations
 import pytest
 import torch
 
-from tilefoundry.ir.hir.nn.matmul import MatMul
-from tilefoundry.ir.types import DType, TensorType
-from tilefoundry.ir.types.dim import DimVar
-from tilefoundry.ir.types.shard.layout import Layout
-from tilefoundry.ir.types.shard.mesh import Mesh
-from tilefoundry.ir.types.shard.layout import Layout
-from tilefoundry.ir.types.shard.shard_layout import (
-    Partial,
-    ShardLayout,
-    Split,
-)
 from tests.ops.eval_utils import EvalCase, run_eval_case
 from tests.ops.typeinfer_utils import (
     ExpectedError,
@@ -31,6 +20,16 @@ from tests.ops.typeinfer_utils import (
     infer_call,
     run_typeinfer_case,
     ten,
+)
+from tilefoundry.ir.hir.nn.matmul import MatMul
+from tilefoundry.ir.types import DType, TensorType
+from tilefoundry.ir.types.dim import DimVar
+from tilefoundry.ir.types.shard.layout import Layout
+from tilefoundry.ir.types.shard.mesh import Mesh
+from tilefoundry.ir.types.shard.shard_layout import (
+    Partial,
+    ShardLayout,
+    Split,
 )
 
 _MM = MatMul()

--- a/tests/ops/test_mma.py
+++ b/tests/ops/test_mma.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import pytest
 
+from tests.ops.typeinfer_utils import TypeInferCase, run_typeinfer_case, ten
 from tilefoundry.ir.hir.cuda.nn.mma import Mma, Mma_SM80_16x8x16, Wgmma_SM90_64x128x16
 from tilefoundry.ir.target.storage import StorageKind
 from tilefoundry.ir.types import DType
-from tests.ops.typeinfer_utils import TypeInferCase, run_typeinfer_case, ten
 
 _BF = DType.bf16
 _RMEM = StorageKind.RMEM

--- a/tests/ops/test_quant.py
+++ b/tests/ops/test_quant.py
@@ -4,15 +4,15 @@ from __future__ import annotations
 
 import pytest
 
-from tilefoundry.ir.hir.tensor.quant import Quant
-from tilefoundry.ir.target.storage import StorageKind
-from tilefoundry.ir.types import DType, TupleType
 from tests.ops.typeinfer_utils import (
     ExpectedError,
     TypeInferCase,
     run_typeinfer_case,
     ten,
 )
+from tilefoundry.ir.hir.tensor.quant import Quant
+from tilefoundry.ir.target.storage import StorageKind
+from tilefoundry.ir.types import DType, TupleType
 
 _BF = DType.bf16
 _FP8 = DType.fp8e4m3

--- a/tests/ops/test_reduce.py
+++ b/tests/ops/test_reduce.py
@@ -13,6 +13,14 @@ import pytest
 import torch
 
 import tilefoundry
+from tests.ops.eval_utils import EvalCase, run_eval_case
+from tests.ops.typeinfer_utils import (
+    TypeInferCase,
+    mesh,
+    run_typeinfer_case,
+    sharded,
+    ten,
+)
 from tilefoundry import func, module
 from tilefoundry.codegen.cuda.module import emit_cuda_module
 from tilefoundry.codegen.registry import group_functions_by_target
@@ -29,14 +37,6 @@ from tilefoundry.ir.types.shard.shard_layout import (
     layout_axis_to_tensor_axis,
 )
 from tilefoundry.passes.transforms.hir_to_tir import _analyze_cross_warp_workspace
-from tests.ops.eval_utils import EvalCase, run_eval_case
-from tests.ops.typeinfer_utils import (
-    TypeInferCase,
-    mesh,
-    run_typeinfer_case,
-    sharded,
-    ten,
-)
 
 _RMEM = StorageKind.RMEM
 _BF = DType.bf16

--- a/tests/ops/test_repeat_interleave.py
+++ b/tests/ops/test_repeat_interleave.py
@@ -9,9 +9,6 @@ from __future__ import annotations
 import pytest
 import torch
 
-from tilefoundry.ir.hir.tensor.repeat_interleave import RepeatInterleave
-from tilefoundry.ir.types import DType
-from tilefoundry.ir.types.shard.shard_layout import Broadcast, Split
 from tests.ops.eval_utils import EvalCase, run_eval_case
 from tests.ops.typeinfer_utils import (
     ExpectedError,
@@ -21,6 +18,9 @@ from tests.ops.typeinfer_utils import (
     sharded,
     ten,
 )
+from tilefoundry.ir.hir.tensor.repeat_interleave import RepeatInterleave
+from tilefoundry.ir.types import DType
+from tilefoundry.ir.types.shard.shard_layout import Broadcast, Split
 
 _F = DType.f32
 _M = mesh((4,))

--- a/tests/ops/test_reshape.py
+++ b/tests/ops/test_reshape.py
@@ -12,10 +12,6 @@ from __future__ import annotations
 import pytest
 import torch
 
-from tilefoundry.ir.hir.tensor.reshape import Reshape
-from tilefoundry.ir.types import DType
-from tilefoundry.ir.types.dim import DimVar
-from tilefoundry.ir.types.shard.shard_layout import Partial, Split
 from tests.ops.eval_utils import EvalCase, run_eval_case
 from tests.ops.typeinfer_utils import (
     ExpectedError,
@@ -25,6 +21,10 @@ from tests.ops.typeinfer_utils import (
     sharded,
     ten,
 )
+from tilefoundry.ir.hir.tensor.reshape import Reshape
+from tilefoundry.ir.types import DType
+from tilefoundry.ir.types.dim import DimVar
+from tilefoundry.ir.types.shard.shard_layout import Partial, Split
 
 _F = DType.f32
 _M = mesh((4,))

--- a/tests/ops/test_reshard.py
+++ b/tests/ops/test_reshard.py
@@ -15,13 +15,6 @@ from __future__ import annotations
 import pytest
 import torch
 
-from tilefoundry.dsl.storage import gmem, rmem
-from tilefoundry.ir.hir.sharding.reshard import Reshard
-from tilefoundry.ir.target.storage import StorageKind
-from tilefoundry.ir.types import DType
-from tilefoundry.ir.types.dim import DimMul, DimVar, simplify_dim
-from tilefoundry.ir.types.shard import Layout, Mesh, ShardLayout, Topology
-from tilefoundry.ir.types.shard.shard_layout import Split
 from tests.ops.eval_utils import EvalCase, run_eval_case
 from tests.ops.typeinfer_utils import (
     ExpectedError,
@@ -29,6 +22,13 @@ from tests.ops.typeinfer_utils import (
     run_typeinfer_case,
     ten,
 )
+from tilefoundry.dsl.storage import gmem, rmem
+from tilefoundry.ir.hir.sharding.reshard import Reshard
+from tilefoundry.ir.target.storage import StorageKind
+from tilefoundry.ir.types import DType
+from tilefoundry.ir.types.dim import DimMul, DimVar, simplify_dim
+from tilefoundry.ir.types.shard import Layout, Mesh, ShardLayout, Topology
+from tilefoundry.ir.types.shard.shard_layout import Split
 
 
 def _ten(shape, storage=gmem, layout=None):

--- a/tests/ops/test_rms_norm.py
+++ b/tests/ops/test_rms_norm.py
@@ -23,6 +23,12 @@ from __future__ import annotations
 import pytest
 import torch
 
+from tests.ops.eval_utils import EvalCase, run_eval_case
+from tests.ops.typeinfer_utils import (
+    ExpectedError,
+    TypeInferCase,
+    run_typeinfer_case,
+)
 from tilefoundry.dsl import DimVar
 from tilefoundry.ir.core import Call, Constant, Var
 from tilefoundry.ir.core.kinds import BinaryKind, UnaryKind
@@ -47,14 +53,8 @@ from tilefoundry.ir.tir.stmts import (
     While,
 )
 from tilefoundry.ir.types import DType, TensorType
-from tilefoundry.ir.types.shard import Mesh, Layout, Topology
+from tilefoundry.ir.types.shard import Layout, Mesh, Topology
 from tilefoundry.passes.transforms.hir_to_tir import HirToTirPass
-from tests.ops.eval_utils import EvalCase, run_eval_case
-from tests.ops.typeinfer_utils import (
-    ExpectedError,
-    TypeInferCase,
-    run_typeinfer_case,
-)
 
 
 def _ten(shape, dtype):

--- a/tests/ops/test_rope.py
+++ b/tests/ops/test_rope.py
@@ -6,6 +6,12 @@ from dataclasses import replace
 import pytest
 import torch
 
+from tests.ops.typeinfer_utils import (
+    ExpectedError,
+    TypeInferCase,
+    run_typeinfer_case,
+    ten,
+)
 from tilefoundry.evaluator import evaluate
 from tilefoundry.ir.core import Call, Var
 from tilefoundry.ir.hir.function import Function
@@ -13,12 +19,6 @@ from tilefoundry.ir.hir.nn.rope import RoPE
 from tilefoundry.ir.types import DType, TensorType, TupleType
 from tilefoundry.visitor_registry.contexts import TypeInferContext
 from tilefoundry.visitor_registry.visitors import TypeInferVisitor
-from tests.ops.typeinfer_utils import (
-    ExpectedError,
-    TypeInferCase,
-    run_typeinfer_case,
-    ten,
-)
 
 _BF = DType.bf16
 

--- a/tests/ops/test_rsqrt.py
+++ b/tests/ops/test_rsqrt.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 
 import torch
 
+from tests.ops.eval_utils import EvalCase, run_eval_case
 from tilefoundry.ir.core.kinds import UnaryKind
 from tilefoundry.ir.hir.math.unary import Unary
-from tests.ops.eval_utils import EvalCase, run_eval_case
 
 
 def test_rsqrt_evaluate():

--- a/tests/ops/test_sigmoid.py
+++ b/tests/ops/test_sigmoid.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 
 import torch
 
-from tilefoundry.ir.hir.nn.sigmoid import Sigmoid
 from tests.ops.eval_utils import EvalCase, run_eval_case
+from tilefoundry.ir.hir.nn.sigmoid import Sigmoid
 
 
 def test_sigmoid_evaluate():

--- a/tests/ops/test_slice.py
+++ b/tests/ops/test_slice.py
@@ -6,9 +6,6 @@ from __future__ import annotations
 import pytest
 import torch
 
-from tilefoundry.ir.hir.tensor.slice import Slice
-from tilefoundry.ir.types import DType
-from tilefoundry.ir.types.shard.shard_layout import Split
 from tests.ops.eval_utils import EvalCase, run_eval_case
 from tests.ops.typeinfer_utils import (
     TypeInferCase,
@@ -17,6 +14,9 @@ from tests.ops.typeinfer_utils import (
     sharded,
     ten,
 )
+from tilefoundry.ir.hir.tensor.slice import Slice
+from tilefoundry.ir.types import DType
+from tilefoundry.ir.types.shard.shard_layout import Split
 
 _F = DType.f32
 _M = mesh((4,))

--- a/tests/ops/test_softmax.py
+++ b/tests/ops/test_softmax.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 import pytest
 import torch
 
-from tilefoundry.ir.hir.nn.softmax import SoftMax
 from tests.ops.eval_utils import EvalCase, run_eval_case
+from tilefoundry.ir.hir.nn.softmax import SoftMax
 
 
 @pytest.mark.parametrize(

--- a/tests/ops/test_softplus.py
+++ b/tests/ops/test_softplus.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 
 import torch
 
-from tilefoundry.ir.hir.math.softplus import Softplus
 from tests.ops.eval_utils import EvalCase, run_eval_case
+from tilefoundry.ir.hir.math.softplus import Softplus
 
 
 def test_softplus_evaluate():

--- a/tests/ops/test_transpose.py
+++ b/tests/ops/test_transpose.py
@@ -12,9 +12,6 @@ from __future__ import annotations
 import pytest
 import torch
 
-from tilefoundry.ir.hir.tensor.transpose import Transpose
-from tilefoundry.ir.types import DType
-from tilefoundry.ir.types.shard.shard_layout import Broadcast, Split
 from tests.ops.eval_utils import EvalCase, run_eval_case
 from tests.ops.typeinfer_utils import (
     TypeInferCase,
@@ -23,6 +20,9 @@ from tests.ops.typeinfer_utils import (
     sharded,
     ten,
 )
+from tilefoundry.ir.hir.tensor.transpose import Transpose
+from tilefoundry.ir.types import DType
+from tilefoundry.ir.types.shard.shard_layout import Broadcast, Split
 
 # A 4-axis mesh whose split axis factorizes a tensor dim into mesh-extent ×
 # per-shard sub-positions (cluster, cta, warp, lane).

--- a/tests/ops/test_tuple_get_item.py
+++ b/tests/ops/test_tuple_get_item.py
@@ -3,16 +3,16 @@ from __future__ import annotations
 
 import pytest
 
-from tilefoundry.ir.core import Op
-from tilefoundry.ir.hir.tensor.tuple_get_item import TupleGetItem
-from tilefoundry.ir.target.storage import StorageKind
-from tilefoundry.ir.types import DType, TupleType
 from tests.ops.typeinfer_utils import (
     ExpectedError,
     TypeInferCase,
     run_typeinfer_case,
     ten,
 )
+from tilefoundry.ir.core import Op
+from tilefoundry.ir.hir.tensor.tuple_get_item import TupleGetItem
+from tilefoundry.ir.target.storage import StorageKind
+from tilefoundry.ir.types import DType, TupleType
 
 
 def _scalar(dtype):

--- a/tests/ops/test_typeinfer_harness.py
+++ b/tests/ops/test_typeinfer_harness.py
@@ -3,10 +3,6 @@ from __future__ import annotations
 
 import pytest
 
-from tilefoundry.ir.core.kinds import BinaryKind, UnaryKind
-from tilefoundry.ir.hir.math.binary import Binary
-from tilefoundry.ir.hir.math.unary import Unary
-from tilefoundry.ir.types import DType
 from tests.ops.typeinfer_utils import (
     STORAGES,
     ExpectedError,
@@ -15,6 +11,10 @@ from tests.ops.typeinfer_utils import (
     ten,
     tensor_grid,
 )
+from tilefoundry.ir.core.kinds import BinaryKind, UnaryKind
+from tilefoundry.ir.hir.math.binary import Binary
+from tilefoundry.ir.hir.math.unary import Unary
+from tilefoundry.ir.types import DType
 
 _ADD = Binary(kind=BinaryKind.ADD)
 

--- a/tests/ops/typeinfer_utils.py
+++ b/tests/ops/typeinfer_utils.py
@@ -16,7 +16,6 @@ from tilefoundry.ir.core.errors import VerifyError
 from tilefoundry.ir.types import DType, TensorType, TupleType
 from tilefoundry.ir.types.shard.layout import Layout
 from tilefoundry.ir.types.shard.mesh import Mesh
-from tilefoundry.ir.types.shard.layout import Layout
 from tilefoundry.ir.types.shard.shard_layout import ShardLayout
 from tilefoundry.visitor_registry.contexts import TypeInferContext
 from tilefoundry.visitor_registry.visitors import TypeInferVisitor

--- a/tests/parser/hir/test_demo_proj_qkv.py
+++ b/tests/parser/hir/test_demo_proj_qkv.py
@@ -27,8 +27,8 @@ from tilefoundry.inspection.viewer import (
     Viewer,
 )
 from tilefoundry.ir.core.expr import Call
-from tilefoundry.ir.hir.grid_region import GridRegionExpr
 from tilefoundry.ir.hir.cuda.nn.mma import Mma_SM80_16x8x16
+from tilefoundry.ir.hir.grid_region import GridRegionExpr
 from tilefoundry.ir.types.shard import (
     Mesh,
     Topology,

--- a/tests/parser/hir/test_parse_shard_sugar.py
+++ b/tests/parser/hir/test_parse_shard_sugar.py
@@ -16,6 +16,7 @@ from typing import Any, Callable
 
 import pytest
 
+from tests.fixtures.demo_ir import build_demo
 from tilefoundry import func
 from tilefoundry.dsl import Tensor
 from tilefoundry.dsl.tf import *  # noqa: F401, F403 -- binds bare op names (reshard, ...)
@@ -34,8 +35,6 @@ from tilefoundry.ir.types.shard import (
 )
 from tilefoundry.ir.types.shard.shard_layout import Broadcast, Partial, Split
 from tilefoundry.parser.sugar import parse_shard_layout_sugar
-from tests.fixtures.demo_ir import build_demo
-
 
 # ── shared assertion helpers ─────────────────────────────────────────────────
 

--- a/tests/parser/tir/test_dynamic_cta.py
+++ b/tests/parser/tir/test_dynamic_cta.py
@@ -9,7 +9,7 @@ kernels get no hidden scalars.
 from __future__ import annotations
 
 from tilefoundry import prim_func
-from tilefoundry.dsl import DimVar, Tensor, T
+from tilefoundry.dsl import DimVar, T, Tensor
 from tilefoundry.ir.target.storage import StorageKind
 from tilefoundry.ir.types import DType, TensorType
 from tilefoundry.ir.types.shard import Layout, Mesh, ShardLayout, Split, Topology

--- a/tests/parser/tir/test_mma_atom.py
+++ b/tests/parser/tir/test_mma_atom.py
@@ -16,12 +16,12 @@ import pytest
 from tilefoundry import prim_func
 from tilefoundry.dsl import T, Tensor
 from tilefoundry.ir.core import VerifyError
+from tilefoundry.ir.target.storage import StorageKind
 from tilefoundry.ir.tir.cuda.nn.mma import make_atom
 from tilefoundry.ir.tir.cuda.nn.mma_atom import MmaAtom, MmaOpSpec
 from tilefoundry.ir.tir.stmts import LetStmt, MeshScope
 from tilefoundry.ir.types import DType, TensorType
-from tilefoundry.ir.types.shard import Mesh, Layout, ShardLayout, Topology
-from tilefoundry.ir.target.storage import StorageKind
+from tilefoundry.ir.types.shard import Layout, Mesh, ShardLayout, Topology
 
 # Module-level pre-instantiated alias (equivalent to building it inline).
 _OP = T.cuda.mma.SM80_16x8x16_F32BF16BF16F32_TN
@@ -87,7 +87,7 @@ def test_infunc_op_and_atom_emit_no_letstmt() -> None:
     @prim_func(target="cuda")
     def kernel(a: Tensor[(16, 16), "bf16"]):  # noqa: ARG001
         op = T.cuda.mma.SM80_16x8x16_F32BF16BF16F32_TN
-        atom = T.cuda.mma.atom(op=op)
+        atom = T.cuda.mma.atom(op=op)  # noqa: F841
 
     assert all(not isinstance(s, LetStmt) for s in kernel.body.body)
     assert kernel.body.body == ()
@@ -120,8 +120,8 @@ def _alloc_frag_kernel(topology, mesh_layout):
     """A kernel that allocs a fragment via `atom.A` inside the given scope."""
     def kernel(a: Tensor[(16, 16), "bf16"]):  # noqa: ARG001
         atom = T.cuda.mma.atom(op=T.cuda.mma.SM80_16x8x16_F32BF16BF16F32_TN)
-        with Mesh(topology, mesh_layout) as warp:
-            frag = T.alloc_tensor(
+        with Mesh(topology, mesh_layout) as warp:  # noqa: F841
+            frag = T.alloc_tensor(  # noqa: F841
                 TensorType(shape=(16, 16), dtype=DType.bf16, layout=atom.A,
                            storage=StorageKind.RMEM)
             )
@@ -195,7 +195,7 @@ def test_atom_A_outside_mesh_scope_is_rejected() -> None:
 
     def kernel(a: Tensor[(16, 16), "bf16"]):  # noqa: ARG001
         atom = T.cuda.mma.atom(op=T.cuda.mma.SM80_16x8x16_F32BF16BF16F32_TN)
-        frag = T.alloc_tensor(
+        frag = T.alloc_tensor(  # noqa: F841
             TensorType(shape=(16, 16), dtype=DType.bf16, layout=atom.A,
                        storage=StorageKind.RMEM)
         )

--- a/tests/parser/tir/test_sync.py
+++ b/tests/parser/tir/test_sync.py
@@ -19,8 +19,8 @@ import pytest
 import tilefoundry.codegen.cuda  # noqa: F401 — trigger emitter autodiscovery
 from tilefoundry import prim_func
 from tilefoundry.codegen.cuda.context import CodegenContext
-from tilefoundry.dsl import Tensor, T
-from tilefoundry.ir.core import VerifyError, Var
+from tilefoundry.dsl import T, Tensor
+from tilefoundry.ir.core import Var, VerifyError
 from tilefoundry.ir.tir.prim_function import PrimFunction
 from tilefoundry.ir.tir.stmts import Evaluate, MeshScope, Return, Sequential
 from tilefoundry.ir.tir.sync import Sync, SyncBarrier, classify

--- a/tests/passes/test_bufferize.py
+++ b/tests/passes/test_bufferize.py
@@ -5,6 +5,7 @@ pass leaves the ``PrimFunction`` body structurally unchanged.
 """
 from __future__ import annotations
 
+from tests.fixtures.demo_ir import build_demo
 from tilefoundry.ir.core import Call
 from tilefoundry.ir.core.module import Module
 from tilefoundry.ir.tir.memory import AllocTensor as AllocTensorOp
@@ -17,7 +18,6 @@ from tilefoundry.passes.transforms.bufferize import (
     LifetimeCollector,
     Placement,
 )
-from tests.fixtures.demo_ir import build_demo
 
 
 def _lower() -> tuple[PrimFunction, Module]:

--- a/tests/passes/test_hir_to_tir.py
+++ b/tests/passes/test_hir_to_tir.py
@@ -6,6 +6,8 @@ import textwrap
 
 import pytest
 
+from tests.fixtures.demo_ir import build_demo
+
 # DSL surface imported at module scope so ``@func`` closure
 # resolution sees ``Tensor`` / ``Mesh`` / ... when the tests below
 # build inline @func definitions.
@@ -29,7 +31,6 @@ from tilefoundry.ir.types import DType
 from tilefoundry.ir.types.shard.shard_layout import ShardLayout as SL
 from tilefoundry.parser.hir_parser import parse_script
 from tilefoundry.passes.transforms import HirToTirPass
-from tests.fixtures.demo_ir import build_demo
 
 
 def _run() -> PrimFunction:

--- a/tests/passes/test_pass_manager.py
+++ b/tests/passes/test_pass_manager.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 import pytest
 
 import tilefoundry
+from tests.fixtures.demo_ir import build_demo
 from tilefoundry.dump import DumpFlags, DumpScope, MemoryDumper
 from tilefoundry.ir.core.module import Module
 from tilefoundry.ir.tir.prim_function import PrimFunction
 from tilefoundry.passes import ModulePass, PassManager
 from tilefoundry.passes.transforms import HirToTirPass
-from tests.fixtures.demo_ir import build_demo
 
 
 def _demo_module() -> Module:

--- a/tests/runtime/test_jit.py
+++ b/tests/runtime/test_jit.py
@@ -4,13 +4,13 @@ import hashlib
 
 import pytest
 
+from tests.fixtures.demo_canonical import build_demo_canonical
+from tests.fixtures.demo_ir import build_demo
 from tilefoundry import jit
 from tilefoundry.compile import _canonical_module_text, _jit_cache_key_payload
 from tilefoundry.ir.core.module import Module
 from tilefoundry.ir.types.shard.mesh import Topology
 from tilefoundry.runtime.module import RuntimeModule
-from tests.fixtures.demo_canonical import build_demo_canonical
-from tests.fixtures.demo_ir import build_demo
 
 
 def test_jit_rejects_non_ir_inputs_and_unknown_targets() -> None:


### PR DESCRIPTION
## What

Adds a required GitHub Actions gate for `main`: `pre-commit run --all-files`
(lint) then the full `pytest tests/` (unit + codegen + nvcc + GPU e2e), both
running **directly inside a self-hosted runner container** on an H200 (sm_90).
No `container:` key / nested Docker — the Actions agent already runs inside the
container.

Four scoped commits:

1. `style:` tree-wide `ruff --fix` + `clang-format` so the new lint gate starts
   clean (import order / line-wrapping only; the 7 intentional DSL binding sites
   get `# noqa: F841`).
2. `feat(codegen):` parameterize the CUDA arch (was hard-coded `"80"`), threading
   `CudaTarget.arch` end-to-end (`compile.py` → `link_modules` → CMake template);
   default sm_90 (native Hopper).
3. `ci:` the workflow + `Dockerfile` + pre-commit ruff hook.
4. `build:` require `torch>=2.7` — `main` maps `DType.f8e8m0` to
   `torch.float8_e8m0fnu` (added in torch 2.7), but declared only a bare `torch`
   dep, so `import tilefoundry` fails on torch < 2.7.

## Runner requirements

The suite needs `nvcc` + a CUDA device, so it runs on a **self-hosted** runner
(hosted runners fail, not skip, the compile/e2e tests). CI expects a runner:

- labelled `tilefoundry`,
- launched pinned to one GPU (e.g. `--gpus '"device=4"'`),
- built from the included `Dockerfile` (CUDA 12.9 devel, Python 3.12,
  **torch 2.9.1+cu128**, cmake / ninja / g++ / clang-format-18, cutlass
  `include/` baked at the pinned submodule SHA at `/opt/cutlass/include`).

Jobs run their steps directly in that container; `test` symlinks the baked
cutlass headers, does an offline editable install, then runs the suite.

## Verified locally (H200, GPU 4, torch 2.9.1+cu128)

- `pre-commit run --all-files`: ruff / clang-format / spec-rules / spec-entropy — all pass.
- full `pytest tests/`: **827 passed**.

## Notes

- `pull_request` runs on the merge of this branch + base, so CI also exercises
  the current `main`.
- The `Dockerfile` uses the official `download.pytorch.org` index (portable).
- Image-rebuild automation is intentionally left out of this PR.
