### PR TITLE
ir: replace DType enum with descriptors

### DIFF
--- a/docs/spec/inspection.md
+++ b/docs/spec/inspection.md
@@ -65,6 +65,10 @@ Both modes MUST agree on semantics; only the level of detail differs.
 The meaning of `Split` / `Partial` / `Broadcast` is owned by
 [shard](./shard.md); these forms define only render syntax.
 
+Canonical DType text is the descriptor's `name`. Tensor annotations and DType
+op attributes MUST emit that name as a quoted DSL string. Compact labels MAY
+omit the quotes, but MUST NOT use the descriptor's raw `repr()`.
+
 ### 2.4 Pretty-print / debug display contract
 
 Pretty print is the core presentation layer.  Sugar, debug dumps, and
@@ -72,7 +76,8 @@ viewer type/value text reuse the same DSL text forms in §2.3.  That keeps
 round-trippable source, labels, and detail panes semantically aligned.
 
 - op attributes that are `DType`, `TensorType`, `Layout`, or `ShardLayout` are
-  rendered through the §2.3 printer, not through raw dataclass / enum `repr()`
+  rendered through the §2.3 printer; `DType` uses its canonical name and these
+  values do not use raw `repr()` output
 
 `repr()` is a debug surface, not the source of truth.  It may delegate to
 the §2.3 implementation for context-free values, but context-dependent
@@ -121,6 +126,8 @@ MUST round-trip: `print → parse → structural_equal` holds over
 
 - Params: shape, dtype, storage, layout.attrs, layout.shape, layout.strides, mesh identity (topology name/size, layout shape, names)
 - Body: op class, args, keyword attrs, types
+- DType annotations and op attributes preserve the selected descriptor singleton
+  through their canonical names
 - Partial layouts preserve mesh names through the canonical
   parser §1.5 value-state form, and preserve `Partial.reduction` plus the
   attrs-position mesh axis in the underlying IR

--- a/docs/spec/parser.md
+++ b/docs/spec/parser.md
@@ -173,6 +173,14 @@ Tensor[(4096, 2048), "bf16", (4096 @ gpu.cta, 2048), "smem"]
 Tensor[(), "bf16"]                                    # scalar
 ```
 
+- constraints:
+  - The dtype slot MUST use a canonical quoted `DType.name` from
+    [types §3](./types.md#3-dtype).
+  - The parser MUST normalize that string to the corresponding process-lifetime
+    descriptor before constructing `TensorType`.
+  - An unknown dtype string MUST be rejected; it MUST NOT fall back to another
+    descriptor.
+
 ### 1.5 Layout sugar
 
 ```
@@ -449,17 +457,16 @@ Conventions:
   (`int` / `str` / `ShardLayout` / …). Referenced types
   are auto-imported in the generated header so the `.pyi` is
   self-contained.
