### PR TITLE
workflow: enforce spec impact and forward-reference guards

### DIFF
--- a/docs/develop.md
+++ b/docs/develop.md
@@ -93,6 +93,24 @@ short bullet list — keep it that way.
 - Out-of-scope changes that cannot be split MUST be called out in the
   commit body.
 
+### Spec impact
+
+- Every milestone declares `#### Spec Impact`, including documentation-only
+  and internal-only milestones.
+- A public-contract change lists its owning `docs/spec/*.md` files and repeats
+  those files in the milestone's effective `#### Related Files`.
+- A milestone without public-contract changes uses exactly one reasoned
+  `N/A:` entry; it never mixes `N/A:` with spec paths.
+- Contract-changing implementation and its specification ship in the same
+  milestone.
+
+### Forward references
+
+- Break type-only import cycles with quoted forward-reference annotations.
+- Do not guard type-only imports with `typing.TYPE_CHECKING`; Ruff rejects that
+  shim.
+- Import runtime dependencies normally or lazily at their point of use.
+
 ### Tests
 
 - Write meaningful positive tests that exercise the intended path.
@@ -127,4 +145,3 @@ short bullet list — keep it that way.
   headers use `.cuh`, target-neutral / cpu headers use `.h`; exactly one
   `TILEFOUNDRY_TARGET_*` macro is defined per translation unit and the build
   injects it per target.
-

--- a/docs/plans/TEMPLATE.md
+++ b/docs/plans/TEMPLATE.md
@@ -44,6 +44,12 @@ target_repo: tilefoundry
      not allowed. -->
 - <path>
 
+#### Spec Impact
+<!-- List one or more owning `docs/spec/*.md` paths and repeat them in this
+     milestone's effective Related Files. If no public contract changes, use exactly
+     one reasoned entry: `- N/A: <reason>`. Do not mix paths and N/A. -->
+- N/A: <reason this milestone does not change a public contract>
+
 #### Plan
 - [ ] step 0.1 <action with affected files>
 - [ ] step 0.2 <action>
@@ -61,6 +67,9 @@ target_repo: tilefoundry
 
 #### Related Files
 - <path>
+
+#### Spec Impact
+- `docs/spec/<name>.md`
 
 #### Plan
 - [ ] step 1.1 <action>

