### PR TITLE
Add LayoutBase contract and nested layout printing

### DIFF
--- a/docs/spec/shard.md
+++ b/docs/spec/shard.md
@@ -94,9 +94,10 @@ class ShardLayout(LayoutBase): ...       # concrete `LayoutBase` member
 
 Common contract — every legal layout object MUST satisfy:
 
-- a stable domain shape (`domain(layout)`),
+- a stable domain shape exposed as `shape`,
 - a coord-to-physical mapping (`layout(coord) → physical index / offset`),
-- a stable domain-axis numbering (`range(rank(layout))`),
+- a stable domain-axis numbering exposed as `domain_rank`, where
+  `domain_rank == rank(flatten(shape))`,
 - **injective mapping** — overlapping / aliasing layouts are not
   permitted; distinct domain coords MUST NOT map to the same physical
   element. Extending to non-injective cases (padding / broadcast
@@ -151,32 +152,40 @@ Mirrors CuTeDSL `make_composed_layout(inner, offset, outer)`:
 
 ```python
 class ComposedLayout(LayoutBase):
-    inner: LayoutBase   # applied last (output-side layout)
-    offset: int         # intermediate scalar offset (a property of the composition)
-    outer: LayoutBase   # applied first (input / domain-side layout)
+    inner: LayoutBase | None   # applied last (output-side layout); `None` is identity
+    offset: int                # intermediate scalar offset (a property of the composition)
+    outer: LayoutBase | None   # applied first (input / domain-side layout); `None` is identity
 ```
 
 - constraints:
-  - `idx = inner(offset + outer(coord))`; inherits domain shape and axis numbering
-    from `outer`.
+  - `idx = apply(inner, offset + apply(outer, coord))`, where
+    `apply(None, value) == value`.
+  - `shape` and `domain_rank` come from `outer` when it is present, otherwise
+    from `inner`; a composition with no explicit domain has `shape == ()`.
+  - either non-`None` component MAY be any `LayoutBase`, including a
+    `ShardLayout` that preserves an earlier distribution.
 
 Field meanings:
 
-- `outer` — applied **first** (the input / domain-side layout)
+- `outer` — applied **first** (the input / domain-side layout); `None`
+  applies the identity mapping
 - `offset` — the intermediate scalar offset (a property of the
   composition object, not of the primitive `Layout`)
-- `inner` — applied **last** (the output-side layout)
+- `inner` — applied **last** (the output-side layout); `None` applies
+  the identity mapping
 
 Minimum semantics:
 
 ```python
-idx = inner(offset + outer(coord))
+idx = apply(inner, offset + apply(outer, coord))
+assert apply(None, value) == value
 ```
 
-A `ComposedLayout` inherits its domain shape and axis numbering from
-`outer`. Therefore, when an outer `ShardLayout` binds a
-`ComposedLayout`, a `Split(k)` attr still references the stable domain
-axis exposed by `outer`.
+A `ComposedLayout` normally inherits its domain shape and axis numbering
+from `outer`. When `outer=None`, the identity mapping contributes no explicit
+domain, so the composition inherits them from `inner`. Therefore, when an
+outer `ShardLayout` binds a `ComposedLayout`, a `Split(k)` attr still
+references the composition's stable `shape` / `domain_rank` contract.
 
 ---
 
@@ -285,7 +294,7 @@ axes to mesh axes.
 
 ```python
 class ShardLayout(LayoutBase):
-    layout: LayoutBase                                        # the underlying `Layout` / `ComposedLayout` being bound
+    layout: LayoutBase                                        # the underlying layout-family member being bound
     attrs: tuple[Split | Broadcast | Dynamic | Partial, ...]  # per-mesh-axis attributes, ordered by mesh axis
     mesh: Mesh                                                # the device-domain `Mesh`
 ```
@@ -299,9 +308,10 @@ itself an IR op (`hir.sharding.Reshard`, see [hir](./hir.md) §2.5).
 
 ### 7.1 `layout`
 
-The underlying `Layout` / `ComposedLayout`. `Layout` /
-`ComposedLayout` (§3, §4) own the layout algebra; `ShardLayout` does
-not redefine it.
+The underlying `LayoutBase`. `Layout` / `ComposedLayout` (§3, §4) own
+the layout algebra; `ShardLayout` binds their stable `shape` and
+`domain_rank` to a mesh without redefining that algebra. Nested stage
+layouts remain represented through the `LayoutBase` hierarchy.
 
 When a `Layout` sits inside `ShardLayout.layout`, its `shape` and
 `stride` carry **additional, narrower semantics** beyond the plain

--- a/docs/spec/types.md
+++ b/docs/spec/types.md
@@ -49,13 +49,15 @@ its derivations: `TensorType` / `TupleType` / `UnitType` /
 class TensorType(IRType):
     shape: tuple[ShapeDim, ...]                      # logical shape; invariant under sharding / storage / layout
     dtype: DType                                     # element dtype
-    layout: Layout | ShardLayout | ComposedLayout    # member of the Layout family (see shard)
+    layout: LayoutBase | None                        # member of the Layout family, or no assigned layout (see shard)
     storage: StorageKind | None                      # abstract result residency, or umat / None
 ```
 
 - constraints:
   - A *scalar* is `TensorType(shape=(), ...)` — a rank-0 tensor. There
     is no separate `Scalar` type.
+  - `layout` is either `None` or one member of the `LayoutBase` hierarchy
+    defined by [shard §2](./shard.md#2-layout-hierarchy).
   - `storage` is a `StorageKind` (`gmem` / `smem` / `rmem` / `host` / `tmem` /
     `umat`) or `None`. A concrete level (`gmem` / `smem` / `rmem` / `host` /
     `tmem`) is the value's **abstract result residency** — where the result tensor
@@ -66,9 +68,9 @@ class TensorType(IRType):
     unmaterialized value MUST be resolved to a concrete residency (or otherwise
     materialized) before codegen consumes it. `None` is unchanged — a tensor with
     no memory space (a shape-element scalar), distinct from `umat`.
-  - For plain `Layout` / `ComposedLayout`, `len(shape)` MUST equal the
-    layout's logical axis count; for `ComposedLayout` this is the
-    outer-layout's axis count after expansion.
+  - For plain `Layout` / `ComposedLayout`, `len(shape)` MUST equal
+    `layout.domain_rank`; consumers use this common contract rather than
+    inspecting a `ComposedLayout` component.
   - For `ShardLayout`, `TensorType.shape` remains the logical shape;
     `ShardLayout.layout.shape` is the sharding-internal / per-shard
     layout shape and need not match `shape` axis-by-axis. `Reshard`

--- a/src/tilefoundry/__init__.py
+++ b/src/tilefoundry/__init__.py
@@ -42,6 +42,7 @@ from tilefoundry.ir.types.shard import (
     Dynamic,
     IntTuple,
     Layout,
+    LayoutBase,
     LayoutLike,
     Mesh,
     MeshAxis,
@@ -103,7 +104,7 @@ __all__ = [
     "DType", "TensorType", "TupleType", "Type",
     "Pattern", "DimVarRangePat", "DimVar",
     # shard
-    "IntTuple", "Layout", "ComposedLayout", "LayoutLike",
+    "IntTuple", "LayoutBase", "Layout", "ComposedLayout", "LayoutLike",
     "Topology", "MeshAxis", "Mesh",
     "ShardAttr", "Split", "Partial", "Broadcast", "Dynamic", "ShardLayout",
     "S", "P", "B",

--- a/src/tilefoundry/__init__.py
+++ b/src/tilefoundry/__init__.py
@@ -43,7 +43,6 @@ from tilefoundry.ir.types.shard import (
     IntTuple,
     Layout,
     LayoutBase,
-    LayoutLike,
     Mesh,
     MeshAxis,
     P,
@@ -104,7 +103,7 @@ __all__ = [
     "DType", "TensorType", "TupleType", "Type",
     "Pattern", "DimVarRangePat", "DimVar",
     # shard
-    "IntTuple", "LayoutBase", "Layout", "ComposedLayout", "LayoutLike",
+    "IntTuple", "LayoutBase", "Layout", "ComposedLayout",
     "Topology", "MeshAxis", "Mesh",
     "ShardAttr", "Split", "Partial", "Broadcast", "Dynamic", "ShardLayout",
     "S", "P", "B",

--- a/src/tilefoundry/inspection/python_printer.py
+++ b/src/tilefoundry/inspection/python_printer.py
@@ -30,7 +30,7 @@ from tilefoundry.ir.types.dim import (
     DimSub,
     DimVar,
 )
-from tilefoundry.ir.types.shard.layout import Layout
+from tilefoundry.ir.types.shard.layout import ComposedLayout, Layout, LayoutBase
 from tilefoundry.ir.types.shard.mesh import Mesh
 from tilefoundry.ir.types.shard.shard_layout import (
     Broadcast,
@@ -243,14 +243,31 @@ def _shard_attr_str(attr) -> str:
     return f"/* {type(attr).__name__} */"
 
 
-def _mesh_str(mesh: Mesh) -> str:
+def _layout_str(layout: LayoutBase | None, indent: str = "") -> str:
+    """Render a complete layout descriptor without flattening compositions."""
+    if layout is None:
+        return "None"
+    if isinstance(layout, Layout):
+        strides = _shape_tuple(layout.strides) if layout.strides is not None else "None"
+        return f"Layout({_shape_tuple(layout.shape)}, {strides})"
+    if isinstance(layout, ShardLayout):
+        return _shard_layout_str(layout, indent=indent)
+    if isinstance(layout, ComposedLayout):
+        child_indent = indent + "    "
+        return (
+            "ComposedLayout(\n"
+            f"{child_indent}inner={_layout_str(layout.inner, child_indent)},\n"
+            f"{child_indent}offset={layout.offset},\n"
+            f"{child_indent}outer={_layout_str(layout.outer, child_indent)},\n"
+            f"{indent})"
+        )
+    raise TypeError(f"unsupported layout type: {type(layout).__name__}")
+
+
+def _mesh_str(mesh: Mesh, indent: str = "") -> str:
     """Mesh(...) constructor string, includes ``names=`` when non-empty."""
     topo = mesh.topology
-    layout = mesh.layout
-    base = (
-        f'Mesh(Topology("{topo.name}", {topo.size}), '
-        f"Layout({_shape_tuple(layout.shape)}, {_shape_tuple(layout.strides)})"
-    )
+    base = f'Mesh(Topology("{topo.name}", {topo.size}), {_layout_str(mesh.layout, indent)}'
     if mesh.names:
         base += f", names={repr(tuple(mesh.names))}"
     return base + ")"
@@ -258,18 +275,17 @@ def _mesh_str(mesh: Mesh) -> str:
 
 def _shard_layout_str(sl: ShardLayout, indent: str = "") -> str:
     """ShardLayout(...) constructor string, multi-line for readability."""
-    layout = sl.layout
-    mesh = _mesh_str(sl.mesh)
+    child_indent = indent + "    "
+    layout = _layout_str(sl.layout, child_indent)
+    mesh = _mesh_str(sl.mesh, child_indent)
     attrs = ", ".join(_shard_attr_str(a) for a in sl.attrs)
-    shape_tup = _shape_tuple(layout.shape)
-    # ``layout.strides`` may be ``None`` for un-materialized sugar; the
-    # printer surfaces that explicitly rather than crashing.
-    stride_tup = _shape_tuple(layout.strides) if layout.strides is not None else "None"
+    if len(sl.attrs) == 1:
+        attrs += ","
     return (
         f"ShardLayout(\n"
-        f"{indent}    layout=Layout({shape_tup}, {stride_tup}),\n"
-        f"{indent}    attrs=({attrs}),\n"
-        f"{indent}    mesh={mesh},\n"
+        f"{child_indent}layout={layout},\n"
+        f"{child_indent}attrs=({attrs}),\n"
+        f"{child_indent}mesh={mesh},\n"
         f"{indent})"
     )
 
@@ -695,7 +711,7 @@ def hir_function_to_python(fn: HirFunction) -> str:
     lines.append("from tilefoundry.dsl import Tensor")
     lines.append("from tilefoundry.dsl.storage import gmem, host, rmem, smem, tmem  # noqa: F401")
     lines.append("from tilefoundry.ir.types.shard import (")
-    lines.append(f"{indent}B, S, P, Layout, Mesh, ShardLayout, Topology,")
+    lines.append(f"{indent}B, S, P, ComposedLayout, Layout, Mesh, ShardLayout, Topology,")
     lines.append(")")
     if fn.variants:
         lines.append("from tilefoundry.ir.core.pattern import DimVarRangePat")
@@ -712,7 +728,7 @@ def hir_function_to_python(fn: HirFunction) -> str:
             lines.append(
                 f"{name} = Mesh("
                 f'Topology("{topo.name}", {topo.size}), '
-                f"Layout({_shape_tuple(ml.shape)}, {_shape_tuple(ml.strides)}), "
+                f"{_layout_str(ml)}, "
                 f"names={names_repr}"
                 f")"
             )
@@ -789,7 +805,7 @@ def _module_to_python(fn: HirFunction, module_name: str = "M") -> str:
     lines.append("from tilefoundry.dsl import Tensor")
     lines.append("from tilefoundry.dsl.storage import gmem, host, rmem, smem, tmem  # noqa: F401")
     lines.append("from tilefoundry.ir.types.shard import (")
-    lines.append(f"{indent4}B, S, P, Layout, Mesh, ShardLayout, Topology,")
+    lines.append(f"{indent4}B, S, P, ComposedLayout, Layout, Mesh, ShardLayout, Topology,")
     lines.append(")")
     lines.append("")
 
@@ -805,7 +821,7 @@ def _module_to_python(fn: HirFunction, module_name: str = "M") -> str:
             lines.append(
                 f"{name} = Mesh("
                 f'Topology("{topo.name}", {topo.size}), '
-                f"Layout({_shape_tuple(ml.shape)}, {_shape_tuple(ml.strides)}), "
+                f"{_layout_str(ml)}, "
                 f"names={names_repr}"
                 f")"
             )

--- a/src/tilefoundry/ir/types/shard/__init__.py
+++ b/src/tilefoundry/ir/types/shard/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 # ruff: noqa: I001 -- curated re-export order; alphabetical sort breaks staged imports.
 
 from .int_tuple import IntTuple, flatten, product
-from .layout import ComposedLayout, Layout, LayoutLike
+from .layout import ComposedLayout, Layout, LayoutBase, LayoutLike
 from .mesh import Mesh, MeshAxis, Topology
 from .shard_layout import (
     B,
@@ -22,7 +22,7 @@ __all__ = [
     # int tuple
     "IntTuple", "flatten", "product",
     # layout
-    "Layout", "ComposedLayout", "LayoutLike",
+    "LayoutBase", "Layout", "ComposedLayout", "LayoutLike",
     # mesh
     "Topology", "MeshAxis", "Mesh", "make_mesh",
     # shard

--- a/src/tilefoundry/ir/types/shard/__init__.py
+++ b/src/tilefoundry/ir/types/shard/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 # ruff: noqa: I001 -- curated re-export order; alphabetical sort breaks staged imports.
 
 from .int_tuple import IntTuple, flatten, product
-from .layout import ComposedLayout, Layout, LayoutBase, LayoutLike
+from .layout import ComposedLayout, Layout, LayoutBase
 from .mesh import Mesh, MeshAxis, Topology
 from .shard_layout import (
     B,
@@ -22,7 +22,7 @@ __all__ = [
     # int tuple
     "IntTuple", "flatten", "product",
     # layout
-    "LayoutBase", "Layout", "ComposedLayout", "LayoutLike",
+    "LayoutBase", "Layout", "ComposedLayout",
     # mesh
     "Topology", "MeshAxis", "Mesh", "make_mesh",
     # shard

--- a/src/tilefoundry/ir/types/shard/int_tuple.py
+++ b/src/tilefoundry/ir/types/shard/int_tuple.py
@@ -10,18 +10,23 @@ fail closed otherwise.
 
 from __future__ import annotations
 
-from typing import Union
+from typing import Union, overload
 
 IntTuple = Union[int, tuple["IntTuple", ...]]
 
 
-def flatten(t: IntTuple) -> tuple[int, ...]:
-    if isinstance(t, int):
+@overload
+def flatten(t: IntTuple) -> tuple[int, ...]: ...
+
+
+@overload
+def flatten(t: object) -> tuple[object, ...]: ...
+
+
+def flatten(t: object) -> tuple[object, ...]:
+    if not isinstance(t, tuple):
         return (t,)
-    out: list[int] = []
-    for x in t:
-        out.extend(flatten(x))
-    return tuple(out)
+    return tuple(value for item in t for value in flatten(item))
 
 
 def product(t: IntTuple) -> int:

--- a/src/tilefoundry/ir/types/shard/layout.py
+++ b/src/tilefoundry/ir/types/shard/layout.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Optional
 
-
-def _domain_rank(shape: tuple) -> int:
-    return sum(_domain_rank(dim) if isinstance(dim, tuple) else 1 for dim in shape)
+from .int_tuple import flatten
 
 
 class LayoutBase:
@@ -13,7 +11,7 @@ class LayoutBase:
 
     @property
     def domain_rank(self) -> int:
-        return _domain_rank(self.shape)
+        return len(flatten(self.shape))
 
 
 @dataclass(frozen=True)

--- a/src/tilefoundry/ir/types/shard/layout.py
+++ b/src/tilefoundry/ir/types/shard/layout.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional, Union
+from typing import Optional
 
 
 def _domain_rank(shape: tuple) -> int:
@@ -46,9 +46,9 @@ class ComposedLayout(LayoutBase):
     ``image⁻¹(t) = outer⁻¹(inner⁻¹(t) − offset)``.
     """
 
-    inner: "LayoutLike | None"
+    inner: LayoutBase | None
     offset: int
-    outer: "LayoutLike | None"
+    outer: LayoutBase | None
 
     @property
     def shape(self) -> tuple:
@@ -58,10 +58,7 @@ class ComposedLayout(LayoutBase):
         return domain.shape
 
 
-# Forward ref resolved after shard_layout import
-LayoutLike = Union[Layout, ComposedLayout, "ShardLayout"]  # noqa: F821
-
 EMPTY_LAYOUT = Layout(shape=(), strides=())
 
 
-__all__ = ["LayoutBase", "Layout", "ComposedLayout", "LayoutLike", "EMPTY_LAYOUT"]
+__all__ = ["LayoutBase", "Layout", "ComposedLayout", "EMPTY_LAYOUT"]

--- a/src/tilefoundry/ir/types/shard/layout.py
+++ b/src/tilefoundry/ir/types/shard/layout.py
@@ -7,8 +7,20 @@ if TYPE_CHECKING:
     from tilefoundry.ir.types.shape_dim import ShapeDim
 
 
+def _domain_rank(shape: tuple) -> int:
+    return sum(_domain_rank(dim) if isinstance(dim, tuple) else 1 for dim in shape)
+
+
+class LayoutBase:
+    """Common domain-shape contract for tensor layout descriptors."""
+
+    @property
+    def domain_rank(self) -> int:
+        return _domain_rank(self.shape)
+
+
 @dataclass(frozen=True)
-class Layout:
+class Layout(LayoutBase):
     """Cute-style layout: shape + per-axis cute strides."""
 
     shape: tuple["ShapeDim | None", ...]
@@ -16,7 +28,7 @@ class Layout:
 
 
 @dataclass(frozen=True)
-class ComposedLayout:
+class ComposedLayout(LayoutBase):
     """CuTe composed layout: ``image(c) = inner(offset + outer(c))``.
 
     Field order + names mirror CuTeDSL ``make_composed_layout(inner, offset,
@@ -26,16 +38,27 @@ class ComposedLayout:
       axis numbering of the composition come from ``outer``, so a binding
       ``ShardLayout``'s ``Split(k)`` references ``outer``'s domain axis.
     - ``offset`` — intermediate scalar offset added before ``inner``.
-    - ``inner`` — applied **last** (codomain / output side).
+    - ``inner`` — applied **last** (codomain / output side); ``None`` is
+      identity.
+
+    Either component may be a ``ShardLayout`` so a later placement stage can
+    preserve an earlier stage's distribution as a nested layout.
 
     The left inverse reverses the composition (see CuTe
     ``layout_composed.hpp`` ``left_inverse``):
     ``image⁻¹(t) = outer⁻¹(inner⁻¹(t) − offset)``.
     """
 
-    inner: "LayoutLike"
+    inner: "LayoutLike | None"
     offset: int
-    outer: "LayoutLike"
+    outer: "LayoutLike | None"
+
+    @property
+    def shape(self) -> tuple:
+        domain = self.outer if self.outer is not None else self.inner
+        if domain is None:
+            return ()
+        return domain.shape
 
 
 # Forward ref resolved after shard_layout import
@@ -44,4 +67,4 @@ LayoutLike = Union[Layout, ComposedLayout, "ShardLayout"]  # noqa: F821
 EMPTY_LAYOUT = Layout(shape=(), strides=())
 
 
-__all__ = ["Layout", "ComposedLayout", "LayoutLike", "EMPTY_LAYOUT"]
+__all__ = ["LayoutBase", "Layout", "ComposedLayout", "LayoutLike", "EMPTY_LAYOUT"]

--- a/src/tilefoundry/ir/types/shard/shard_layout.py
+++ b/src/tilefoundry/ir/types/shard/shard_layout.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from .layout import ComposedLayout, Layout
+from .layout import LayoutBase
 from .mesh import Mesh
 
 
@@ -43,10 +43,16 @@ def B() -> Broadcast:
 
 
 @dataclass(frozen=True)
-class ShardLayout:
-    layout: "Layout | ComposedLayout"
+class ShardLayout(LayoutBase):
+    """Bind an underlying layout's domain axes to a mesh."""
+
+    layout: LayoutBase
     attrs: tuple[ShardAttr, ...]
     mesh: Mesh
+
+    @property
+    def shape(self) -> tuple:
+        return self.layout.shape
 
 
 def shard_layout_local_shape(sl: "ShardLayout") -> tuple[int, ...]:

--- a/src/tilefoundry/ir/types/tensor_type.py
+++ b/src/tilefoundry/ir/types/tensor_type.py
@@ -37,7 +37,7 @@ def _canonicalize_static_dims(shape: tuple) -> tuple:
 class TensorType:
     shape: tuple[ShapeDim, ...]
     dtype: DType
-    layout: object
+    layout: "LayoutBase | None"
     # Memory space of the tensor. ``None`` marks a non-memory-resident
     # compile-time / shape scalar; a memory-resident tensor must carry a
     # concrete ``StorageKind``.
@@ -60,7 +60,7 @@ class TensorType:
     @staticmethod
     def scalar(
         dtype: DType,
-        layout: object = None,
+        layout: "LayoutBase | None" = None,
         storage: Optional[StorageKind] = StorageKind.RMEM,
     ) -> "TensorType":
         return TensorType(shape=(), dtype=dtype, layout=layout, storage=storage)

--- a/tests/inspection/test_roundtrip.py
+++ b/tests/inspection/test_roundtrip.py
@@ -431,3 +431,36 @@ def test_tuple_return_with_mesh_element_roundtrips() -> None:
     assert "return (" in printed, printed
     fn2 = parse_script(printed)
     assert _structural_equal(fn, fn2), f"round-trip mismatch:\n{printed}"
+
+
+def test_nested_composed_shard_layout_roundtrips_without_flattening() -> None:
+    src = (
+        "from __future__ import annotations\n"
+        "from tilefoundry import func\n"
+        "from tilefoundry.dsl import Tensor\n"
+        "from tilefoundry.ir.types.shard import (\n"
+        "    B, S, ComposedLayout, Layout, Mesh, ShardLayout, Topology,\n"
+        ")\n"
+        "thread = Mesh(Topology('thread', 2), Layout((2,), (1,)))\n"
+        "cta = Mesh(Topology('cta', 4), Layout((4,), (1,)))\n"
+        "prior = ShardLayout(\n"
+        "    layout=Layout((8,), (1,)), attrs=(S(0),), mesh=thread,\n"
+        ")\n"
+        "nested = ShardLayout(\n"
+        "    layout=ComposedLayout(inner=None, offset=1, outer=prior),\n"
+        "    attrs=(B(),),\n"
+        "    mesh=cta,\n"
+        ")\n"
+        "\n"
+        "@func\n"
+        "def f(a: Tensor[(8,), 'f32', nested]) -> Tensor[(8,), 'f32', nested]:\n"
+        "    return a\n"
+    )
+    fn = parse_script(src)
+
+    printed = as_script(fn)
+
+    assert "layout=ComposedLayout(" in printed
+    assert "outer=ShardLayout(" in printed
+    reparsed = parse_script(printed)
+    assert _structural_equal(fn, reparsed), f"round-trip mismatch:\n{printed}"

--- a/tests/ir_types/test_shard_layout.py
+++ b/tests/ir_types/test_shard_layout.py
@@ -68,6 +68,17 @@ def test_layout_base_contract_preserves_nested_shard_domain():
     assert base.domain_rank == prior_stage.domain_rank == composed.domain_rank == 3
 
 
+def test_composed_layout_none_components_are_identity():
+    base = Layout(shape=(4,), strides=(2,))
+    inner_identity = ComposedLayout(inner=None, offset=3, outer=base)
+    outer_identity = ComposedLayout(inner=base, offset=0, outer=None)
+
+    assert la._apply_any(inner_identity, 1) == 5
+    assert la._apply_any(outer_identity, 1) == 2
+    assert inner_identity.shape == outer_identity.shape == base.shape
+    assert inner_identity.domain_rank == outer_identity.domain_rank == 1
+
+
 # --- layout algebra: CuTe left/right inverse (ported, ``layout_algebra``) ----
 
 _INJECTIVE_LAYOUTS = [
@@ -220,6 +231,8 @@ def test_composed_left_inverse_round_trip():
     scope = ComposedLayout(inner=None, offset=128, outer=Layout(shape=(4, 32), strides=(32, 1)))
     inv = la.left_inverse(scope)
     assert isinstance(inv, ComposedLayout)
+    assert inv.shape == inv.inner.shape
+    assert inv.domain_rank == inv.inner.domain_rank
     for c in range(la.size(scope.outer)):
         t = la.image(scope, c)
         assert la._apply_any(inv, t) == c

--- a/tests/ir_types/test_shard_layout.py
+++ b/tests/ir_types/test_shard_layout.py
@@ -9,6 +9,7 @@ from tilefoundry.ir.types.shard import (
     Broadcast,
     ComposedLayout,
     Layout,
+    LayoutBase,
     P,
     Partial,
     S,
@@ -51,6 +52,20 @@ def test_composed_layout_nests_layouts():
     c = ComposedLayout(inner=inner, offset=0, outer=outer)
     assert c.inner is inner
     assert c.outer is outer
+
+
+def test_layout_base_contract_preserves_nested_shard_domain():
+    base = Layout(shape=((2, 4), 8), strides=None)
+    mesh = make_mesh((2,), topology=Topology("thread", 2))
+    prior_stage = ShardLayout(layout=base, attrs=(B(),), mesh=mesh)
+    composed = ComposedLayout(inner=None, offset=3, outer=prior_stage)
+
+    assert isinstance(base, LayoutBase)
+    assert isinstance(prior_stage, LayoutBase)
+    assert isinstance(composed, LayoutBase)
+    assert prior_stage.shape == base.shape
+    assert composed.shape == base.shape
+    assert base.domain_rank == prior_stage.domain_rank == composed.domain_rank == 3
 
 
 # --- layout algebra: CuTe left/right inverse (ported, ``layout_algebra``) ----

--- a/tests/ir_types/test_shard_layout.py
+++ b/tests/ir_types/test_shard_layout.py
@@ -55,7 +55,7 @@ def test_composed_layout_nests_layouts():
 
 
 def test_layout_base_contract_preserves_nested_shard_domain():
-    base = Layout(shape=((2, 4), 8), strides=None)
+    base = Layout(shape=((None, 4), 8), strides=None)
     mesh = make_mesh((2,), topology=Topology("thread", 2))
     prior_stage = ShardLayout(layout=base, attrs=(B(),), mesh=mesh)
     composed = ComposedLayout(inner=None, offset=3, outer=prior_stage)

--- a/tests/ir_types/test_tensor_type.py
+++ b/tests/ir_types/test_tensor_type.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import inspect
+
 import pytest
 
+import tilefoundry.ir.types.tensor_type as tensor_type_module
 from tilefoundry.ir.types import DType, TensorType, TupleType
 from tilefoundry.ir.types.dim import DimVar
 
@@ -12,6 +15,14 @@ def test_scalar_builds_rank0_tensor_type():
     t = TensorType.scalar(DType.f32)
     assert t.shape == ()
     assert t.dtype == DType.f32
+
+
+def test_layout_annotations_use_layout_base_forward_reference():
+    class_annotation = TensorType.__annotations__["layout"]
+    scalar_annotation = inspect.signature(TensorType.scalar).parameters["layout"].annotation
+
+    assert class_annotation.strip("'\"") == scalar_annotation.strip("'\"") == "LayoutBase | None"
+    assert "LayoutBase" not in vars(tensor_type_module)
 
 
 def test_tensor_type_equality_on_fields():


### PR DESCRIPTION
Summary

- add a shared LayoutBase shape and domain-rank contract for Layout, ComposedLayout, and ShardLayout
- preserve nested ShardLayout composition and identity components
- print complete composed layouts canonically without flattening them

Tests

- 923 repository tests passed
- 67 focused acceptance tests passed independently
- Ruff and diff checks passed