-- An attribute whose `annotation` is a string-valued enum (e.g.
-  `DType`, `ReduceKind`) renders as `Literal[<member strings>] |
-  <EnumType>`, with the `Literal` members derived from the enum
-  itself so the candidate set has a single source of truth. The DSL
-  surface accepts the string form (`dtype="f32"`, `kind="sum"`),
-  which the parser normalizes to the enum at the call boundary (§3);
-  the enum remains the IR-canonical attribute type and is kept in
-  the union for back-compatibility. Static enum objects are not
-  exported as a parallel authoring surface — the string form is the
-  authoring path, matching the `Tensor[..., "bf16"]` dtype slot
-  (§1.4).
+- A `DType` attribute renders as `Literal[<canonical names>] | DType`, with the
+  `Literal` members derived from the closed descriptor set in
+  [types §3](./types.md#3-dtype). The string form is the canonical DSL authoring
+  path and the parser normalizes it to the corresponding descriptor at the call
+  boundary. A descriptor value remains accepted as the IR-canonical attribute
+  value in direct Python expressions.
+- Any other string-valued enum attribute, such as `ReduceKind`, renders as
+  `Literal[<member strings>] | <EnumType>`. Its `Literal` members derive from
+  the enum, and the parser normalizes a string to the corresponding enum member
+  at the call boundary.
 
 Stubs are not part of the runtime resolution path; the parser still
 goes through §2.3. They exist solely so editors can show typed
@@ -706,6 +713,13 @@ ParamDef declares a layout annotation. Ops without a registered
 schema fall through to a small legacy heuristic
 (`attr_name == "layout"` ⇒ `ShardLayout` sugar) until they migrate.
 
+Attribute string normalization is also annotation-driven:
+
+- `annotation=DType` resolves a canonical string by descriptor `name` and
+  rejects any other string with a `VerifyError`.
+- A string-valued Enum annotation resolves by Enum value and rejects any other
+  string with a `VerifyError`.
+
 ### 3.5 `Tensor[...]` annotation surface
 
 `Tensor[shape, dtype, layout, storage]` is recognised by
@@ -714,6 +728,9 @@ both `@func` and `@prim_func` parsers when reading parameter and
 return-type annotations. The shape and dtype slots are required;
 the layout and storage slots are optional. The same routine reads
 the layout sugar described in §1.4.
+
+The dtype slot MUST resolve to the canonical descriptor named by its string.
+Unknown names MUST be rejected and MUST NOT silently select `DType.f32`.
 
 ### 3.6 Per-dialect strict resolution
 

--- a/docs/spec/types.md
+++ b/docs/spec/types.md
@@ -90,22 +90,67 @@ dispatch is described in
 ## 3. `DType`
 
 ```python
-class DType(enum.Enum):    # enumerated dtype values, extended on demand
-    f32 = "f32"
-    f16 = "f16"
-    bf16 = "bf16"
-    fp8e4m3 = "fp8e4m3"
-    f8e8m0 = "f8e8m0"
-    f4e2m1 = "f4e2m1"
-    i32 = "i32"
-    i64 = "i64"
-    bool = "bool"
+class DType:
+    """Describe an element type.
+
+    Attributes:
+        name: Canonical DSL spelling.
+        bit_width: Logical number of bits per element.
+    """
+
+    name: str
+    bit_width: int
+
+
+class FloatDType(DType):
+    """Describe a floating-point element type.
+
+    Attributes:
+        exponent_bits: Number of exponent bits.
+        mantissa_bits: Number of explicit mantissa bits.
+    """
+
+    exponent_bits: int
+    mantissa_bits: int
+
+
+class IntegerDType(DType):
+    """Describe an integer element type.
+
+    Attributes:
+        signed: Whether the integer representation is signed.
+    """
+
+    signed: bool
+
+
+class BoolDType(DType):
+    """Describe the boolean element type."""
 ```
 
-`DType` is a value enumeration, independent of `layout` / `storage`.
+The canonical descriptors are:
+
+| Surface | Descriptor class | `bit_width` | Family-specific facts |
+| --- | --- | ---: | --- |
+| `DType.f32` | `FloatDType` | 32 | `exponent_bits=8`, `mantissa_bits=23` |
+| `DType.f16` | `FloatDType` | 16 | `exponent_bits=5`, `mantissa_bits=10` |
+| `DType.bf16` | `FloatDType` | 16 | `exponent_bits=8`, `mantissa_bits=7` |
+| `DType.fp8e4m3` | `FloatDType` | 8 | `exponent_bits=4`, `mantissa_bits=3` |
+| `DType.f8e8m0` | `FloatDType` | 8 | `exponent_bits=8`, `mantissa_bits=0` |
+| `DType.f4e2m1` | `FloatDType` | 4 | `exponent_bits=2`, `mantissa_bits=1` |
+| `DType.i32` | `IntegerDType` | 32 | `signed=True` |
+| `DType.i64` | `IntegerDType` | 64 | `signed=True` |
+| `DType.bool` | `BoolDType` | 1 | none |
 
 - constraints:
-  - Each member's value equals its name.
+  - `DType` MUST be an immutable descriptor hierarchy, not an `enum.Enum`.
+  - Each surface value MUST be a process-lifetime singleton whose `name` equals
+    the attribute spelling after `DType.`.
+  - The table above is the complete built-in set. The type system MUST NOT
+    expose custom registration or Enum-style `.value`, `__members__`, indexing,
+    or iteration surfaces.
+  - Descriptor equality and hashing MUST use the complete descriptor fields.
+  - `DType` is independent of `layout` and `storage`.
   - `fp8e4m3` is the canonical fp8 spelling; no alternate fp8 spelling (e.g.
     `f8e4m3`) exists.
   - `fp8e4m3`, `f8e8m0`, and `f4e2m1` are low-precision dtypes: logical element

--- a/src/tilefoundry/dsl/__init__.py
+++ b/src/tilefoundry/dsl/__init__.py
@@ -20,7 +20,7 @@ via ``python -m tilefoundry.dsl regen``).
 
 DType values use **string form** in DSL source —
 ``Tensor[(8,), "bf16"]``, ``zeros((1, 64), "bf16", ...)`` — and the