--- a/docs/policies/project-policy.json
+++ b/docs/policies/project-policy.json
@@ -34,6 +34,41 @@
       }
     },
     {
+      "id": "spec_impact",
+      "name": "Spec impact",
+      "description": "Every source milestone explicitly classifies whether it changes a public contract and names the owning specifications when it does.",
+      "when": {
+        "path_glob": ["src/**", "include/**"]
+      },
+      "ac": [
+        "Milestone MUST classify public-contract impact in `#### Spec Impact`: list owning `docs/spec/*.md` paths or exactly one reasoned `N/A:` entry."
+      ],
+      "rules": {
+        "implementer": [
+          {"path": "docs/develop.md", "section": "Spec impact"}
+        ],
+        "reviewer": [
+          {"path": "docs/develop.md", "section": "Spec impact"}
+        ]
+      }
+    },
+    {
+      "id": "forward_references",
+      "name": "Forward references",
+      "description": "Python type-only cycles use quoted forward references without `typing.TYPE_CHECKING` shims.",
+      "when": {
+        "path_glob": ["**/*.py"]
+      },
+      "rules": {
+        "implementer": [
+          {"path": "docs/develop.md", "section": "Forward references"}
+        ],
+        "reviewer": [
+          {"path": "docs/develop.md", "section": "Forward references"}
+        ]
+      }
+    },
+    {
       "id": "clang_format",
       "name": "C++ formatting",
       "description": "C++/CUDA sources follow the repo .clang-format; touched files are formatted by the versioned pre-commit clang-format hook (touched-files scope, no tree-wide pass).",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ ignore = ["E501", "F821", "E741"]
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 "typing.TYPE_CHECKING".msg = "Use quoted forward references; TYPE_CHECKING shims are not used in TileFoundry."
+"typing_extensions.TYPE_CHECKING".msg = "Use quoted forward references; TYPE_CHECKING shims are not used in TileFoundry."
 
 [tool.ruff.lint.per-file-ignores]
 # DSL tests use `from tilefoundry.dsl import *` as part of the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,9 +49,10 @@ target-version = "py311"
 #   E, W  pycodestyle (PEP 8 errors / warnings)
 #   F     pyflakes    (unused / undefined / shadowed)
 #   I     isort       (import order)
-# Plus one extra rule from pylint conventions:
+# Plus targeted rules from pylint and flake8-tidy-imports:
 #   PLC0415  import-outside-top-level
-select = ["E", "F", "W", "I", "PLC0415"]
+#   TID251   banned-api
+select = ["E", "F", "W", "I", "PLC0415", "TID251"]
 
 # Ignored rules:
 #   E501  line-too-long — long strings / compact code stay on one line.
@@ -63,9 +64,11 @@ select = ["E", "F", "W", "I", "PLC0415"]
 #         ``r`` / ``a``) are allowed.
 ignore = ["E501", "F821", "E741"]
 
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"typing.TYPE_CHECKING".msg = "Use quoted forward references; TYPE_CHECKING shims are not used in TileFoundry."
+
 [tool.ruff.lint.per-file-ignores]
 # DSL tests use `from tilefoundry.dsl import *` as part of the
 # authoring-surface ergonomics. Internal implementation code in
 # `src/` must NOT use star imports (no exception here).
 "tests/**/*.py" = ["F403", "F405"]
-

--- a/scripts/finalize_plan_context.py
+++ b/scripts/finalize_plan_context.py
@@ -16,7 +16,9 @@ generated regions:
 
 The finalizer never touches handwritten content outside the marker
 ranges. A ``policy_*`` HTML comment appearing outside any allowed
-range is a hard validation failure.
+range is a hard validation failure. Every milestone must also declare
+its public-contract impact in ``Spec Impact`` as either owning
+``docs/spec/*.md`` paths or one reasoned ``N/A:`` entry.
 """
 from __future__ import annotations
 
@@ -155,6 +157,17 @@ def _strip_path_bullet(item: str) -> str:
     return s
 
 
+def _is_spec_path(path: str) -> bool:
+    """Return whether *path* is a repo-relative Markdown spec path."""
+    parts = Path(path).parts
+    return (
+        len(parts) >= 3
+        and parts[:2] == ("docs", "spec")
+        and all(part not in ("", ".", "..") for part in parts)
+        and path.endswith(".md")
+    )
+
+
 class PlanModel:
     def __init__(self, plan_path: Path) -> None:
         self.path = plan_path
@@ -252,6 +265,7 @@ class PlanModel:
         for required in (
             "Depends",
             "Related Files",
+            "Spec Impact",
             "Plan",
             "Acceptance Criteria",
         ):
@@ -287,6 +301,12 @@ class PlanModel:
             else:
                 effective_paths.append(_strip_path_bullet(item))
 
+        self._validate_spec_impact(
+            name,
+            sections["Spec Impact"],
+            effective_paths,
+        )
+
         ac_section = sections["Acceptance Criteria"]
 
         # Locate the local policy_ac marker pair inside the AC section.
@@ -316,6 +336,49 @@ class PlanModel:
             "policy_ac_start_idx": ac_start,
             "policy_ac_end_idx": ac_end,
         }
+
+    def _validate_spec_impact(
+        self,
+        milestone_name: str,
+        section: tuple[int, int],
+        related_files: list[str],
+    ) -> None:
+        items = _list_bullets(self.lines, section[0] + 1, section[1])
+        label = f"{self.path}: milestone {milestone_name!r} `#### Spec Impact`"
+        if not items:
+            raise FinalizeError(
+                f"{label} must contain one or more bullet entries."
+            )
+
+        na_items = [item for item in items if item.upper().startswith("N/A")]
+        if na_items:
+            if len(items) != 1:
+                raise FinalizeError(
+                    f"{label} cannot mix an `N/A:` entry with spec paths."
+                )
+            if re.fullmatch(r"N/A:\s+\S(?:.*\S)?", items[0], re.IGNORECASE) is None:
+                raise FinalizeError(
+                    f"{label} must use one reasoned `N/A: <reason>` entry."
+                )
+            return
+
+        spec_paths: list[str] = []
+        for item in items:
+            path = _strip_path_bullet(item)
+            if not _is_spec_path(path):
+                raise FinalizeError(
+                    f"{label} entry {item!r} must be a `docs/spec/*.md` path "
+                    "or one reasoned `N/A:` entry."
+                )
+            spec_paths.append(path)
+
+        missing = [path for path in spec_paths if path not in related_files]
+        if missing:
+            formatted = ", ".join(repr(path) for path in missing)
+            raise FinalizeError(
+                f"{label} path(s) {formatted} must also appear in the milestone's "
+                "effective `#### Related Files`."
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/src/tilefoundry/ir/target/launch.py
+++ b/src/tilefoundry/ir/target/launch.py
@@ -15,10 +15,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import IntEnum
-from typing import TYPE_CHECKING, Optional, Union
-
-if TYPE_CHECKING:
-    from tilefoundry.ir.types.shape_dim import ShapeDim
+from typing import Optional, Union
 
 
 class CudaLaunchAttr(IntEnum):

--- a/src/tilefoundry/ir/tir/stmts.py
+++ b/src/tilefoundry/ir/tir/stmts.py
@@ -13,15 +13,10 @@ positions.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
 
 from tilefoundry.ir.core import Expr, Var
 from tilefoundry.ir.tir.stmt import Stmt
 from tilefoundry.ir.types.shard.mesh import Mesh
-
-if TYPE_CHECKING:
-    from tilefoundry.ir.core.op import Op
-    from tilefoundry.ir.tir.symbol_ref import SymbolRef
 
 
 @dataclass(frozen=True)

--- a/src/tilefoundry/ir/types/shard/layout.py
+++ b/src/tilefoundry/ir/types/shard/layout.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional, Union
-
-if TYPE_CHECKING:
-    from tilefoundry.ir.types.shape_dim import ShapeDim
+from typing import Optional, Union
 
 
 @dataclass(frozen=True)

--- a/src/tilefoundry/runtime/loader.py
+++ b/src/tilefoundry/runtime/loader.py
@@ -1,12 +1,7 @@
 """Runtime loader — turn a ``LinkedModule`` into a callable ``RuntimeModule``."""
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from tilefoundry.runtime.module import RuntimeFunction, RuntimeModule
-
-if TYPE_CHECKING:
-    from tilefoundry.codegen.linker import LinkedModule
 
 
 def load_linked_module(linked: "LinkedModule") -> RuntimeModule:

--- a/tests/scripts/test_finalize_plan_context.py
+++ b/tests/scripts/test_finalize_plan_context.py
@@ -1,0 +1,156 @@
+from pathlib import Path
+
+import pytest
+
+from scripts.finalize_plan_context import FinalizeError, finalize_plan, main
+
+
+def _write_plan(
+    tmp_path: Path,
+    *,
+    related_files: list[str] | None = None,
+    spec_impact: list[str] | None = None,
+    include_spec_impact: bool = True,
+) -> Path:
+    related_files = related_files or ["src/tilefoundry/example.py"]
+    spec_impact = spec_impact or ["N/A: internal behavior-preserving change"]
+    related = "\n".join(f"- `{path}`" for path in related_files)
+    impact = "\n".join(f"- {item}" for item in spec_impact)
+    impact_section = f"\n#### Spec Impact\n{impact}\n" if include_spec_impact else ""
+    plan = tmp_path / "plan.md"
+    plan.write_text(
+        f"""---
+type: META
+component: test
+target_repo: tilefoundry
+---
+
+# [META][test] Finalizer fixture
+
+## Description
+
+### Symptom / Motivation
+
+Test fixture.
+
+### Root Cause Analysis
+
+Test fixture.
+
+### Related Files
+
+{related}
+
+## Goal
+
+Exercise plan validation.
+
+## Constraints
+
+- Keep the fixture minimal.
+
+## Milestones
+
+### Milestone M0: Validate fixture
+
+#### Depends
+
+- None
+
+#### Related Files
+
+{related}
+{impact_section}
+#### Plan
+
+- [ ] Exercise validation.
+
+#### Acceptance Criteria
+
+- [ ] The fixture is accepted or rejected as expected.
+<!-- policy_ac:start -->
+<!-- policy_ac:end -->
+
+## Execution Preflight
+
+<!-- policy_preflight:start -->
+<!-- policy_preflight:end -->
+"""
+    )
+    return plan
+
+
+def test_accepts_reasoned_na(tmp_path: Path) -> None:
+    plan = _write_plan(tmp_path)
+
+    finalize_plan(plan, write=False)
+
+
+def test_accepts_scoped_spec_paths(tmp_path: Path) -> None:
+    paths = ["docs/spec/core-ir.md", "docs/spec/types.md"]
+    plan = _write_plan(
+        tmp_path,
+        related_files=["src/tilefoundry/example.py", *paths],
+        spec_impact=[f"`{path}`" for path in paths],
+    )
+
+    finalize_plan(plan, write=False)
+
+
+def test_requires_spec_impact_with_milestone_name(tmp_path: Path) -> None:
+    plan = _write_plan(tmp_path, include_spec_impact=False)
+
+    with pytest.raises(
+        FinalizeError,
+        match=r"Milestone M0: Validate fixture.*missing `#### Spec Impact`",
+    ):
+        finalize_plan(plan, write=False)
+
+
+@pytest.mark.parametrize(
+    ("spec_impact", "message"),
+    [
+        (
+            ["N/A: internal change", "`docs/spec/types.md`"],
+            "cannot mix an `N/A:` entry with spec paths",
+        ),
+        (["N/A:"], "must use one reasoned `N/A: <reason>` entry"),
+        (
+            ["`docs/develop.md`"],
+            "must be a `docs/spec/\\*\\.md` path",
+        ),
+    ],
+)
+def test_rejects_malformed_spec_impact(
+    tmp_path: Path,
+    spec_impact: list[str],
+    message: str,
+) -> None:
+    plan = _write_plan(
+        tmp_path,
+        related_files=["src/tilefoundry/example.py", "docs/spec/types.md"],
+        spec_impact=spec_impact,
+    )
+
+    with pytest.raises(FinalizeError, match=message):
+        finalize_plan(plan, write=False)
+
+
+def test_rejects_spec_path_absent_from_related_files(tmp_path: Path) -> None:
+    plan = _write_plan(
+        tmp_path,
+        spec_impact=["`docs/spec/types.md`"],
+    )
+
+    with pytest.raises(
+        FinalizeError,
+        match="must also appear in the milestone's effective `#### Related Files`",
+    ):
+        finalize_plan(plan, write=False)
+
+
+def test_finalization_remains_idempotent(tmp_path: Path) -> None:
+    plan = _write_plan(tmp_path)
+
+    assert main([str(plan)]) == 0
+    assert main(["--check", str(plan)]) == 0


### PR DESCRIPTION
## Summary

- require every finalized-plan milestone to declare `Spec Impact` as owning `docs/spec/*.md` paths or one reasoned `N/A:` entry
- enforce spec-path membership in effective milestone `Related Files`, with template, policy, documentation, and focused finalizer coverage
- ban both `typing.TYPE_CHECKING` and `typing_extensions.TYPE_CHECKING` through Ruff TID251, and remove the four existing shims

## Migration impact

Existing local plans without `#### Spec Impact` now fail finalization by design. Add the owning spec paths or a reasoned `N/A:` entry, then rerun `scripts/finalize_plan_context.py`.

## Validation

- implementation worktree: full Ruff passed; finalizer tests `8 passed`; full suite `929 passed`
- independent acceptance: updated guard plan finalized and `--check` passed; finalizer tests `8 passed`; core/IR/parser/runtime `278 passed`; full Ruff passed; `rg TYPE_CHECKING src tests` returned no matches
