### PR TITLE
ir: add typed expression metadata

### DIFF
--- a/docs/spec/core-ir.md
+++ b/docs/spec/core-ir.md
@@ -1,17 +1,18 @@
 # TileFoundry Spec — core_ir
 
-Defines the shared node algebra — `Module` / `Expr` / `Op` / `Call` /
-`Var` / `Constant` / `Tuple` — that both HIR and TIR consume. `core_ir` is the
-shared node algebra layer, not a standalone IR: HIR and TIR each extend it with
-their own `Function` container and their own `Op` / `Stmt` subclasses. Types
-carried by `Expr.type` are defined in [types](./types.md); the distributed
-layout layer is [shard](./shard.md); `Stmt` is not here — it lives only in
-[tir §1](./tir.md) as a TIR-only base class.
+Defines the shared node algebra — `Module` / `Expr` / `IRMetadata` / `Op` /
+`Call` / `Var` / `Constant` / `Tuple` — that both HIR and TIR consume.
+`core_ir` is the shared node algebra layer, not a standalone IR: HIR and TIR
+each extend it with their own `Function` container and their own `Op` / `Stmt`
+subclasses. Types carried by `Expr.type` are defined in [types](./types.md);
+the distributed layout layer is [shard](./shard.md); `Stmt` is not here — it
+lives only in [tir §1](./tir.md) as a TIR-only base class.
 
 ```mermaid
 flowchart TB
     Module["<b>Module</b>"]
     Expr["<b>Expr</b>"]
+    IRMetadata["<b>IRMetadata</b>"]
     Op["<b>Op</b>"]
     Call["<b>Call</b>"]
     Var["<b>Var</b>"]
@@ -21,6 +22,7 @@ flowchart TB
     Expr --> Constant
     Expr --> Tuple
     Expr --> Call
+    Expr -. metadata .-> IRMetadata
     Call -. target .-> Op
 ```
 
@@ -93,14 +95,45 @@ entries — so name resolution is always single-valued.
 ## 2. `Expr`
 
 ```python
+class IRMetadata:
+    def format_comment(self) -> str | None: ...
+```
+
+- constraints:
+  - the immutable base of every typed annotation stored on an `Expr`;
+    `format_comment()` returns `None` unless a concrete metadata class provides
+    a printable comment.
+
+```python
 class Expr:
-    type: IRType        # the node's IRType; always present
-    source: str | None  # optional original source slice for debug / error location
+    type: Type
+    loc: str | None = None
+    metadata: tuple[IRMetadata, ...] = ()
 ```
 
 - constraints:
   - base of every expression node; concrete subclasses are dialect-owned, not
     introduced per Op (value-producing Ops appear as `Call` nodes).
+  - `metadata` contains only `IRMetadata` values and contains at most one value
+    of each exact concrete metadata class; invalid entries or duplicate classes
+    raise `VerifyError`, including `loc` when it is available.
+  - `metadata` MUST NOT participate in expression equality, hashing, or repr.
+
+```python
+def get_metadata(expr: "Expr", cls: type[T]) -> T | None: ...
+def replace_metadata(expr: "Expr", value: IRMetadata) -> "Expr": ...
+def remove_metadata(expr: "Expr", cls: type[IRMetadata]) -> "Expr": ...
+```
+
+- constraints:
+  - all three helpers match an exact concrete class, not subclasses, and never
+    mutate the input expression.
+  - `get_metadata` returns the unique matching value or `None`.
+  - `replace_metadata` returns a copy with the matching value replaced in its
+    existing position; every other value keeps its relative order, and a value
+    whose class is absent is appended.
+  - `remove_metadata` returns a copy without the matching value; when the class
+    is absent it returns the input expression unchanged.
 
 `Expr` always carries a `type`. The runtime class of `Expr.type` is
 one of `TensorType` / `TupleType` / `UnitType`

--- a/src/tilefoundry/ir/core/__init__.py
+++ b/src/tilefoundry/ir/core/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from .errors import VerifyError
 from .expr import Call, Constant, Expr, Tuple, Var