-parser auto-converts the string to the corresponding ``DType`` enum
+parser auto-converts the string to the corresponding ``DType`` descriptor
 at attribute-binding time.
 """
 

--- a/src/tilefoundry/dsl/_stub_gen.py
+++ b/src/tilefoundry/dsl/_stub_gen.py
@@ -36,6 +36,7 @@ from tilefoundry.ir.core.expr import Expr
 from tilefoundry.ir.core.op_registry import _schemas_by_dialect_name
 from tilefoundry.ir.core.op_schema import OpSchema
 from tilefoundry.ir.core.param_def import MISSING, ParamDef
+from tilefoundry.ir.types import DType
 
 # Builtin type names that don't need an explicit ``import`` in the .pyi.
 _BUILTIN_TYPE_NAMES: frozenset[str] = frozenset({
@@ -59,13 +60,24 @@ def _annotation_type(pd: ParamDef) -> tuple[str, str]:
     """Render an attribute ParamDef's annotation as ``(stub_type, import_name)``.
 
     ``import_name`` is the bare class name to import (``""`` for builtins).
-    A string-valued enum attribute renders as ``Literal[<values>] | EnumName``
-    so the authoring surface accepts the string form while the enum stays the
-    IR-canonical type; the import name is the enum class (not ``Literal``).
+    A DType or string-valued enum attribute renders as
+    ``Literal[<values>] | TypeName`` so the authoring surface accepts the
+    string form while the descriptor or enum stays IR-canonical.
     """
     ann = pd.annotation
     if ann is object:
         return "Any", ""
+    if ann is DType:
+        members = ", ".join(
+            repr(candidate.name)
+            for candidate in vars(DType).values()
+            if isinstance(candidate, DType)
+        )
+        name = ann.__name__
+        base = f"Literal[{members}] | {name}"
+        if pd.optional:
+            base = f"{base} | None"
+        return base, name
     if isinstance(ann, type) and issubclass(ann, enum.Enum):
         members = ", ".join(repr(e.value) for e in ann)
         name = ann.__name__

--- a/src/tilefoundry/dsl/_tensor.py
+++ b/src/tilefoundry/dsl/_tensor.py
@@ -26,7 +26,10 @@ class Tensor:
         shape = args[0]
         dtype_val = args[1] if len(args) > 1 else DType.f32
         if isinstance(dtype_val, str):
-            dtype_val = getattr(DType, dtype_val, DType.f32)
+            member = getattr(DType, dtype_val, None)
+            if not isinstance(member, DType):
+                raise ValueError(f"DType: unknown value {dtype_val!r}")
+            dtype_val = member
         if not isinstance(shape, tuple):
             shape = (shape,)
         layout = args[2] if len(args) > 2 else None

--- a/src/tilefoundry/inspection/python_printer.py
+++ b/src/tilefoundry/inspection/python_printer.py
@@ -626,11 +626,10 @@ def _emit_def(
                 for k, v in attrs.items():
                     if isinstance(v, str):
                         attr_strs.append(f'{k}="{v}"')
+                    elif isinstance(v, DType):
+                        attr_strs.append(f'{k}="{v.name}"')
                     elif isinstance(v, enum.Enum) and isinstance(v.value, str):
-                        # A string-valued enum attribute (ReduceKind / DType /
-                        # ...) prints as its DSL string value so the source
-                        # re-parses without a bare enum reference — the parser
-                        # promotes the string back via the ParamDef annotation.
+                        # String-valued enum attributes print in their DSL form.
                         attr_strs.append(f'{k}="{v.value}"')
                     elif isinstance(v, float):
                         attr_strs.append(f"{k}={v!r}")

--- a/src/tilefoundry/inspection/viewer/builder.py
+++ b/src/tilefoundry/inspection/viewer/builder.py
@@ -156,7 +156,7 @@ def _format_constant(c: Constant) -> str:
     ``const([1.0f, 2.0f, ...])`` truncated to the first 8 elements."""
     ty = getattr(c, "type", None)
     suffix = (
-        _CONST_DTYPE_SUFFIX.get(ty.dtype.value, "")
+        _CONST_DTYPE_SUFFIX.get(ty.dtype.name, "")
         if isinstance(ty, TensorType) and isinstance(ty.dtype, DType) else ""
     )
 

--- a/src/tilefoundry/ir/types/__init__.py
+++ b/src/tilefoundry/ir/types/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 # ruff: noqa: I001 -- curated re-export order; alphabetical sort breaks staged imports.
 
-from .dtype import DType
+from .dtype import BoolDType, DType, FloatDType, IntegerDType
 from .tensor_type import TensorType, TupleType, Type, UnitType
 from .utils import make_shard_tensor_type, make_tensor_type
 from .callable_type import (
@@ -13,8 +13,11 @@ from .callable_type import (
 
 
 __all__ = [
+    "BoolDType",
     "CallableType",
     "DType",
+    "FloatDType",
+    "IntegerDType",
     "TensorType",
     "TupleType",
     "Type",

--- a/src/tilefoundry/ir/types/dtype.py
+++ b/src/tilefoundry/ir/types/dtype.py
@@ -1,18 +1,41 @@
+"""Closed, process-lifetime DType descriptors."""
+
 from __future__ import annotations
 
-import enum
+from dataclasses import dataclass
 
 
-class DType(enum.Enum):
-    f32 = "f32"
-    f16 = "f16"
-    bf16 = "bf16"
-    fp8e4m3 = "fp8e4m3"
-    f8e8m0 = "f8e8m0"
-    f4e2m1 = "f4e2m1"
-    i32 = "i32"
-    i64 = "i64"
-    bool = "bool"
+@dataclass(frozen=True)
+class DType:
+    name: str
+    bit_width: int
 
 
-__all__ = ["DType"]
+@dataclass(frozen=True)
+class FloatDType(DType):
+    exponent_bits: int
+    mantissa_bits: int
+
+
+@dataclass(frozen=True)
+class IntegerDType(DType):
+    signed: bool
+
+
+@dataclass(frozen=True)
+class BoolDType(DType):
+    pass
+
+
+DType.f32 = FloatDType(name="f32", bit_width=32, exponent_bits=8, mantissa_bits=23)
+DType.f16 = FloatDType(name="f16", bit_width=16, exponent_bits=5, mantissa_bits=10)
+DType.bf16 = FloatDType(name="bf16", bit_width=16, exponent_bits=8, mantissa_bits=7)
+DType.fp8e4m3 = FloatDType(name="fp8e4m3", bit_width=8, exponent_bits=4, mantissa_bits=3)
+DType.f8e8m0 = FloatDType(name="f8e8m0", bit_width=8, exponent_bits=8, mantissa_bits=0)
+DType.f4e2m1 = FloatDType(name="f4e2m1", bit_width=4, exponent_bits=2, mantissa_bits=1)
+DType.i32 = IntegerDType(name="i32", bit_width=32, signed=True)
+DType.i64 = IntegerDType(name="i64", bit_width=64, signed=True)
+DType.bool = BoolDType(name="bool", bit_width=1)
+
+
+__all__ = ["BoolDType", "DType", "FloatDType", "IntegerDType"]

--- a/src/tilefoundry/parser/base.py
+++ b/src/tilefoundry/parser/base.py
@@ -729,13 +729,7 @@ class BaseExprVisitor:
             except ValueError:
                 pass
         value = self._eval_static(node)
-        # String-enum sugar: when the receiving ParamDef declares a
-        # string-valued enum annotation (``DType`` / ``ReduceKind`` /
-        # ``BinaryKind`` / ``UnaryKind``) and the user passed a plain string
-        # literal (``"bf16"`` / ``"sum"`` / ...), promote it to the enum
-        # member by VALUE so DSL source can stay free of ``DType.bf16`` /
-        # ``ReduceKind.SUM`` etc. (the enum stays the IR-canonical attribute
-        # type; this is the parser/Call-build boundary).
+        # String-enum sugar: promote plain strings to the receiving enum member.
         if (
             isinstance(value, str)
             and isinstance(annotation, type)
@@ -749,6 +743,18 @@ class BaseExprVisitor:
                     f"{annotation.__name__}: unknown value {value!r}; "
                     f"valid values are {valid}"
                 ) from None
+        if isinstance(value, str) and annotation is DType:
+            member = getattr(DType, value, None)
+            if not isinstance(member, DType):
+                valid = ", ".join(
+                    repr(name)
+                    for name, candidate in vars(DType).items()
+                    if isinstance(candidate, DType)
+                )
+                raise VerifyError(
+                    f"DType: unknown value {value!r}; valid values are {valid}"
+                )
+            return member
         return value
 
     def _lookup_param_annotation(

--- a/src/tilefoundry/parser/sugar.py
+++ b/src/tilefoundry/parser/sugar.py
@@ -158,7 +158,8 @@ def _auto_strides(shape: tuple[int, ...]) -> tuple[int, ...]:
 def _resolve_dtype_ast(node: ast.AST, closure: dict[str, Any]) -> DType | None:
     """Resolve a dtype from an AST node (bare name, string, or DType.attr)."""
     if isinstance(node, ast.Constant) and isinstance(node.value, str):
-        return getattr(DType, node.value, DType.f32)
+        member = getattr(DType, node.value, None)
+        return member if isinstance(member, DType) else None
     if isinstance(node, ast.Name):
         val = closure.get(node.id)
         if isinstance(val, DType):

--- a/tests/ir_types/test_dtype.py
+++ b/tests/ir_types/test_dtype.py
@@ -1,12 +1,43 @@
-"""DType declarations: the low-precision members and their canonical spellings."""
+"""DType descriptor declarations and hardware-relevant facts."""
 from __future__ import annotations
 
-from tilefoundry.ir.types import DType
+import pytest
+
+from tilefoundry.ir.types import BoolDType, DType, FloatDType, IntegerDType
 
 
-def test_low_precision_dtypes_declared():
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("f32", FloatDType("f32", 32, 8, 23)),
+        ("f16", FloatDType("f16", 16, 5, 10)),
+        ("bf16", FloatDType("bf16", 16, 8, 7)),
+        ("fp8e4m3", FloatDType("fp8e4m3", 8, 4, 3)),
+        ("f8e8m0", FloatDType("f8e8m0", 8, 8, 0)),
+        ("f4e2m1", FloatDType("f4e2m1", 4, 2, 1)),
+        ("i32", IntegerDType("i32", 32, True)),
+        ("i64", IntegerDType("i64", 64, True)),
+        ("bool", BoolDType("bool", 1)),
+    ],
+)
+def test_builtin_dtype_facts(name: str, expected: DType) -> None:
+    member = getattr(DType, name)
+
+    assert member == expected
+    assert hash(member) == hash(expected)
+    assert repr(member) == repr(expected)
+
+
+def test_low_precision_dtypes_have_canonical_names() -> None:
     for name in ("fp8e4m3", "f8e8m0", "f4e2m1"):
-        assert name in DType.__members__, f"missing DType {name}"
-        assert DType[name].value == name
+        member = getattr(DType, name, None)
+        assert isinstance(member, FloatDType), f"missing DType {name}"
+        assert member.name == name
     # fp8e4m3 is the sole canonical fp8 spelling; no alternate is introduced.
-    assert "f8e4m3" not in DType.__members__
+    assert not hasattr(DType, "f8e4m3")
+
+
+def test_dtype_members_are_stable_singletons() -> None:
+    assert DType.f32 is DType.f32
+    assert DType.f32 is not DType.f16
+    assert {DType.f32, FloatDType("f32", 32, 8, 23)} == {DType.f32}

--- a/tests/ir_types/test_dtype.py
+++ b/tests/ir_types/test_dtype.py
@@ -41,3 +41,5 @@ def test_dtype_members_are_stable_singletons() -> None:
     assert DType.f32 is DType.f32
     assert DType.f32 is not DType.f16
     assert {DType.f32, FloatDType("f32", 32, 8, 23)} == {DType.f32}
+    assert not hasattr(DType.f32, "value")
+    assert not hasattr(DType, "__members__")

--- a/tests/ir_types/test_mma_fragment_layouts.py
+++ b/tests/ir_types/test_mma_fragment_layouts.py
@@ -121,7 +121,7 @@ def _assert_reshard_typeinfer_ok(
     resulting TensorType pins the requested rank-5 ShardLayout while
     preserving the logical shape."""
 
-    dtype = DType[src_dtype_name]
+    dtype = getattr(DType, src_dtype_name)
     src_ty = TensorType(
         shape=src_shape, dtype=dtype, layout=None, storage=StorageKind.GMEM
     )

--- a/tests/ops/test_binary.py
+++ b/tests/ops/test_binary.py
@@ -261,12 +261,12 @@ def test_binary_evaluate_dtypes(dtype):
 # Low-precision dtypes are legal typeinfer operands: inference is purely
 # logical, so they pass through like any other element type.
 @pytest.mark.parametrize(
-    "dt", [DType.fp8e4m3, DType.f8e8m0, DType.f4e2m1], ids=lambda d: d.value
+    "dt", [DType.fp8e4m3, DType.f8e8m0, DType.f4e2m1], ids=lambda d: d.name
 )
 def test_binary_low_precision_typeinfer_passthrough(dt):
     run_typeinfer_case(
         TypeInferCase(
-            f"low_precision_{dt.value}",
+            f"low_precision_{dt.name}",
             _ADD,
             (make_tensor_type((4, 8), dt), make_tensor_type((4, 8), dt)),
             make_tensor_type((4, 8), dt),

--- a/tests/ops/test_unary.py
+++ b/tests/ops/test_unary.py
@@ -49,7 +49,7 @@ CASES = [
     # Low-precision dtypes are legal typeinfer operands: inference is purely
     # logical, so they pass through like any other element type.
     TypeInferCase(
-        name=f"low_precision_passthrough_{dt.value}",
+        name=f"low_precision_passthrough_{dt.name}",
         op=_NEG,
         inputs=(make_tensor_type((4, 8), dt),),
         expected=make_tensor_type((4, 8), dt),

--- a/tests/parser/hir/test_str_dtype_surface.py
+++ b/tests/parser/hir/test_str_dtype_surface.py
@@ -1,9 +1,9 @@
 """String dtype / reduce-kind authoring surface (parser.md §2.4).
 
 The DSL surface accepts the string form (`dtype="f32"`, `kind="sum"`); the
-parser normalizes it to the IR-canonical enum at the call boundary, and an
-unknown string raises a clear error. The string and enum forms parse to the
-same IR.
+parser normalizes it to the IR-canonical descriptor or enum at the call
+boundary, and an unknown string raises a clear error. Both authoring forms
+print to the same canonical IR.
 """
 
 from __future__ import annotations
@@ -14,6 +14,7 @@ import pytest
 
 from tilefoundry.inspection import as_script
 from tilefoundry.ir.core import VerifyError
+from tilefoundry.ir.types import DType
 from tilefoundry.parser.hir_parser import parse_script
 
 
@@ -36,6 +37,30 @@ def f(x: Tensor[(8,), "f32"]) -> Tensor[(8,), "bf16"]:
 """
     fn = parse_script(_dedent(src))
     assert fn.body is not None
+
+
+def test_string_and_descriptor_dtype_forms_are_equivalent() -> None:
+    string_form = _HEADER + """
+@func
+def f(x: Tensor[(8,), "f32"]) -> Tensor[(8,), "bf16"]:
+    return cast(x, dtype="bf16")
+"""
+    descriptor_form = _HEADER + """
+from tilefoundry.ir.types import DType
+@func
+def f(x: Tensor[(8,), "f32"]) -> Tensor[(8,), "bf16"]:
+    return cast(x, dtype=DType.bf16)
+"""
+
+    string_ir = parse_script(_dedent(string_form))
+    descriptor_ir = parse_script(_dedent(descriptor_form))
+
+    assert string_ir.body is not None
+    assert descriptor_ir.body is not None
+    assert string_ir.body.target.dtype is DType.bf16
+    assert descriptor_ir.body.target.dtype is DType.bf16
+    assert as_script(string_ir) == as_script(descriptor_ir)
+    assert 'dtype="bf16"' in as_script(string_ir)
 
 
 def test_string_reduce_kind_parses() -> None:

--- a/tests/parser/hir/test_str_dtype_surface.py
+++ b/tests/parser/hir/test_str_dtype_surface.py
@@ -29,14 +29,21 @@ from tilefoundry.dsl.tf import *
 """
 
 
-def test_string_dtype_parses() -> None:
-    src = _HEADER + """
+@pytest.mark.parametrize(
+    "name",
+    ("f32", "f16", "bf16", "fp8e4m3", "f8e8m0", "f4e2m1", "i32", "i64", "bool"),
+)
+def test_string_dtype_parses_and_prints_canonically(name: str) -> None:
+    src = _HEADER + f"""
 @func
-def f(x: Tensor[(8,), "f32"]) -> Tensor[(8,), "bf16"]:
-    return cast(x, dtype="bf16")
+def f(x: Tensor[(8,), "f32"]) -> Tensor[(8,), "{name}"]:
+    return cast(x, dtype="{name}")
 """
     fn = parse_script(_dedent(src))
+
     assert fn.body is not None
+    assert fn.body.target.dtype is getattr(DType, name)
+    assert f'dtype="{name}"' in as_script(fn)
 
 
 def test_string_and_descriptor_dtype_forms_are_equivalent() -> None:
@@ -95,6 +102,16 @@ def test_invalid_dtype_string_raises() -> None:
 @func
 def f(x: Tensor[(8,), "f32"]) -> Tensor[(8,), "bf16"]:
     return cast(x, dtype="float32")
+"""
+    with pytest.raises(VerifyError, match=r"DType: unknown value 'float32'"):
+        parse_script(_dedent(src))
+
+
+def test_invalid_tensor_annotation_dtype_raises() -> None:
+    src = _HEADER + """
+@func
+def f(x: Tensor[(8,), "float32"]) -> Tensor[(8,), "f32"]:
+    return cast(x, dtype="f32")
 """
     with pytest.raises(VerifyError, match=r"DType: unknown value 'float32'"):
         parse_script(_dedent(src))


### PR DESCRIPTION
## Summary

- replace the DType enum with closed descriptor classes and nine canonical singleton values
- preserve DType.f32-style access, string parsing, canonical printing, viewer formatting, and generated stub literals
- migrate direct Enum API consumers from value/index access to descriptor names

## Tests

- focused DType/parser/layout tests: 25 passed
- inspection tests: 30 passed
- full suite: 932 passed
- Ruff on changed Python files: passed