+from .metadata import IRMetadata, get_metadata, remove_metadata, replace_metadata
 from .op import Op, ParameterInfo
 from .registry import (
     AnalysisRegistry,
@@ -23,6 +24,8 @@ from .context import TypeInferContext
 __all__ = [
     # exprs
     "Expr", "Var", "Constant", "Call", "Tuple",
+    # metadata
+    "IRMetadata", "get_metadata", "replace_metadata", "remove_metadata",
     # op
     "Op", "ParameterInfo",
     # registry

--- a/src/tilefoundry/ir/core/expr.py
+++ b/src/tilefoundry/ir/core/expr.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+from tilefoundry.ir.core.errors import VerifyError
+from tilefoundry.ir.core.metadata import IRMetadata
 from tilefoundry.ir.core.op import Op
 
 from ..types.tensor_type import Type
@@ -17,6 +19,31 @@ class Expr:
     """
     type: Type = field(kw_only=True)
     loc: str | None = field(default=None, kw_only=True)
+    metadata: tuple[IRMetadata, ...] = field(
+        default_factory=tuple,
+        kw_only=True,
+        compare=False,
+        hash=False,
+        repr=False,
+    )
+
+    def __post_init__(self) -> None:
+        seen: set[type[IRMetadata]] = set()
+        for value in self.metadata:
+            if not isinstance(value, IRMetadata):
+                where = f"\n  at {self.loc}" if self.loc else ""
+                raise VerifyError(
+                    f"{type(self).__name__} metadata entries must be IRMetadata, "
+                    f"got {type(value).__name__}{where}"
+                )
+            value_cls = type(value)
+            if value_cls in seen:
+                where = f"\n  at {self.loc}" if self.loc else ""
+                raise VerifyError(
+                    f"{type(self).__name__} has duplicate {value_cls.__name__} "
+                    f"metadata{where}"
+                )
+            seen.add(value_cls)
 
 
 @dataclass(frozen=True)

--- a/src/tilefoundry/ir/core/metadata.py
+++ b/src/tilefoundry/ir/core/metadata.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import TYPE_CHECKING, TypeVar
+
+if TYPE_CHECKING:
+    from .expr import Expr
+
+T = TypeVar("T", bound="IRMetadata")
+
+
+@dataclass(frozen=True)
+class IRMetadata:
+    """Base class for typed metadata attached to an IR expression."""
+
+    def format_comment(self) -> str | None:
+        """Return an optional source-printer comment for this metadata."""
+        return None
+
+
+def get_metadata(expr: Expr, cls: type[T]) -> T | None:
+    """Return the metadata whose concrete class is ``cls``, if present."""
+    return next((value for value in expr.metadata if type(value) is cls), None)
+
+
+def replace_metadata(expr: Expr, value: IRMetadata) -> Expr:
+    """Return ``expr`` with metadata of ``value``'s concrete class replaced."""
+    value_cls = type(value)
+    found = False
+    updated = []
+    for current in expr.metadata:
+        if type(current) is value_cls:
+            updated.append(value)
+            found = True
+        else:
+            updated.append(current)
+    if not found:
+        updated.append(value)
+    return replace(expr, metadata=tuple(updated))
+
+
+def remove_metadata(expr: Expr, cls: type[IRMetadata]) -> Expr:
+    """Return ``expr`` without metadata whose concrete class is ``cls``."""
+    updated = tuple(value for value in expr.metadata if type(value) is not cls)
+    if updated == expr.metadata:
+        return expr
+    return replace(expr, metadata=updated)
+
+
+__all__ = ["IRMetadata", "get_metadata", "remove_metadata", "replace_metadata"]

--- a/src/tilefoundry/ir/core/metadata.py
+++ b/src/tilefoundry/ir/core/metadata.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
-from typing import TYPE_CHECKING, TypeVar
-
-if TYPE_CHECKING:
-    from .expr import Expr
+from typing import TypeVar
 
 T = TypeVar("T", bound="IRMetadata")
 
@@ -18,12 +15,12 @@ class IRMetadata:
         return None
 
 
-def get_metadata(expr: Expr, cls: type[T]) -> T | None:
+def get_metadata(expr: "Expr", cls: type[T]) -> T | None:
     """Return the metadata whose concrete class is ``cls``, if present."""
     return next((value for value in expr.metadata if type(value) is cls), None)
 
 
-def replace_metadata(expr: Expr, value: IRMetadata) -> Expr:
+def replace_metadata(expr: "Expr", value: IRMetadata) -> "Expr":
     """Return ``expr`` with metadata of ``value``'s concrete class replaced."""
     value_cls = type(value)
     found = False
@@ -39,7 +36,7 @@ def replace_metadata(expr: Expr, value: IRMetadata) -> Expr:
     return replace(expr, metadata=tuple(updated))
 
 
-def remove_metadata(expr: Expr, cls: type[IRMetadata]) -> Expr:
+def remove_metadata(expr: "Expr", cls: type[IRMetadata]) -> "Expr":
     """Return ``expr`` without metadata whose concrete class is ``cls``."""
     updated = tuple(value for value in expr.metadata if type(value) is not cls)
     if updated == expr.metadata:

--- a/tests/core/test_metadata.py
+++ b/tests/core/test_metadata.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from tilefoundry.ir.core import (
+    IRMetadata,
+    Var,
+    VerifyError,
+    get_metadata,
+    remove_metadata,
+    replace_metadata,
+)
+from tilefoundry.ir.types import DType, TensorType
+
+
+@dataclass(frozen=True)
+class _Label(IRMetadata):
+    value: str
+
+
+@dataclass(frozen=True)
+class _Ordinal(IRMetadata):
+    value: int
+
+
+def _type() -> TensorType:
+    return TensorType.scalar(DType.f32)
+
+
+def test_metadata_defaults_and_base_comment() -> None:
+    expr = Var(type=_type(), name="x")
+
+    assert expr.metadata == ()
+    assert IRMetadata().format_comment() is None
+
+
+def test_metadata_does_not_change_expr_semantics_or_repr() -> None:
+    plain = Var(type=_type(), name="x")
+    annotated = Var(type=_type(), name="x", metadata=(_Label("selected"),))
+
+    assert annotated == plain
+    assert hash(annotated) == hash(plain)
+    assert "metadata" not in repr(annotated)
+
+
+def test_expr_rejects_duplicate_concrete_metadata_class() -> None:
+    with pytest.raises(VerifyError, match=r"duplicate _Label metadata") as exc_info:
+        Var(
+            type=_type(),
+            name="x",
+            loc="model.py:7",
+            metadata=(_Label("first"), _Label("second")),
+        )
+    assert "at model.py:7" in str(exc_info.value)
+
+
+def test_expr_rejects_untyped_metadata_entry() -> None:
+    with pytest.raises(VerifyError, match="must be IRMetadata, got object"):
+        Var(type=_type(), name="x", metadata=(object(),))  # type: ignore[arg-type]
+
+
+def test_metadata_helpers_preserve_order_and_source_expr() -> None:
+    label = _Label("old")
+    ordinal = _Ordinal(3)
+    expr = Var(type=_type(), name="x", metadata=(label, ordinal))
+
+    assert get_metadata(expr, _Label) is label
+    assert get_metadata(expr, IRMetadata) is None
+
+    replacement = _Label("new")
+    replaced = replace_metadata(expr, replacement)
+    assert replaced.metadata == (replacement, ordinal)
+    assert expr.metadata == (label, ordinal)
+
+    removed = remove_metadata(replaced, _Label)
+    assert removed.metadata == (ordinal,)
+    assert remove_metadata(removed, _Label) is removed


### PR DESCRIPTION
## Summary

- add the frozen IRMetadata base and typed get, replace, and remove helpers
- attach immutable metadata tuples to Expr without changing equality, hashing, or repr
- reject duplicate concrete metadata classes and invalid entries with source locations

## Testing

- focused core and IR suite: 141 passed
- full suite: 926 passed in 259.67s
- Ruff passed on all changed Python files
- git diff --check passed