### PR TITLE
refactor: complete deferred consolidation (reduce tiers, shard canonicalizer, HIR->TIR lowering)

### DIFF
--- a/docs/spec/passes.md
+++ b/docs/spec/passes.md
@@ -240,6 +240,22 @@ chain (§4): each HIR op registers its lowering handler keyed by op class
 lowering, so the pass core depends on the registry contract, not on importing
 target-specific op classes.
 
+A handler is a free function `handler(ctx, target, expr) -> Var`, where
+`ctx` is the lowering context and `target` is the dispatched `Op`
+instance. A handler SHOULD interact with `ctx` only through its public ABI:
+
+- `ctx.lower(expr) -> Var` — recursively lower a nested sub-expression;
+- `ctx.fresh(type, hint) -> Var` — a fresh Var name (no binding emitted);
+- `ctx.alloc(type, hint) -> Var` — a fresh Var bound to a new `AllocTensor`;
+- `ctx.emit(stmt)` — append a raw Stmt to the pending lowered sequence;
+- `ctx.emit_bind(var, value)` — append a let-binding `var = value`.
+
+A target-owned op's handler MUST use only this public ABI — it has no
+standing to reach into pass-internal state. A core op whose lowering
+depends on pass-internal cooperation (dispatch-group resolution, the
+reshard cross-CTA sync fence, tuple-carry field lookup) MAY call other
+`_Lowerer` methods directly; this is the exception, not the norm.
+
 #### Mesh structure derivation
 
 `HirToTirPass` MUST NOT fabricate mesh structure. `cta_mesh` and

--- a/docs/spec/shard.md
+++ b/docs/spec/shard.md
@@ -194,12 +194,15 @@ references the composition's stable `shape` / `domain_rank` contract.
 ```python
 class Topology:                            # device-domain description
     name: str
-    num_devices: int
+    num_devices: int | None                # `None` only for a launch-provided (dynamic) `cta` extent
 
 class Mesh:                                # the parallel device domain
-    topology: Topology
+    topology: Topology                     # primary (first) Topology
+    topologies: tuple[Topology, ...]       # full Topology sequence; normalized non-empty, `topologies[0] is topology`
     layout: Layout | ComposedLayout        # a plain `Layout` (un-sliced) or a `ComposedLayout` (a constant `m[...]` slice)
     names: tuple[str, ...] | None = None
+
+    def topology_domain(self) -> int | None: ...  # product of `topologies[i].num_devices`; `None` if any is dynamic
 
 class MeshAxis:                            # single-axis object via `mesh.x` / `mesh.axes[i]`
     mesh: Mesh
@@ -213,7 +216,8 @@ class MeshAxis:                            # single-axis object via `mesh.x` / `
 
 Field meanings:
 
-- `topology` — device-domain description (`name` + `num_devices`)
+- `topology` — the primary (first) device-domain description (`name` +
+  `num_devices`)
 - `layout` — the mesh's own shape / strides (a `Layout`); a constant slice
   (`m[...]`) replaces it with a `ComposedLayout` recording the sub-box
   (tir.md §1.5)
@@ -224,6 +228,20 @@ Field meanings:
 
 `Mesh` describes the parallel device domain; it is not a tensor layout
 object.
+
+`Mesh` MAY carry more than one `Topology` (e.g. `warp(4) × thread(32)`); the
+full sequence is `topologies`, and `topology` is always its first entry.
+
+- constraints:
+  - `topologies` MUST normalize to a non-empty `tuple[Topology, ...]`; a
+    single `Topology` normalizes to a one-element `topologies` and a raw
+    string MUST be rejected (a caller resolving a surface topology name,
+    e.g. the parser's topology namespace or `make_mesh`, MUST convert it to
+    a `Topology` first) — a consumer MAY read `mesh.topologies` /
+    `mesh.topology` directly, with no fallback or duck-typing.
+  - `Mesh.topology_domain() -> int | None` is the product of every
+    `topologies[i].size`; it is `None` when any entry is a launch-provided
+    (dynamic) extent.
 
 ---
 

--- a/include/tilefoundry/runtime/cuda/ops/reduce.cuh
+++ b/include/tilefoundry/runtime/cuda/ops/reduce.cuh
@@ -5,32 +5,17 @@
 // therefore does NOT open ``namespace tilefoundry`` / ``ops`` and pulls in no
 // system headers — cute/std and the surrounding names (``detail::to_local``,
 // ``shard::S``/``shard::B``, ``TopologyScope``) are already in scope. The op
-// tags below must precede the impl-header includes because the tier impl
-// classes switch on them.
+// tags below must precede the impl-header includes because
+// ``reduce_impl::reduce_traits<Op>`` specializes on them.
 #pragma once
 
-struct mean_op {
-    template <class T> __device__ T operator()(T sum, T count) const {
-        return sum / count;
-    }
-};
-struct sum_op {
-    template <class T> __device__ T operator()(T sum, T) const { return sum; }
-};
-// Max-reduction tag. Consumed as a compile-time ``Op`` type by the sharded
-// reduce templates (their ``if constexpr`` / ``static_assert`` branches switch
-// on it); the reduce entry points support the SUM and MAX combines.
-struct rmax_op {
-    template <class T> __device__ T operator()(T acc, T) const { return acc; }
-};
-struct absmax_op {
-    template <class T> __device__ T operator()(T cur, T candidate) const {
-        return fabsf(static_cast<float>(candidate)) >
-                       fabsf(static_cast<float>(cur))
-                   ? candidate
-                   : cur;
-    }
-};
+// Reduce combine-kind tags — pure compile-time markers. Semantics (init
+// value, elem/combine/finalize) live in one place per tag,
+// ``reduce_impl::reduce_traits<Op>`` (reduce/reduce_common_impl.h), consumed
+// uniformly by all four reduce tiers below.
+struct mean_op {};
+struct sum_op {};
+struct absmax_op {};
 
 // ── Sharded reduce ───────────────────────────────
 // Per-tier reduce building blocks; the public ``reduce`` entry below selects a

--- a/include/tilefoundry/runtime/cuda/ops/reduce/reduce_common_impl.h
+++ b/include/tilefoundry/runtime/cuda/ops/reduce/reduce_common_impl.h
@@ -1,4 +1,5 @@
-// reduce common impl — shared helpers, dispatch trait, and layout detector.
+// reduce common impl — shared per-tag traits, per-thread fold, cell
+// decomposition, and the sharded-reduce dispatch trait / layout detector.
 //
 // Included in-context from ``ops/reduce.cuh`` (which is itself included inside
 // ``namespace tilefoundry::ops`` from runtime.cuh). This header therefore does
@@ -14,44 +15,125 @@ namespace reduce_impl {
 struct no_workspace_t {};
 inline constexpr no_workspace_t no_workspace{};
 
-// Per-thread local fold: max absolute value over N elements.
-template <class SrcT>
-__device__ float local_fold_maxabs(SrcT const &src, int N) {
-    float best = 0.f;
-    for (int i = 0; i < N; ++i) {
-        best = fmaxf(best, fabsf(static_cast<float>(src(i))));
+// ── Per-tag combine semantics ──────────────────────────────────────
+// One trait per Op tag, shared by every reduce tier (plain, intra-warp,
+// intra-cta, cross-warp). ``init`` seeds the fold; ``elem(x)`` maps a raw
+// source element into the fold domain (identity for sum/mean, ``|x|`` for
+// absmax); ``combine(a, b)`` merges two fold-domain values (``+`` for
+// sum/mean, ``fmaxf`` for absmax — both have ``init`` as their identity
+// element over this domain, since absmax's domain is always non-negative);
+// ``finalize(acc, count)`` produces the per-cell result (mean divides by the
+// reduced element count; sum/absmax pass the accumulator through unchanged).
+template <class Op> struct reduce_traits;
+
+template <> struct reduce_traits<sum_op> {
+    static constexpr float init = 0.f;
+    __device__ static float elem(float x) { return x; }
+    __device__ static float combine(float a, float b) { return a + b; }
+    __device__ static float finalize(float acc, float /*count*/) { return acc; }
+};
+
+template <> struct reduce_traits<mean_op> {
+    static constexpr float init = 0.f;
+    __device__ static float elem(float x) { return x; }
+    __device__ static float combine(float a, float b) { return a + b; }
+    __device__ static float finalize(float acc, float count) {
+        return acc / count;
     }
-    return best;
+};
+
+template <> struct reduce_traits<absmax_op> {
+    static constexpr float init = 0.f;
+    __device__ static float elem(float x) { return fabsf(x); }
+    __device__ static float combine(float a, float b) { return fmaxf(a, b); }
+    __device__ static float finalize(float acc, float /*count*/) { return acc; }
+};
+
+template <class Op>
+inline constexpr bool is_supported_reduce_op_v =
+    std::is_same_v<Op, sum_op> || std::is_same_v<Op, mean_op> ||
+    std::is_same_v<Op, absmax_op>;
+
+// Per-thread cell decomposition, shared by every reduce tier: the per-thread
+// cute tensor has ``size(s)`` source elements feeding ``size(d)`` destination
+// cells; the source is treated as ``n_cells`` contiguous chunks of ``step``
+// elements, each chunk reducing to one output cell (``n_cells == 1`` when
+// ``d`` is a single scalar cell, e.g. dst rank 0/1).
+struct cell_decomp_t {
+    int n_src;
+    int n_dst;
+    int n_cells;
+    int step;
+};
+
+template <class SrcT, class DstT>
+__device__ cell_decomp_t cell_decomp(SrcT const &s, DstT const &d) {
+    const int n_src = static_cast<int>(cute::size(s));
+    const int n_dst = static_cast<int>(cute::size(d));
+    const int n_cells = (n_dst == 0) ? 1 : n_dst;
+    const int step = n_src / n_cells;
+    return {n_src, n_dst, n_cells, step};
 }
 
-// Per-thread local fold of a contiguous tensor of size N into a single
-// scalar accumulator (sum / max / min, etc.). Returns the
-// f32-promoted accumulator so MEAN's final divide stays in f32.
-template <class SrcT> __device__ float local_fold_sum(SrcT const &src, int N) {
-    float acc = 0.f;
-    for (int i = 0; i < N; ++i) {
-        acc += static_cast<float>(src(i));
+// Rank-aware per-thread local fold: folds the ``step`` source elements of
+// logical cell ``j`` (out of ``cell_decomp``'s ``n_cells``) into a single
+// scalar accumulator via ``reduce_traits<Op>``.
+//
+// ``step == cute::size(s)`` is the single-cell / whole-tensor contract (Plain
+// with a scalar dst, and IntraCta — whose per-thread tensor has no dedicated
+// cell axis at all): it flattens across cute's *entire* multi-mode domain via
+// single-index addressing (``s(k)``), which stays correct however many cute
+// axes the per-thread layout carries — including residual axes introduced by
+// single-axis sugar factorisation (spec shard §7.1.2) — because ``s(k)``
+// always visits every coordinate of ``s`` exactly once regardless of its mode
+// structure.
+//
+// Otherwise (``n_cells > 1``, e.g. IntraWarp / CrossWarp, where each thread
+// owns several distinct output cells), cell-aligned 2-D access (``s(j, k)``)
+// keeps cell ``j`` on its own row of the per-thread cute layout, regardless
+// of cute's col-major linearisation: a linear ``s(j*step+k)`` over the full
+// tensor mis-aligns here because it reinterprets the (cells, step) mode pair
+// as one flat dimension in the wrong order. The single-axis path (rank-1
+// ``s``) uses ``s(j*step+k)`` directly in both cases — unambiguous, since
+// there is only one mode to address.
+template <class Op, class SrcT>
+__device__ float local_fold(SrcT const &s, int j, int step) {
+    using traits = reduce_traits<Op>;
+    float acc = traits::init;
+    constexpr int s_rank = decltype(cute::rank(s))::value;
+    if constexpr (s_rank > 1) {
+        if (step == static_cast<int>(cute::size(s))) {
+            for (int k = 0; k < step; ++k) {
+                acc = traits::combine(acc,
+                                      traits::elem(static_cast<float>(s(k))));
+            }
+        } else {
+            for (int k = 0; k < step; ++k) {
+                acc = traits::combine(
+                    acc, traits::elem(static_cast<float>(s(j, k))));
+            }
+        }
+    } else {
+        const int base = j * step;
+        for (int k = 0; k < step; ++k) {
+            acc = traits::combine(
+                acc, traits::elem(static_cast<float>(s(base + k))));
+        }
     }
     return acc;
 }
 
-// Intra-warp butterfly sum reduction (32 lanes → broadcast sum).
-__device__ inline float warp_sum_butterfly(float val) {
+// Intra-warp butterfly reduction (32 lanes → broadcast combine), using
+// ``Op``'s combine (``+`` for sum/mean, ``fmaxf`` for absmax).
+template <class Op> __device__ float warp_butterfly(float val) {
     for (int delta = 16; delta > 0; delta >>= 1) {
-        val += __shfl_xor_sync(0xFFFFFFFFu, val, delta);
+        val = reduce_traits<Op>::combine(
+            val, __shfl_xor_sync(0xFFFFFFFFu, val, delta));
     }
     return val;
 }
 
-// Intra-warp butterfly max reduction (32 lanes → broadcast max).
-__device__ inline float warp_max_butterfly(float val) {
-    for (int delta = 16; delta > 0; delta >>= 1) {
-        val = fmaxf(val, __shfl_xor_sync(0xFFFFFFFFu, val, delta));
-    }
-    return val;
-}
-
-// Cross-warp sum reduction via a shared-memory workspace.
+// Cross-warp SUM aggregation via a shared-memory workspace.
 //
 // ``workspace`` is sized to ``total_warps`` (all non-thread mesh
 // positions).  ``warps_per_group`` (≤ total_warps) controls grouping:
@@ -92,7 +174,7 @@ struct reduce_dispatch_info {
 // Derive, from the (src, dst) operand ShardLayouts, the active reduction level
 // and its ``warps_per_group``. Pure compile-time so the caller can select the
 // tier with ``if constexpr`` — otherwise the untaken tier still instantiates
-// and, e.g., ``CrossWarp<mean_op>`` would trip its SUM/MAX-only guard.
+// and, e.g., ``CrossWarp<mean_op>`` would trip its supported-op guard.
 // Requires a static mesh layout (the reduce mesh is a thread-scoped static
 // mesh); a reduced axis on a non-thread mesh scope yields the cross-warp tier.
 template <class SrcSL, class DstSL>

--- a/include/tilefoundry/runtime/cuda/ops/reduce/reduce_cross_warp_impl.h
+++ b/include/tilefoundry/runtime/cuda/ops/reduce/reduce_cross_warp_impl.h
@@ -7,59 +7,43 @@
 namespace reduce_impl {
 
 // ── Reduce tier-2b: cross-warp ONLY (lanes independent) ───────────
-// Stages one slot per (warp, lane, cell): each thread folds its local cells and
-// writes them, and after one ``__syncthreads`` folds its group's warps for its
-// own lane.
+// Stages one slot per (warp, lane, cell): each thread folds its local cells
+// via the shared rank-aware ``local_fold`` and writes them, and after one
+// ``__syncthreads`` folds its group's warps for its own lane via
+// ``reduce_traits<Op>::combine``; ``finalize`` divides by the total reduced
+// count for MEAN.
 template <class Op, class Axes> struct CrossWarp {
     template <class SrcT, class DstT, class WorkspaceT>
     __device__ void operator()(SrcT const &src, DstT &dst,
                                WorkspaceT &workspace,
                                int warps_per_group) const {
+        static_assert(is_supported_reduce_op_v<Op>,
+                      "tilefoundry::ops::reduce: unsupported Op");
         auto s = detail::to_local(src);
         auto &&d = detail::to_local(dst);
         auto &&ws = detail::to_local(workspace);
         using value_type = cute::remove_cvref_t<decltype(d(0))>;
-        const int n_src = static_cast<int>(cute::size(s));
-        const int n_dst = static_cast<int>(cute::size(d));
-        const int n_cells = (n_dst == 0) ? 1 : n_dst;
-        const int local_n = n_src / n_cells;
+
+        const auto decomp = cell_decomp(s, d);
         const int lane = threadIdx.x & 31;
         const int warp_id = threadIdx.x >> 5;
-        for (int j = 0; j < n_cells; ++j) {
-            float acc;
-            if constexpr (std::is_same_v<Op, rmax_op>) {
-                acc = -INFINITY;
-                for (int k = 0; k < local_n; ++k)
-                    acc = fmaxf(acc, static_cast<float>(s(j * local_n + k)));
-            } else {
-                acc = 0.f;
-                for (int k = 0; k < local_n; ++k)
-                    acc += static_cast<float>(s(j * local_n + k));
-            }
-            ws((warp_id * 32 + lane) * n_cells + j) = acc;
+        for (int j = 0; j < decomp.n_cells; ++j) {
+            const float local = local_fold<Op>(s, j, decomp.step);
+            ws((warp_id * 32 + lane) * decomp.n_cells + j) = local;
         }
         __syncthreads();
         const int group_start = (warp_id / warps_per_group) * warps_per_group;
-        for (int j = 0; j < n_cells; ++j) {
-            float acc;
-            if constexpr (std::is_same_v<Op, rmax_op>) {
-                acc = -INFINITY;
-                for (int w = 0; w < warps_per_group; ++w)
-                    acc = fmaxf(
-                        acc,
-                        static_cast<float>(
-                            ws(((group_start + w) * 32 + lane) * n_cells + j)));
-            } else if constexpr (std::is_same_v<Op, sum_op>) {
-                acc = 0.f;
-                for (int w = 0; w < warps_per_group; ++w)
-                    acc += static_cast<float>(
-                        ws(((group_start + w) * 32 + lane) * n_cells + j));
-            } else {
-                static_assert(std::is_same_v<Op, rmax_op> ||
-                                  std::is_same_v<Op, sum_op>,
-                              "reduce_cross_warp: only SUM / MAX supported");
+        for (int j = 0; j < decomp.n_cells; ++j) {
+            float acc = reduce_traits<Op>::init;
+            for (int w = 0; w < warps_per_group; ++w) {
+                acc = reduce_traits<Op>::combine(
+                    acc,
+                    static_cast<float>(ws(
+                        ((group_start + w) * 32 + lane) * decomp.n_cells + j)));
             }
-            d(j) = static_cast<value_type>(acc);
+            const float total_n = float(decomp.step) * float(warps_per_group);
+            d(j) = static_cast<value_type>(
+                reduce_traits<Op>::finalize(acc, total_n));
         }
     }
 };

--- a/include/tilefoundry/runtime/cuda/ops/reduce/reduce_intra_cta_impl.h
+++ b/include/tilefoundry/runtime/cuda/ops/reduce/reduce_intra_cta_impl.h
@@ -7,63 +7,35 @@
 namespace reduce_impl {
 
 // ── Reduce tier-2: cross-warp within a CTA (smem workspace) ───────
-// Each warp folds locally then writes its partial into the workspace; after one
-// ``__syncthreads()`` every thread sums its group's slots and broadcasts the
-// result to its output cells. ``warps_per_group`` partitions the workspace into
-// independent reduction groups. MEAN divides by ``local_n × 32 ×
-// warps_per_group``.
+// This tier's contract has a single group output per thread (``cell_decomp``'s
+// ``n_cells == 1``): each thread folds its *entire* per-thread tensor via
+// ``local_fold`` (its ``step == cute::size(s)`` whole-tensor path — correct
+// however many cute axes the per-thread layout carries, see
+// reduce_common_impl.h), then a warp butterfly + ``cta_sum_via_workspace``
+// combine across warps; ``reduce_traits<Op>`` finalises. MEAN divides by
+// ``step × 32 × warps_per_group``.
 template <class Op, class Axes> struct IntraCta {
     template <class SrcT, class DstT, class WorkspaceT>
     __device__ void operator()(SrcT const &src, DstT &dst,
                                WorkspaceT &workspace,
                                int warps_per_group) const {
+        static_assert(is_supported_reduce_op_v<Op>,
+                      "tilefoundry::ops::reduce: unsupported Op");
         auto s = detail::to_local(src);
         auto &&d = detail::to_local(dst);
         auto &&ws = detail::to_local(workspace);
         using value_type = cute::remove_cvref_t<decltype(d(0))>;
-        // local_n: elements folded per thread.  Per the tier-1 ``reduce``
-        // contract (size(s) % size(d) == 0; size(d) chunks of step lanes),
-        // each output cell takes ``size(s) / size(d)`` source elements.
-        // For the headline rmsnorm path size(d) == 1 ⇒ local_n == size(s)
-        // — folds the entire per-thread tensor. Taking only the last cute
-        // axis here (as the prior heuristic did) silently dropped the
-        // per-warp residual axes introduced by single-axis sugar
-        // factorisation (spec shard §7.1.2 + parser/sugar.py), so the mean
-        // reduce summed only a fraction of the row.
-        const int n_src = static_cast<int>(cute::size(s));
-        const int n_dst = static_cast<int>(cute::size(d));
-        const int local_n = (n_dst == 0) ? n_src : (n_src / n_dst);
 
-        float local, warp_partial, cta_partial;
-        if constexpr (std::is_same_v<Op, absmax_op>) {
-            local = reduce_impl::local_fold_maxabs(s, local_n);
-            warp_partial = reduce_impl::warp_max_butterfly(local);
-            cta_partial = reduce_impl::cta_sum_via_workspace(warp_partial, ws,
-                                                             warps_per_group);
-        } else {
-            local = reduce_impl::local_fold_sum(s, local_n);
-            warp_partial = reduce_impl::warp_sum_butterfly(local);
-            cta_partial = reduce_impl::cta_sum_via_workspace(warp_partial, ws,
-                                                             warps_per_group);
-        }
-
-        if constexpr (std::is_same_v<Op, mean_op>) {
-            float total_n = float(local_n) * 32.f * float(warps_per_group);
-            float result = cta_partial / total_n;
-            for (int i = 0; i < static_cast<int>(cute::size(d)); ++i) {
-                d(i) = static_cast<value_type>(result);
-            }
-        } else if constexpr (std::is_same_v<Op, sum_op>) {
-            for (int i = 0; i < static_cast<int>(cute::size(d)); ++i) {
-                d(i) = static_cast<value_type>(cta_partial);
-            }
-        } else if constexpr (std::is_same_v<Op, absmax_op>) {
-            for (int i = 0; i < static_cast<int>(cute::size(d)); ++i) {
-                d(i) = static_cast<value_type>(cta_partial);
-            }
-        } else {
-            static_assert(sizeof(Op) == 0,
-                          "tilefoundry::ops::reduce: unsupported Op");
+        const auto decomp = cell_decomp(s, d);
+        const float local = local_fold<Op>(s, 0, decomp.step);
+        const float warp_partial = warp_butterfly<Op>(local);
+        const float cta_partial =
+            cta_sum_via_workspace(warp_partial, ws, warps_per_group);
+        const float total_n =
+            float(decomp.step) * 32.f * float(warps_per_group);
+        const float result = reduce_traits<Op>::finalize(cta_partial, total_n);
+        for (int i = 0; i < static_cast<int>(cute::size(d)); ++i) {
+            d(i) = static_cast<value_type>(result);
         }
     }
 };

--- a/include/tilefoundry/runtime/cuda/ops/reduce/reduce_intra_warp_impl.h
+++ b/include/tilefoundry/runtime/cuda/ops/reduce/reduce_intra_warp_impl.h
@@ -7,79 +7,26 @@
 namespace reduce_impl {
 
 // ── Reduce tier-1: intra-warp only, no smem workspace ─────────────
-// Each thread folds its per-cell slice locally, then a 32-lane
-// ``__shfl_xor_sync`` butterfly broadcasts the partial.
-//
-// Per-thread cell decomposition: the per-thread cute tensor has ``size(s)``
-// source elements feeding ``size(d)`` destination cells; the source is treated
-// as ``size(d)`` contiguous chunks of ``size(s) / size(d)`` lanes, each chunk
-// reducing to one output cell.
+// Each thread folds its per-cell slice locally via ``local_fold`` (rank-aware
+// cell decomposition — see reduce_common_impl.h), then a 32-lane
+// ``warp_butterfly`` broadcasts the combined partial; ``reduce_traits<Op>``
+// finalises (mean divides by the total reduced count).
 template <class Op, class Axes> struct IntraWarp {
     template <class SrcT, class DstT>
     __device__ void operator()(SrcT const &src, DstT &dst) const {
+        static_assert(is_supported_reduce_op_v<Op>,
+                      "tilefoundry::ops::reduce: unsupported Op");
         auto s = detail::to_local(src);
         auto &&d = detail::to_local(dst);
         using value_type = cute::remove_cvref_t<decltype(d(0))>;
 
-        const int n_src = static_cast<int>(cute::size(s));
-        const int n_dst = static_cast<int>(cute::size(d));
-        const int n_cells = (n_dst == 0) ? 1 : n_dst;
-        const int step = n_src / n_cells;
-
-        // Cell-aligned 2-D access (``s(j, k)``) keeps each cell on a single
-        // row of the per-thread cute layout, regardless of cute's
-        // col-major linearisation. Linear ``s(j*step + k)`` mis-aligns
-        // when the coalesced per-thread layout has multiple cute axes
-        // (factorised single-axis sugar — spec shard §7.1.2). The
-        // single-axis path (1-D ``s``) uses linear access — that's the
-        // headline rmsnorm seq_1 case where the per-thread cute layout
-        // collapses to a single contiguous dim after coalesce.
-        constexpr int s_rank = decltype(cute::rank(s))::value;
-        for (int j = 0; j < n_cells; ++j) {
-            float local;
-            if constexpr (std::is_same_v<Op, absmax_op>) {
-                local = 0.f;
-                if constexpr (s_rank > 1) {
-                    for (int k = 0; k < step; ++k) {
-                        local =
-                            fmaxf(local, fabsf(static_cast<float>(s(j, k))));
-                    }
-                } else {
-                    const int base = j * step;
-                    for (int k = 0; k < step; ++k) {
-                        local = fmaxf(local,
-                                      fabsf(static_cast<float>(s(base + k))));
-                    }
-                }
-            } else {
-                local = 0.f;
-                if constexpr (s_rank > 1) {
-                    for (int k = 0; k < step; ++k) {
-                        local += static_cast<float>(s(j, k));
-                    }
-                } else {
-                    const int base = j * step;
-                    for (int k = 0; k < step; ++k) {
-                        local += static_cast<float>(s(base + k));
-                    }
-                }
-            }
-            float partial;
-            if constexpr (std::is_same_v<Op, absmax_op>) {
-                partial = reduce_impl::warp_max_butterfly(local);
-            } else {
-                partial = reduce_impl::warp_sum_butterfly(local);
-            }
-            if constexpr (std::is_same_v<Op, mean_op>) {
-                const float total_n = float(step) * 32.f;
-                d(j) = static_cast<value_type>(partial / total_n);
-            } else if constexpr (std::is_same_v<Op, sum_op> ||
-                                 std::is_same_v<Op, absmax_op>) {
-                d(j) = static_cast<value_type>(partial);
-            } else {
-                static_assert(sizeof(Op) == 0,
-                              "tilefoundry::ops::reduce: unsupported Op");
-            }
+        const auto decomp = cell_decomp(s, d);
+        for (int j = 0; j < decomp.n_cells; ++j) {
+            const float local = local_fold<Op>(s, j, decomp.step);
+            const float partial = warp_butterfly<Op>(local);
+            const float total_n = float(decomp.step) * 32.f;
+            d(j) = static_cast<value_type>(
+                reduce_traits<Op>::finalize(partial, total_n));
         }
     }
 };

--- a/include/tilefoundry/runtime/cuda/ops/reduce/reduce_plain_impl.h
+++ b/include/tilefoundry/runtime/cuda/ops/reduce/reduce_plain_impl.h
@@ -1,38 +1,29 @@
 // reduce plain (non-sharded) rank-aware fold.
 //
 // Included in-context from ``ops/reduce.cuh`` (see reduce_common_impl.h for the
-// in-context include contract). Op tags are in scope.
+// in-context include contract). Op tags and reduce_impl helpers are in scope.
 #pragma once
 
 namespace reduce_impl {
 
 // Non-sharded reduce over a plain cute tensor. Extents are derived from the
-// operand: rank-1 folds all ``cute::size(src)`` elements into ``dst(0)``;
-// rank-2 folds each of the ``M`` rows over its ``K`` columns into ``dst(m)``.
-// Combine finalisation (``op(acc, count)``) matches the legacy plain reduce.
+// operand via the shared ``cell_decomp``: a scalar ``dst`` folds every
+// element of ``src`` into ``dst(0)``; an ``M``-cell ``dst`` folds each of the
+// ``M`` cells over its ``size(src) / M`` elements into ``dst(j)``. Combine +
+// finalisation come from ``reduce_traits<Op>``, shared with the sharded
+// tiers.
 template <class Op, class Axes> struct Plain {
     template <class SrcT, class DstT>
     __device__ void operator()(SrcT const &src, DstT &dst) const {
+        static_assert(is_supported_reduce_op_v<Op>,
+                      "tilefoundry::ops::reduce: unsupported Op");
         using value_type = cute::remove_cvref_t<decltype(dst(0))>;
-        Op op{};
-        constexpr int s_rank = decltype(cute::rank(src))::value;
-        if constexpr (s_rank == 1) {
-            const int N = static_cast<int>(cute::size(src));
-            float acc = 0.0f;
-            for (int i = 0; i < N; ++i) {
-                acc += static_cast<float>(src(i));
-            }
-            dst(0) = static_cast<value_type>(op(acc, float(N)));
-        } else {
-            const int M = static_cast<int>(cute::size<0>(src));
-            const int K = static_cast<int>(cute::size<1>(src));
-            for (int m = 0; m < M; ++m) {
-                float acc = 0.0f;
-                for (int k = 0; k < K; ++k) {
-                    acc += static_cast<float>(src(m * K + k));
-                }
-                dst(m) = static_cast<value_type>(op(acc, float(K)));
-            }
+
+        const auto decomp = cell_decomp(src, dst);
+        for (int j = 0; j < decomp.n_cells; ++j) {
+            const float acc = local_fold<Op>(src, j, decomp.step);
+            dst(j) = static_cast<value_type>(
+                reduce_traits<Op>::finalize(acc, float(decomp.step)));
         }
     }
 };

--- a/src/tilefoundry/codegen/cuda/emit.py
+++ b/src/tilefoundry/codegen/cuda/emit.py
@@ -127,11 +127,9 @@ def _derive_launch_config(
         nonlocal cta_dynamic
         g = 1
         b = 1
-        for t in mesh.topologies or (mesh.topology,):
-            if t is None:
-                continue
-            tname = t.name if hasattr(t, "name") else str(t)
-            size = getattr(t, "size", 1)
+        for t in mesh.topologies:
+            tname = t.name
+            size = t.size
             if not isinstance(size, int):
                 if tname == "cta":
                     # Launch-provided (dynamic) CTA extent: the grid is supplied

--- a/src/tilefoundry/codegen/cuda/tir/stmts/mesh_scope.py
+++ b/src/tilefoundry/codegen/cuda/tir/stmts/mesh_scope.py
@@ -17,8 +17,7 @@ def _validate_topology(mesh) -> None:
     supports; finer levels (e.g. warp) belong in the mesh layout, not as a
     program topology level. Defense-in-depth alongside the declared-topology
     check at lowering entry."""
-    topos = getattr(mesh, "topologies", None) or (mesh.topology,)
-    validate_cuda_topology_levels(t.name for t in topos)
+    validate_cuda_topology_levels(t.name for t in mesh.topologies)
 
 
 

--- a/src/tilefoundry/ir/tir/sync.py
+++ b/src/tilefoundry/ir/tir/sync.py
@@ -127,18 +127,6 @@ class Participation:
     lane_mask: int      # __syncwarp mask (only meaningful when single_warp)
 
 
-def _topology_domain(mesh: Mesh) -> "int | None":
-    """Block thread count = product of the mesh's topology extents. ``None`` if
-    any topology extent is dynamic (launch-provided)."""
-    topos = mesh.topologies or (mesh.topology,)
-    domain = 1
-    for t in topos:
-        if not isinstance(t.size, int):
-            return None
-        domain *= t.size
-    return domain
-
-
 def _participant_layout(mesh: Mesh) -> "tuple[Layout, int]":
     """The (outer layout, offset) describing which threads participate.
 
@@ -159,7 +147,7 @@ def participation(mesh: Mesh) -> Participation:
 
     Raises ``VerifyError`` for a malformed mesh (dynamic extent) or an
     unsupported slice (non-contiguous / overlapping)."""
-    domain = _topology_domain(mesh)
+    domain = mesh.topology_domain()
     if domain is None:
         raise VerifyError(
             "T.sync: a mesh with a dynamic topology extent cannot be classified; "
@@ -211,8 +199,8 @@ def participation(mesh: Mesh) -> Participation:
 def classify(mesh: Mesh) -> SyncBarrier:
     """Pick the hardware barrier for ``mesh``. Raises ``VerifyError`` for a
     cross-warp subset that is not warp-aligned."""
-    topos = mesh.topologies or (mesh.topology,)
-    if topos and all(getattr(t, "name", None) == "cta" for t in topos):
+    topos = mesh.topologies
+    if all(t.name == "cta" for t in topos):
         # A cta-scope mesh maps to the grid-wide barrier; only the full mesh
         # (no cta slice) has a supported barrier.
         if isinstance(mesh.layout, ComposedLayout):

--- a/src/tilefoundry/ir/types/shard/__init__.py
+++ b/src/tilefoundry/ir/types/shard/__init__.py
@@ -16,6 +16,7 @@ from .shard_layout import (
     ShardAttr,
     ShardLayout,
     Split,
+    canonical_shard_layout,
 )
 from .utils import make_mesh
 
@@ -30,5 +31,5 @@ __all__ = [
     "Topology", "MeshAxis", "Mesh", "make_mesh",
     # shard
     "ShardAttr", "Split", "Partial", "Broadcast", "Dynamic", "ShardLayout",
-    "S", "P", "B",
+    "S", "P", "B", "canonical_shard_layout",
 ]

--- a/src/tilefoundry/ir/types/shard/mesh.py
+++ b/src/tilefoundry/ir/types/shard/mesh.py
@@ -44,19 +44,11 @@ class Mesh:
       axes; the layout shape's product must equal the domain size.
     - ``names`` labels each layout axis.
 
-    For backward compatibility ``Mesh.topology`` remains the *primary*
-    (first) Topology — callers that read ``mesh.topology.name`` /
-    ``.size`` for kernel-launch / codegen-config purposes keep working.
-    The full Topology tuple is exposed via :attr:`topologies` for
-    the multi-topology case.
-
-    Argument coercions accepted in ``__post_init__``:
-
-    - ``topology``: a single ``Topology`` (legacy) or a list / tuple
-      of them (multi-topology). The first becomes ``Mesh.topology``,
-      the full sequence becomes ``Mesh.topologies``.
-    - ``layout``: a ``Layout`` (verbose) or a tuple of ints
-      (shorthand — auto-build row-major-strided ``Layout``).
+    ``Mesh.topology`` is the primary (first) Topology; the full tuple is
+    ``topologies``. ``__post_init__`` normalizes ``topologies`` to a
+    non-empty ``tuple[Topology, ...]`` (a single Topology or a non-empty
+    tuple accepted; a raw string rejected) and coerces a ``(s0, s1, ...)``
+    layout shorthand to a C-order ``Layout`` — see ``docs/spec/shard.md`` §5.
 
     ``layout`` is a plain ``Layout`` for an un-sliced mesh. A constant slice
     (``m[1:3, :]``, used by ``T.sync``) replaces ``layout`` with a
@@ -73,16 +65,30 @@ class Mesh:
     topologies: tuple[Topology, ...] = ()
 
     def __post_init__(self) -> None:
-        # Coerce ``topology`` (list / tuple of Topology accepted at
-        # construction time) into the primary + the full tuple.
+        # Normalize ``topology`` (list / tuple of Topology accepted at
+        # construction time) into the primary + the full, non-empty tuple.
         topo = self.topology
+        if isinstance(topo, str):
+            raise TypeError(
+                f"Mesh.topology must be a Topology (or a non-empty tuple of "
+                f"them), got a raw string {topo!r}; resolve it to a Topology "
+                f"first (e.g. via make_mesh)"
+            )
         if isinstance(topo, (list, tuple)):
+            if not topo:
+                raise ValueError("Mesh.topology tuple must be non-empty")
             primary = topo[0]
             full = tuple(topo)
             object.__setattr__(self, "topology", primary)
             object.__setattr__(self, "topologies", full)
-        elif isinstance(topo, Topology) and not self.topologies:
-            object.__setattr__(self, "topologies", (topo,))
+        elif isinstance(topo, Topology):
+            if not self.topologies:
+                object.__setattr__(self, "topologies", (topo,))
+        else:
+            raise TypeError(
+                f"Mesh.topology must be a Topology or a tuple of Topology, "
+                f"got {type(topo).__name__}"
+            )
 
         # Coerce raw ``(s0, s1, ...)`` layout into a ``Layout`` with
         # C-order strides.
@@ -98,6 +104,16 @@ class Mesh:
             object.__setattr__(
                 self, "layout", Layout(shape=ly, strides=c_order_strides(ly))
             )
+
+    def topology_domain(self) -> "int | None":
+        """Total device-domain extent = product of every ``Topology`` in
+        ``topologies``; ``None`` if any extent is dynamic (launch-provided)."""
+        domain = 1
+        for t in self.topologies:
+            if not isinstance(t.size, int):
+                return None
+            domain *= t.size
+        return domain
 
 
     @property

--- a/src/tilefoundry/ir/types/shard/scope_match.py
+++ b/src/tilefoundry/ir/types/shard/scope_match.py
@@ -10,26 +10,14 @@ def _as_layout(mesh: Mesh) -> Layout:
     return Layout(shape=tuple(mesh.layout.shape), strides=tuple(mesh.layout.strides))
 
 
-def _topology_domain(mesh: Mesh) -> "int | None":
-    """Total thread count = product of the mesh's topology extents; ``None`` if
-    any extent is dynamic (launch-provided)."""
-    topos = mesh.topologies or (mesh.topology,)
-    domain = 1
-    for t in topos:
-        if not isinstance(t.size, int):
-            return None
-        domain *= t.size
-    return domain
-
-
 def mesh_scope_matches_required_scope(current: Mesh, required: Mesh) -> bool:
     """True iff ``current`` provides the thread participation ``required`` needs."""
     # Same program topology level — a `cta` scope is never a `thread`/warp scope.
     if current.topology.name != required.topology.name:
         return False
 
-    cur_domain = _topology_domain(current)
-    req_domain = _topology_domain(required)
+    cur_domain = current.topology_domain()
+    req_domain = required.topology_domain()
     if cur_domain is None or req_domain is None:
         return False
 

--- a/src/tilefoundry/ir/types/shard/shard_layout.py
+++ b/src/tilefoundry/ir/types/shard/shard_layout.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from .layout import LayoutBase
+from .layout import Layout, LayoutBase
+from .layout_algebra import try_c_order_strides
 from .mesh import Mesh
 
 
@@ -53,6 +54,105 @@ class ShardLayout(LayoutBase):
     @property
     def shape(self) -> tuple:
         return self.layout.shape
+
+
+def canonical_shard_layout(logical_shape: tuple, mesh: Mesh, attrs: tuple) -> "ShardLayout":
+    """Build the canonical ``ShardLayout`` (``docs/spec/shard.md`` §7.1.1)
+    binding ``attrs`` (one entry per mesh axis; each ``Split`` names a
+    ``logical_shape`` axis) to ``mesh``.
+
+    Every logical axis split by one or more mesh axes is factored, in
+    mesh-axis order, into one position per splitting mesh axis (sized to
+    that axis's extent) plus a residual position
+    (``logical_size // Π(extents)``, omitted when 1, an error when the
+    division is not exact) — every ``Split``-bound position in the
+    resulting ``Layout`` ends up sized exactly to its mesh extent
+    (``G[k] == mesh.shape[a]``), the §7.1.1 canonical form, *even when a
+    single mesh axis splits the axis*. A single mesh-axis split is instead
+    kept whole (one Split-bound position, no residual) when it cannot be
+    factored into a static extent + residual: either the mesh extent is
+    launch-provided (``mesh.shape[a] is None``, only a ``cta`` topology, its
+    runtime count unknown at compile time) or the logical axis size is itself
+    dynamic (the residual ``size // extent`` would be symbolic) — each shard
+    then owns one runtime-determined 1/extent slice. (A dynamic logical axis
+    split by *several* mesh axes cannot be represented and is an error.)
+    ``Split`` attrs are remapped from the logical axis to that
+    position; ``Broadcast`` / ``Partial`` / ``Dynamic`` pass through
+    unchanged. Strides are freshly built C-order (``None`` when the
+    resulting shape is dynamic).
+
+    This is the single canonicalizer for a §7.1.1 layout: both
+    ``make_shard_tensor_type`` (a from-scratch sharding) and
+    ``derive_output_shard_layout``'s synthesis fallback (a propagated one)
+    call it, so a layout built by either for the same logical sharding
+    always compares structurally equal.
+    """
+    mesh_shape = mesh.layout.shape
+    bindings: dict[int, list[int]] = {}
+    for mesh_axis, attr in enumerate(attrs):
+        if isinstance(attr, Split):
+            bindings.setdefault(attr.axis, []).append(mesh_axis)
+
+    layout_shape: list = []
+    factor_position: dict[int, int] = {}
+    for logical_axis, axis_size in enumerate(logical_shape):
+        splitting_mesh_axes = bindings.get(logical_axis, [])
+        if not splitting_mesh_axes:
+            layout_shape.append(axis_size)
+            continue
+        # A single mesh-axis split keeps the whole logical axis as one
+        # Split-bound position when it cannot be factored into a static extent
+        # + residual: either the mesh extent is launch-provided (dynamic,
+        # ``None``) or the logical axis size is itself dynamic (the residual
+        # ``size // extent`` would be symbolic). Each shard then owns a
+        # runtime-determined 1/extent slice. This matches the pre-canonicalizer
+        # single-split synthesis in ``derive_output_shard_layout`` (a dynamic
+        # axis split by *several* mesh axes still errors, below).
+        axis_static = isinstance(axis_size, int) and not isinstance(axis_size, bool)
+        if len(splitting_mesh_axes) == 1 and (
+            mesh_shape[splitting_mesh_axes[0]] is None or not axis_static
+        ):
+            factor_position[splitting_mesh_axes[0]] = len(layout_shape)
+            layout_shape.append(axis_size)
+            continue
+        extent_product = 1
+        for mesh_axis in splitting_mesh_axes:
+            extent = mesh_shape[mesh_axis]
+            if not (isinstance(extent, int) and not isinstance(extent, bool)):
+                raise ValueError(
+                    f"canonical_shard_layout: mesh axis {mesh_axis} has a "
+                    f"dynamic extent {extent!r}; cannot factorize logical "
+                    f"axis {logical_axis}"
+                )
+            factor_position[mesh_axis] = len(layout_shape)
+            layout_shape.append(extent)
+            extent_product *= extent
+        if not axis_static:
+            raise ValueError(
+                f"canonical_shard_layout: logical axis {logical_axis} size "
+                f"{axis_size!r} is dynamic; cannot factorize across multiple "
+                f"mesh axes"
+            )
+        if axis_size % extent_product != 0:
+            raise ValueError(
+                f"canonical_shard_layout: logical axis {logical_axis} size "
+                f"{axis_size} is not divisible by mesh extent product "
+                f"{extent_product}"
+            )
+        residual = axis_size // extent_product
+        if residual != 1:
+            layout_shape.append(residual)
+
+    remapped_attrs = tuple(
+        Split(factor_position[mesh_axis]) if isinstance(attr, Split) else attr
+        for mesh_axis, attr in enumerate(attrs)
+    )
+    layout_shape = tuple(layout_shape)
+    return ShardLayout(
+        layout=Layout(shape=layout_shape, strides=try_c_order_strides(layout_shape)),
+        attrs=remapped_attrs,
+        mesh=mesh,
+    )
 
 
 def shard_layout_local_shape(sl: "ShardLayout") -> tuple[int, ...]:
@@ -168,6 +268,7 @@ __all__ = [
     "P",
     "B",
     "ShardLayout",
+    "canonical_shard_layout",
     "shard_layout_local_shape",
     "layout_axis_to_tensor_axis",
     "split_target_axes",

--- a/src/tilefoundry/ir/types/shard/utils.py
+++ b/src/tilefoundry/ir/types/shard/utils.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import math
+
 from .mesh import Mesh, Topology
 
 
@@ -12,7 +14,14 @@ def make_mesh(
     extents (C-order strides, via ``Mesh``'s own tuple-shorthand coercion).
     ``names`` defaults to ``a, b, c, ...`` (or ``g`` for a single axis) so a
     caller states only the extents instead of hand-building a ``Mesh``.
+
+    ``topology`` accepts an explicit ``Topology`` or the ``"gpu"``-shorthand
+    default; a raw string is resolved here into a real ``Topology`` sized to
+    the domain (``Mesh`` itself rejects a string — ``docs/spec/shard.md``
+    §5).
     """
     if names is None:
         names = ("g",) if len(layout_shape) == 1 else tuple("abcdef"[: len(layout_shape)])
+    if isinstance(topology, str):
+        topology = Topology(topology, math.prod(layout_shape))
     return Mesh(topology=topology, layout=tuple(layout_shape), names=tuple(names), topologies=(topology,))

--- a/src/tilefoundry/ir/types/utils.py
+++ b/src/tilefoundry/ir/types/utils.py
@@ -5,7 +5,7 @@ from typing import Optional
 from tilefoundry.ir.types.storage import StorageKind
 
 from .dtype import DType
-from .shard import ComposedLayout, Layout, Mesh, ShardLayout, Split, c_order_strides
+from .shard import ComposedLayout, Layout, Mesh, ShardLayout, Split, canonical_shard_layout
 from .tensor_type import TensorType, TupleType, Type
 
 
@@ -31,60 +31,16 @@ def make_shard_tensor_type(
     """Build the canonical sharded ``TensorType`` (``docs/spec/shard.md``
     §7.1.1) from a logical description: ``shape`` is the logical tensor
     shape, ``attrs`` is one entry per mesh axis (``Split(logical_axis)`` /
-    ``Broadcast()`` / ``Partial(reduction)``).
-
-    Each logical axis split by one or more mesh axes is factored, in mesh-axis
-    order, into one position per splitting mesh axis (sized to that axis's
-    extent) plus a residual position (``logical_size // Π(extents)``, omitted
-    when 1, an error when the division is not exact) — the internal ``Layout``
-    this produces has every ``Split``-bound position sized exactly to its mesh
-    extent, which is the §7.1.1 canonical form. ``Split`` attrs are remapped
-    from the logical axis to that position. ``mesh=None`` / ``attrs=()``
-    yields a plain (unsharded) ``TensorType``.
+    ``Broadcast()`` / ``Partial(reduction)``). ``mesh=None`` / ``attrs=()``
+    yields a plain (unsharded) ``TensorType``; otherwise the layout is built
+    by the shared :func:`canonical_shard_layout` (also used by
+    ``derive_output_shard_layout``'s synthesis fallback, so the two
+    producers of a §7.1.1 layout always agree).
     """
     shape = tuple(shape)
     if mesh is None or not attrs:
         return TensorType(shape=shape, dtype=dtype, layout=None, storage=storage)
-
-    mesh_shape = mesh.layout.shape
-    bindings: dict[int, list[int]] = {}
-    for mesh_axis, attr in enumerate(attrs):
-        if isinstance(attr, Split):
-            bindings.setdefault(attr.axis, []).append(mesh_axis)
-
-    layout_shape: list[int] = []
-    factor_position: dict[int, int] = {}
-    for logical_axis, axis_size in enumerate(shape):
-        splitting_mesh_axes = bindings.get(logical_axis, [])
-        if not splitting_mesh_axes:
-            layout_shape.append(axis_size)
-            continue
-        extent_product = 1
-        for mesh_axis in splitting_mesh_axes:
-            extent = mesh_shape[mesh_axis]
-            factor_position[mesh_axis] = len(layout_shape)
-            layout_shape.append(extent)
-            extent_product *= extent
-        if axis_size % extent_product != 0:
-            raise ValueError(
-                f"make_shard_tensor_type: logical axis {logical_axis} size "
-                f"{axis_size} is not divisible by mesh extent product "
-                f"{extent_product}"
-            )
-        residual = axis_size // extent_product
-        if residual != 1:
-            layout_shape.append(residual)
-
-    remapped_attrs = tuple(
-        Split(factor_position[mesh_axis]) if isinstance(attr, Split) else attr
-        for mesh_axis, attr in enumerate(attrs)
-    )
-    layout_shape = tuple(layout_shape)
-    layout = ShardLayout(
-        layout=Layout(shape=layout_shape, strides=c_order_strides(layout_shape)),
-        attrs=remapped_attrs,
-        mesh=mesh,
-    )
+    layout = canonical_shard_layout(shape, mesh, attrs)
     return TensorType(shape=shape, dtype=dtype, layout=layout, storage=storage)
 
 

--- a/src/tilefoundry/passes/transforms/bufferize.py
+++ b/src/tilefoundry/passes/transforms/bufferize.py
@@ -13,14 +13,8 @@ from tilefoundry.ir.core import Call, Var
 from tilefoundry.ir.core.module import Module
 from tilefoundry.ir.tir.memory import AllocTensor
 from tilefoundry.ir.tir.prim_function import PrimFunction
-from tilefoundry.ir.tir.stmts import (
-    For,
-    If,
-    LetStmt,
-    MeshScope,
-    Sequential,
-    While,
-)
+from tilefoundry.ir.tir.stmts import LetStmt
+from tilefoundry.ir.visitor import StmtVisitor
 from tilefoundry.passes.pass_base import PrimFuncPass
 
 
@@ -53,51 +47,40 @@ class Placement:
     offset: int = 0
 
 
-class LifetimeCollector:
+class LifetimeCollector(StmtVisitor):
     """Walk a ``PrimFunction`` body and collect every ``LetStmt`` that binds
     a ``Call(AllocTensor, ...)`` together with its lifetime range.
 
-    MVP impl emits a flat list in pre-order. Subclasses can override
-    ``collect`` to do real liveness analysis (use-def dataflow). The hook
-    boundary is intentionally narrow so swapping it does not ripple into
-    the pass.
+    Traversal completeness (``For`` / ``While`` / ``If`` / ``MeshScope`` /
+    ``DispatchCall`` descent, including its ``case_calls`` / ``fallback``
+    arms) is owned by ``StmtVisitor``'s ``_stmt_children`` table, not by
+    this class. MVP impl emits a flat list in pre-order. Subclasses can
+    override ``collect`` to do real liveness analysis (use-def dataflow).
+    The hook boundary is intentionally narrow so swapping it does not
+    ripple into the pass.
     """
 
     def collect(self, fn: PrimFunction) -> tuple[BufferEntry, ...]:
-        entries: list[BufferEntry] = []
-        counter = [0]
+        self._entries: list[BufferEntry] = []
+        self._point = 0
+        self.visit(fn.body)
+        return tuple(self._entries)
 
-        def emit_entry(var: Var, alloc: AllocTensor, point: int) -> None:
-            entries.append(
+    def visit(self, stmt) -> None:
+        self._point += 1
+        point = self._point
+        if (
+            isinstance(stmt, LetStmt)
+            and isinstance(stmt.value, Call)
+            and isinstance(stmt.value.target, AllocTensor)
+        ):
+            self._entries.append(
                 BufferEntry(
-                    var=var, alloc=alloc, defined_at=point, last_use_at=point
+                    var=stmt.var, alloc=stmt.value.target,
+                    defined_at=point, last_use_at=point,
                 )
             )
-
-        def walk(stmt) -> None:
-            counter[0] += 1
-            point = counter[0]
-            if isinstance(stmt, LetStmt):
-                if isinstance(stmt.value, Call) and isinstance(
-                    stmt.value.target, AllocTensor
-                ):
-                    emit_entry(stmt.var, stmt.value.target, point)
-                walk(stmt.body)
-                return
-            if isinstance(stmt, Sequential):
-                for s in stmt.body:
-                    walk(s)
-                return
-            if isinstance(stmt, (For, While, MeshScope)):
-                walk(stmt.body)
-                return
-            if isinstance(stmt, If):
-                walk(stmt.then_body)
-                walk(stmt.else_body)
-                return
-
-        walk(fn.body)
-        return tuple(entries)
+        return super().visit(stmt)
 
 
 class BufferScheduler:

--- a/src/tilefoundry/passes/transforms/hir_to_tir.py
+++ b/src/tilefoundry/passes/transforms/hir_to_tir.py
@@ -57,7 +57,7 @@ from tilefoundry.ir.tir.memory.tensor_view import TensorView
 from tilefoundry.ir.tir.nn.relu import ReLU as TirReLU
 from tilefoundry.ir.tir.prim_function import PrimFunction
 from tilefoundry.ir.tir.reduce import Reduce as TirReduce
-from tilefoundry.ir.tir.shape import ShapeOf, shape_var_name
+from tilefoundry.ir.tir.shape import ShapeOf, parse_shape_var_name, shape_var_name
 from tilefoundry.ir.tir.stmt import Stmt
 from tilefoundry.ir.tir.stmts import (
     Abort,
@@ -88,6 +88,7 @@ from tilefoundry.ir.types.shard.shard_layout import (
     layout_axis_to_tensor_axis as _layout_axis_to_tensor_axis,
 )
 from tilefoundry.ir.types.storage import StorageKind
+from tilefoundry.ir.visitor import ExprVisitor
 from tilefoundry.passes.pass_base import ModulePass
 from tilefoundry.visitor_registry.registries import (
     hir_lowering_registry,
@@ -298,6 +299,68 @@ class _Lowerer:
         self._name_counter += 1
         return Var(type=type_, name=f"{hint}{self._name_counter}")
 
+    def _alloc(self, type_, hint: str = "r") -> Var:
+        """Fresh Var + ``AllocTensor`` Call + ``_Bind`` — the alloc-and-bind
+        boilerplate shared by every buffer-introducing lowering handler."""
+        r = self._fresh(type_, hint=hint)
+        alloc_r = Call(type=r.type, target=AllocTensorOp(tensor_type=r.type), args=())
+        self._items.append(_Bind(var=r, value=alloc_r))
+        return r
+
+    def _fork(self, *, bind: "dict[int, Var]") -> "_Lowerer":
+        """Create a sub-lowerer for a nested lexical scope (a GridRegion
+        body): shares the read-only dispatch context by reference
+        (``_dispatch_groups`` / ``_mangled_registry`` / ``_caller_fn`` /
+        ``_shape_param_names`` — mutations to ``_shape_param_names`` inside
+        the sub-lowerer must be visible to the enclosing function) and takes
+        a snapshot copy of the accumulated walk state (``_cache`` /
+        ``_tuple_parts`` / ``_carry_init`` / ``_name_counter``). ``bind``
+        seeds extra ``id(expr) -> Var`` cache entries (e.g. the loop
+        induction Var) beyond the inherited snapshot."""
+        sub = _Lowerer(
+            dispatch_groups=self._dispatch_groups,
+            mangled_registry=self._mangled_registry,
+            caller_fn=self._caller_fn,
+            shape_param_names=self._shape_param_names,
+        )
+        sub._name_counter = self._name_counter
+        sub._cache.update(self._cache)
+        sub._cache.update(bind)
+        sub._tuple_parts.update(self._tuple_parts)
+        sub._carry_init.update(self._carry_init)
+        return sub
+
+    def _close(self, sub: "_Lowerer") -> Sequential:
+        """Sync the name counter forward from a forked sub-lowerer and fold
+        its collected items into a nested ``LetStmt``/``Sequential`` chain."""
+        self._name_counter = sub._name_counter
+        return _fold_items_to_sequential(sub._items)
+
+    # ── public per-op lowering-handler ABI ──────────────────────────────
+    # docs/spec/passes.md "Per-op lowering dispatch": a ``@register_hir_lowering``
+    # handler is a module-level free function ``(ctx, target, expr)`` using only
+    # these five methods — it never reaches into ``_Lowerer`` privates.
+
+    def lower(self, expr: Expr) -> Var:
+        """Recursively lower a nested HIR sub-expression to its TIR Var."""
+        return self.lower_expr(expr)
+
+    def fresh(self, type_, hint: str = "v") -> Var:
+        """Allocate a fresh Var name (no binding emitted)."""
+        return self._fresh(type_, hint=hint)
+
+    def alloc(self, type_, hint: str = "r") -> Var:
+        """Fresh Var + ``AllocTensor`` Call + binding (see ``_alloc``)."""
+        return self._alloc(type_, hint=hint)
+
+    def emit(self, stmt: Stmt) -> None:
+        """Append a raw Stmt to the pending item sequence."""
+        self._items.append(stmt)
+
+    def emit_bind(self, var: Var, value: Expr) -> None:
+        """Append a let-binding ``var = value`` to the pending item sequence."""
+        self._items.append(_Bind(var=var, value=value))
+
     def lower_expr(self, expr: Expr) -> Var:
         key = id(expr)
         if key in self._cache:
@@ -317,9 +380,7 @@ class _Lowerer:
                     layout=const_type.layout,
                     storage=StorageKind.RMEM,
                 )
-            r = self._fresh(const_type, hint="c")
-            alloc_r = Call(type=r.type, target=AllocTensorOp(tensor_type=r.type), args=())
-            self._items.append(_Bind(var=r, value=alloc_r))
+            r = self._alloc(const_type, hint="c")
             self._items.append(_eval_call(Fill(), (r, expr)))
             self._cache[key] = r
             return r
@@ -343,24 +404,10 @@ class _Lowerer:
                 layout=grid_ty.layout,
                 storage=grid_ty.storage,
             )
-            out_var = self._fresh(out_type, hint="grid_out")
-            alloc_out = Call(
-                type=out_type,
-                target=AllocTensorOp(tensor_type=out_type),
-                args=(),
-            )
-            self._items.append(_Bind(var=out_var, value=alloc_out))
+            out_var = self._alloc(out_type, hint="grid_out")
 
-            # Create a sub-lowerer for the body
-            sub = _Lowerer()
-            sub._name_counter = self._name_counter
-            for k, v in self._cache.items():
-                sub._cache[k] = v
-            for k, v in self._tuple_parts.items():
-                sub._tuple_parts[k] = v
-            sub._carry_init.update(self._carry_init)
-            # Bind induction var in sub-lowerer; also bind the output alloc
-            sub._cache[id(iv)] = iv
+            # Create a sub-lowerer for the body, with the induction var bound.
+            sub = self._fork(bind={id(iv): iv})
 
             # Lower the body (per-row computation)
             body_result = sub.lower_expr(expr.body)
@@ -384,11 +431,10 @@ class _Lowerer:
             sub._items.append(_Bind(var=out_view_var, value=out_view_call))
             sub._items.append(_eval_call(Copy(), (body_result, out_view_var)))
 
-            self._name_counter = sub._name_counter
-            body_seq = _fold_items_to_sequential(sub._items)
+            body_seq = self._close(sub)
 
             # Wrap in For loop
-            i32_scalar = TensorType(shape=(), dtype=DType.i32, layout=None, storage=StorageKind.RMEM)
+            i32_scalar = TensorType.scalar(dtype=DType.i32)
             start_val = Constant(value=0, type=i32_scalar)
             stop_val = Constant(value=M, type=i32_scalar)
             step_val = Constant(value=1, type=i32_scalar)
@@ -410,7 +456,12 @@ class _Lowerer:
                 f"hir_to_tir: no lowering registered for Op "
                 f"{type(target).__name__}"
             )
-        return handler(self, target, expr)
+        # The handler ABI (docs/spec/passes.md "Per-op lowering dispatch")
+        # returns the Var for `expr`; caching it here (rather than in each
+        # handler) keeps `_cache` a `lower_expr`-owned concern.
+        result = handler(self, target, expr)
+        self._cache[key] = result
+        return result
 
     def _lower_grid_region_carry(self, expr: GridRegionExpr) -> Var:
         """Lower a loop-carried ``GridRegionExpr`` (accumulator loop).
@@ -446,28 +497,15 @@ class _Lowerer:
                 # resolves back to the same var.
                 acc_vars.append(init_var)
                 continue
-            acc_var = self._fresh(init_var.type, hint="acc")
-            alloc_acc = Call(
-                type=acc_var.type,
-                target=AllocTensorOp(tensor_type=acc_var.type),
-                args=(),
-            )
-            self._items.append(_Bind(var=acc_var, value=alloc_acc))
+            acc_var = self._alloc(init_var.type, hint="acc")
             self._items.append(_eval_call(Copy(), (init_var, acc_var)))
             acc_vars.append(acc_var)
 
         # Lower the body with every phi bound to its accumulator buffer.
-        sub = _Lowerer()
-        sub._name_counter = self._name_counter
-        for k, v in self._cache.items():
-            sub._cache[k] = v
-        for k, v in self._tuple_parts.items():
-            sub._tuple_parts[k] = v
-        sub._cache[id(iv)] = iv
+        sub = self._fork(bind={id(iv): iv})
         # Carry-init continuity across the sub-lowerer boundary: a chain rooted
         # in a carried var inside the body must trace to the SAME gmem alias
         # root as the carry's init (used by the reshard-owned sync).
-        sub._carry_init.update(self._carry_init)
         for phi, init_arg in zip(expr.carried_args, expr.init_args):
             self._carry_init[id(phi)] = init_arg
             sub._carry_init[id(phi)] = init_arg
@@ -481,12 +519,9 @@ class _Lowerer:
             if yield_var is not acc_var:
                 sub._items.append(_eval_call(Copy(), (yield_var, acc_var)))
 
-        self._name_counter = sub._name_counter
-        body_seq = _fold_items_to_sequential(sub._items)
+        body_seq = self._close(sub)
 
-        i32_scalar = TensorType(
-            shape=(), dtype=DType.i32, layout=None, storage=StorageKind.RMEM
-        )
+        i32_scalar = TensorType.scalar(dtype=DType.i32)
         for_loop = For(
             induction_var=iv,
             start=Constant(value=start, type=i32_scalar),
@@ -539,457 +574,6 @@ class _Lowerer:
                 return root
         return None
 
-    @register_hir_lowering(Reshard)
-    def _lower_reshard(self, target, expr) -> Var:
-        key = id(expr)
-        src_override = self._reshard_cross_cta_sync(expr)
-        src = (
-            src_override
-            if src_override is not None
-            else self.lower_expr(expr.args[0])
-        )
-        src_ty = src.type
-        # docs/spec/hir.md §3: the dest view layout is the
-        # post-typeinfer materialized form on ``expr.type``. The
-        # source-side ``TensorView`` reads ``src`` using whichever
-        # stride form already materialized for ``src``:
-        # - ``src.type.layout`` is a ShardLayout → reuse it
-        #   verbatim (the upstream Reshard materialized it);
-        # - ``src.type.layout`` is ``None`` (plain kernel-param
-        #   surface) → fall back to shared-engine C-order over
-        #   the dest layout's canonical shape, matching the
-        #   "plain inputs are kernel-boundary shared engines"
-        #   rule in spec hir §3 / function-signature binding.
-        sl = expr.type.layout
-        dst_shape = expr.type.shape
-        view_src = src
-        if isinstance(src_ty.layout, ShardLayout):
-            src_sl = src_ty.layout
-            # Intermediate sharded source: a ShardTensor is bound for
-            # ``src``. A ``TensorView``'s memory must be a pointer (cute
-            # ``make_tensor`` needs an iterator, not a ShardTensor), so
-            # take ``PtrOf(src)`` first — same shape as the Reshape
-            # lowering below.
-            ptr_call = Call(type=src_ty, target=PtrOf(), args=(src,))
-            view_src = self._fresh(src_ty, hint="ptr")
-            self._items.append(_Bind(var=view_src, value=ptr_call))
-        elif isinstance(sl, ShardLayout):
-            # A full (bijective) fragment layout encodes its own
-            # global gather permutation in the strides (e.g. mma A/B
-            # fragments whose lane → (m, k) mapping is non-C-order);
-            # read the source through those strides. A collapsed /
-            # per-instance layout has lost the global embedding, so
-            # fall back to the C-order shared engine.
-            if _is_full_layout(sl.layout):
-                src_strides = tuple(int(s) for s in sl.layout.strides)
-            else:
-                src_strides = _shared_engine_strides(sl)
-            src_sl = ShardLayout(
-                layout=_Layout(
-                    shape=sl.layout.shape,
-                    strides=src_strides,
-                ),
-                attrs=sl.attrs,
-                mesh=sl.mesh,
-            )
-        else:
-            src_sl = sl
-
-        # TensorView(memory, shard_layout) — shard view of src
-        tv = TensorView(layout=src_sl)
-        tv_type = TensorType(
-            shape=dst_shape,
-            dtype=src_ty.dtype,
-            layout=src_sl,
-            storage=src_ty.storage,
-        )
-        tv_call = Call(type=tv_type, target=tv, args=(view_src,))
-        sv = self._fresh(tv_type, hint="sv")
-        self._items.append(_Bind(var=sv, value=tv_call))
-
-        if target.storage is None:
-            # without storage — pure shard view, no alloc / copy
-            self._cache[key] = sv
-            return sv
-
-        # with storage — allocate plain dst, copy from shard view
-        # Compute per-shard physical shape: global multi-D / mesh extents at S<> axes
-        per_shard_shape = list(sl.layout.shape)
-        mesh_shape = sl.mesh.layout.shape
-        attr_idx = 0
-        for a in sl.attrs:
-            if isinstance(a, Split) and attr_idx < len(mesh_shape):
-                mext = mesh_shape[attr_idx]
-                if mext is None:
-                    # Launch-provided (dynamic) CTA extent: this axis is the
-                    # dynamic outer tile count; each CTA owns exactly one
-                    # slice, so its per-shard extent is a static 1. The
-                    # fixed inner tile lives on the non-split axes.
-                    per_shard_shape[a.axis] = 1
-                else:
-                    # Post-reshard typeinfer may have rewritten the
-                    # ShardLayout to reg-view local form already (Split
-                    # positions size 1). Use ``max(1, ...)`` so the
-                    # resulting per-shard extent is at least 1 instead
-                    # of collapsing to 0 via integer division.
-                    per_shard_shape[a.axis] = max(
-                        1, per_shard_shape[a.axis] // mext
-                    )
-            attr_idx += 1
-        per_shard_shape = tuple(per_shard_shape)
-        # ``ShardLayout.layout`` carries the global / unsharded
-        # layout shape with storage-physical strides. The TIR
-        # ``var.type.shape`` remains per-shard local — that's how
-        # downstream alloc / arith size their iteration.
-        dst_type = TensorType(
-            shape=per_shard_shape,
-            dtype=src_ty.dtype,
-            layout=sl,
-            storage=target.storage,
-        )
-        dst = self._fresh(dst_type, hint="t")
-        alloc = Call(
-            type=dst_type,
-            target=AllocTensorOp(tensor_type=dst_type),
-            args=(),
-        )
-        self._items.append(_Bind(var=dst, value=alloc))
-        self._items.append(_eval_call(Copy(), (sv, dst)))
-        self._cache[key] = dst
-        return dst
-
-    # ── HIR per-shape Mma SSA value op → TIR Mma effect Stmt ──
-    # HIR ``Mma_SM80_*`` / ``Wgmma_SM90_*`` are SSA value ops returning
-    # a fragment tensor. Lower into ``Evaluate(tir.cuda.nn.Mma,
-    # (a, b, result))`` plus an upfront ``AllocTensor`` for the
-    # accumulator (matches ``HirReLU`` / ``HirMul`` lowering shape).
-    @register_hir_lowering(HirMmaSM80_16x8x16)
-    @register_hir_lowering(HirWgmma_SM90)
-    def _lower_mma(self, target, expr) -> Var:
-        key = id(expr)
-        a = self.lower_expr(expr.args[0])
-        b = self.lower_expr(expr.args[1])
-        # Per-thread C fragment shape: for SM80 16x8x16 each lane
-        # owns 4 f32 (the SM80_16x8_Row CLayout value layout (2, 2)
-        # at row-major strides (1, 64)). The per-shard buffer
-        # therefore stays at 4 elements in cute terms — match by
-        # allocating ``shape = (2, 2)`` so the fragment has the
-        # same multi-axis layout as the A/B operands after their
-        # own per-shard sizing.
-        if isinstance(target, HirMmaSM80_16x8x16):
-            out_shape = (2, 2)
-        else:
-            out_shape = expr.type.shape
-        out_type = TensorType(
-            shape=out_shape,
-            dtype=target.dtype_acc,
-            layout=None,
-            storage=a.type.storage,
-        )
-        r = self._fresh(out_type, hint="r")
-        alloc_r = Call(
-            type=r.type,
-            target=AllocTensorOp(tensor_type=r.type),
-            args=(),
-        )
-        self._items.append(_Bind(var=r, value=alloc_r))
-        # SSA mma is value-form: ``c = a @ b``. Zero-init the
-        # accumulator buffer so the underlying ``a*b + c`` PTX mma
-        # produces ``a @ b`` exactly. Outer-level accumulation
-        # patterns like ``add(acc, mma(a, b))`` are emitted as a
-        # separate Binary stmt later in the pipeline.
-        zero_const = Constant(
-            value=0.0, type=TensorType.meta_scalar(target.dtype_acc),
-        )
-        self._items.append(_eval_call(Fill(), (r, zero_const)))
-        # TirMma operand order is (acc, lhs, rhs); the lowered path leaves
-        # ``atom`` implicit (None) — the SM80 codegen handler is unchanged.
-        self._items.append(_eval_call(TirMma(), (r, a, b)))
-        self._cache[key] = r
-        return r
-
-    @register_hir_lowering(HirReLU)
-    def _lower_relu(self, target, expr) -> Var:
-        key = id(expr)
-        x = self.lower_expr(expr.args[0])
-        r = self._fresh(x.type, hint="r")
-        # stmt-form pointwise: allocate output, then run ReLU as an
-        # effect stmt that reads x and writes r.
-        alloc_r = Call(
-            type=r.type,
-            target=AllocTensorOp(tensor_type=r.type),
-            args=(),
-        )
-        self._items.append(_Bind(var=r, value=alloc_r))
-        self._items.append(_eval_call(TirReLU(), (x, r)))
-        self._cache[key] = r
-        return r
-
-    # ── pointwise binary / unary (kinded tag dispatch) ──
-    @register_hir_lowering(HirBinary)
-    def _lower_binary(self, target, expr) -> Var:
-        key = id(expr)
-        lhs = self.lower_expr(expr.args[0])
-        rhs = self.lower_expr(expr.args[1])
-        # Build the result type from the **lowered TIR** shapes
-        # (which may already be the
-        # per-shard form after a reg-storage reshard), not the
-        # HIR-side ``expr.type`` (logical). Otherwise the TIR
-        # verifier sees Binary(src=(1,1,1,8), dst=(1,1536)).
-        out_shape = lhs.type.shape if len(lhs.type.shape) >= len(rhs.type.shape) else rhs.type.shape
-        # Destination storage follows the HIR-resolved output residency
-        # (order-independent), not the lowered operands — a materialized
-        # constant operand must not pull the result into its register
-        # buffer. An unmaterialized output is materialized at this boundary.
-        out_storage = (
-            expr.type.storage
-            if expr.type.storage is not StorageKind.UMAT
-            else StorageKind.RMEM
-        )
-        out_type = TensorType(
-            shape=out_shape,
-            dtype=expr.type.dtype,
-            layout=lhs.type.layout if lhs.type.layout is not None else rhs.type.layout,
-            storage=out_storage,
-        )
-        r = self._fresh(out_type, hint="r")
-        alloc_r = Call(type=r.type, target=AllocTensorOp(tensor_type=r.type), args=())
-        self._items.append(_Bind(var=r, value=alloc_r))
-        self._items.append(_eval_call(TirBinary(kind=target.kind), (lhs, rhs, r)))
-        self._cache[key] = r
-        return r
-
-    @register_hir_lowering(HirUnary)
-    def _lower_unary(self, target, expr) -> Var:
-        key = id(expr)
-        x = self.lower_expr(expr.args[0])
-        # See HirBinary above — TIR result mirrors the lowered
-        # input shape, not the HIR logical shape.
-        out_type = TensorType(
-            shape=x.type.shape,
-            dtype=expr.type.dtype,
-            layout=x.type.layout,
-            storage=x.type.storage,
-        )
-        r = self._fresh(out_type, hint="r")
-        alloc_r = Call(type=r.type, target=AllocTensorOp(tensor_type=r.type), args=())
-        self._items.append(_Bind(var=r, value=alloc_r))
-        self._items.append(_eval_call(TirUnary(kind=target.kind), (x, r)))
-        self._cache[key] = r
-        return r
-
-    @register_hir_lowering(HirReshape)
-    def _lower_reshape(self, target, expr) -> Var:
-        key = id(expr)
-        # Reshape: PtrOf(src) + TensorView with same layout,
-        # new logical shape.  PtrOf gives a device pointer to
-        # the per-thread buffer (no offset for reshape).
-        x = self.lower_expr(expr.args[0])
-        # Step 1: PtrOf(x) — take the pointer
-        ptr_op = PtrOf()
-        ptr_ty = x.type  # PtrOf typeinfer returns same type
-        ptr_call = Call(type=ptr_ty, target=ptr_op, args=(x,))
-        ptr_var = self._fresh(ptr_ty, hint="ptr")
-        self._items.append(_Bind(var=ptr_var, value=ptr_call))
-        # Step 2: TensorView over the ptr, with new shape
-        out_ty = TensorType(
-            shape=target.new_shape,
-            dtype=x.type.dtype,
-            layout=x.type.layout,
-            storage=x.type.storage,
-        )
-        tv = TensorView(layout=out_ty.layout, shape=target.new_shape)
-        tv_call = Call(type=out_ty, target=tv, args=(ptr_var,))
-        r = self._fresh(out_ty, hint="r")
-        self._items.append(_Bind(var=r, value=tv_call))
-        self._cache[key] = r
-        return r
-
-    @register_hir_lowering(HirClamp)
-    def _lower_clamp(self, target, expr) -> Var:
-        key = id(expr)
-        x = self.lower_expr(expr.args[0])
-        r = self._fresh(x.type, hint="r")
-        alloc_r = Call(type=r.type, target=AllocTensorOp(tensor_type=r.type), args=())
-        self._items.append(_Bind(var=r, value=alloc_r))
-        self._items.append(_eval_call(
-            TirClamp(min_val=target.min_val, max_val=target.max_val), (x, r)))
-        self._cache[key] = r
-        return r
-
-    @register_hir_lowering(HirCast)
-    def _lower_cast(self, target, expr) -> Var:
-        key = id(expr)
-        x = self.lower_expr(expr.args[0])
-        out_type = TensorType(
-            shape=x.type.shape,
-            dtype=target.dtype,
-            layout=x.type.layout,
-            storage=x.type.storage,
-        )
-        r = self._fresh(out_type, hint="r")
-        alloc_r = Call(type=r.type, target=AllocTensorOp(tensor_type=r.type), args=())
-        self._items.append(_Bind(var=r, value=alloc_r))
-        self._items.append(_eval_call(TirUnary(kind=UnaryKind.CAST), (x, r)))
-        self._cache[key] = r
-        return r
-
-    @register_hir_lowering(HirTupleGetItem)
-    def _lower_tuple_get_item(self, target, expr) -> Var:
-        key = id(expr)
-        # Structural select over a tuple-typed producer (a multi-carry
-        # GridRegion): lowering the producer materialises its per-field Vars in
-        # ``_tuple_parts``; this just picks one.
-        src = expr.args[0]
-        self.lower_expr(src)
-        parts = self._tuple_parts.get(id(src))
-        if parts is None:
-            raise TypeError(
-                "hir_to_tir: TupleGetItem on a producer with no lowered tuple "
-                f"fields ({type(src).__name__})"
-            )
-        r = parts[target.index]
-        self._cache[key] = r
-        return r
-
-    @register_hir_lowering(HirFullLike)
-    def _lower_full_like(self, target, expr) -> Var:
-        key = id(expr)
-        # Pure type-driven alloc + fill: the input expr only donates its type
-        # (shape / dtype / layout / storage). Its LOWERED form is mirrored so
-        # that inside a mesh scope the accumulator carries the per-shard local
-        # shape (not the HIR-global one) — a global-shaped accumulator would
-        # poison downstream broadcast-shape decisions.
-        ty = expr.type
-        storage = (
-            ty.storage if ty.storage is not StorageKind.UMAT else StorageKind.RMEM
-        )
-        try:
-            tmpl = self.lower_expr(expr.args[0])
-        except Exception:
-            tmpl = self._cache.get(id(expr.args[0]))
-        if tmpl is not None:
-            out_type = TensorType(
-                shape=tuple(tmpl.type.shape),
-                dtype=ty.dtype,
-                layout=tmpl.type.layout,
-                storage=(
-                    tmpl.type.storage
-                    if tmpl.type.storage is not StorageKind.UMAT
-                    else storage
-                ),
-            )
-        else:
-            # TIR var shapes are per-shard local (see the Reshard lowering); a
-            # sharded type sizes its buffer / fill count from the layout.
-            local_shape = (
-                shard_layout_local_shape(ty.layout)
-                if isinstance(ty.layout, ShardLayout)
-                else tuple(ty.shape)
-            )
-            out_type = TensorType(
-                shape=tuple(local_shape),
-                dtype=ty.dtype,
-                layout=ty.layout,
-                storage=storage,
-            )
-        r = self._fresh(out_type, hint="c")
-        alloc_r = Call(
-            type=r.type, target=AllocTensorOp(tensor_type=r.type), args=()
-        )
-        self._items.append(_Bind(var=r, value=alloc_r))
-        fill_value = Constant(
-            value=target.value,
-            type=TensorType(
-                shape=(), dtype=ty.dtype, layout=None, storage=StorageKind.RMEM
-            ),
-        )
-        self._items.append(_eval_call(Fill(), (r, fill_value)))
-        self._cache[key] = r
-        return r
-
-    @register_hir_lowering(HirCacheUpdate)
-    def _lower_cache_update(self, target, expr) -> Var:
-        key = id(expr)
-        cache = self.lower_expr(expr.args[0])
-        self.lower_expr(expr.args[1])  # ``cur`` position (runtime row index)
-        cur = self.lower_expr(expr.args[1])
-        # expr.args[2] (``s``) is not consulted: v0 supports the decode-step
-        # shape S_CAP == 1 (exactly one row), where s must be 1.
-        new = self.lower_expr(expr.args[3])
-        cache_shape = tuple(cache.type.shape)
-        new_shape = tuple(expr.args[3].type.shape)
-        if new_shape[1] != 1 or cache_shape[0] != 1:
-            raise NotImplementedError(
-                "cache_update lowering: v0 supports B == 1 and S_CAP == 1 "
-                f"(single-row decode write); got cache {cache_shape}, "
-                f"new {new_shape}"
-            )
-        # Row-slice view of the cache at runtime ``cur`` along axis 1; keep rank
-        # 4 (axis-1 extent 1) so the Copy shape check matches ``new``.
-        view_shape = (new_shape[0], 1, *cache_shape[2:])
-        cstr = c_order_strides(tuple(int(d) for d in cache_shape))
-        view_layout = _Layout(shape=view_shape, strides=cstr)
-        tv_type = TensorType(
-            shape=view_shape,
-            dtype=cache.type.dtype,
-            layout=view_layout,
-            storage=cache.type.storage,
-        )
-        tv_call = Call(type=tv_type, target=TensorView(layout=view_layout), args=(cache, cur))
-        sv = self._fresh(tv_type, hint="sv")
-        self._items.append(_Bind(var=sv, value=tv_call))
-        # In-place per the op contract (anchored on the cache buffer): write the
-        # new row into the cache and return the cache var itself.
-        self._items.append(_eval_call(Copy(), (new, sv)))
-        self._cache[key] = cache
-        return cache
-
-    @register_hir_lowering(HirInsertSlice)
-    def _lower_insert_slice(self, target, expr) -> Var:
-        key = id(expr)
-        dst = self.lower_expr(expr.args[0])
-        upd = self.lower_expr(expr.args[1])
-        # Per-axis window: an offset tuple (rank N) or a single scalar (1-D).
-        # Each window is a tile of the update's own extent starting at the
-        # offset, so each offset is that axis's tile coord. Write ``update`` into
-        # the window IN PLACE and return ``dst`` — a loop-carried
-        # ``ov = insert_slice(ov, …)`` therefore reuses the single carried buffer
-        # with no replacement allocation, and the yield aliases the carry buffer.
-        off_expr = expr.args[2]
-        upd_shape = tuple(upd.type.shape)
-        if isinstance(off_expr, Tuple):
-            coords = tuple(self._insert_slice_coord(el) for el in off_expr.elements)
-        else:
-            coords = (self._insert_slice_coord(off_expr),)
-        # The window carries the update's layout: for a sharded update this is a
-        # ShardLayout, so the Copy verifier sees matching ShardLayouts and the
-        # emitter derives the per-shard tile size.
-        if isinstance(upd.type.layout, ShardLayout):
-            win_layout = upd.type.layout
-        elif isinstance(off_expr, Tuple):
-            win_layout = TensorView.layout_for_slice_nd(
-                src_shape=tuple(dst.type.shape), sliced_shape=upd_shape
-            )
-        else:
-            win_layout = TensorView.layout_for_slice(
-                src_shape=tuple(dst.type.shape), axis=0, sliced_shape=upd_shape
-            )
-        win_type = TensorType(
-            shape=upd_shape,
-            dtype=dst.type.dtype,
-            layout=win_layout,
-            storage=dst.type.storage,
-        )
-        win_call = Call(
-            type=win_type, target=TensorView(layout=win_layout), args=(dst, *coords)
-        )
-        win = self._fresh(win_type, hint="isv")
-        self._items.append(_Bind(var=win, value=win_call))
-        self._items.append(_eval_call(Copy(), (upd, win)))
-        self._cache[key] = dst
-        return dst
-
     def _param_alias_root(self, expr, _depth: int = 0):
         """Walk Reshard / loop-carry chains to the underlying kernel-param Var
         (the gmem alias root), or ``None``. Used by the cross-CTA
@@ -1012,139 +596,6 @@ class _Lowerer:
             return self._param_alias_root(expr.args[0], _depth + 1)
         return None
 
-    def _insert_slice_coord(self, off_expr):
-        """The scalar window index for an in-place ``insert_slice``: the window
-        is one tile of the update's own extent starting at the offset, so the
-        offset is the tile index (matching the ``local_tile`` coord). A
-        compile-time offset folds to a ``Constant`` scalar (emitted as a
-        literal coordinate); a runtime scalar offset lowers to its scalar Var
-        (its single element is read at the coordinate site)."""
-        i32 = TensorType(
-            shape=(), dtype=DType.i32, layout=None, storage=StorageKind.RMEM
-        )
-        if isinstance(off_expr, Constant):
-            val = off_expr.value
-            elem = int(val[0]) if isinstance(val, (list, tuple)) else int(val)
-            return Constant(value=elem, type=i32)
-        # A runtime offset lowers to its scalar Var (a native scalar index, e.g.
-        # the loop induction variable).
-        return self.lower_expr(off_expr)
-
-    # ── reduce (generic tag dispatch) ──
-    @register_hir_lowering(HirGather)
-    def _lower_gather(self, target, expr) -> Var:
-        key = id(expr)
-        if target.batch_dims != 0:
-            # The batched contract is evaluator/typeinfer-only for now; refuse to
-            # fall through to the single-coordinate slice-view lowering below.
-            raise NotImplementedError(
-                "Gather: batched gather lowering (batch_dims>0) is not yet supported"
-            )
-        x = self.lower_expr(expr.args[0])
-        idx = self.lower_expr(expr.args[1])
-        # Compute view layout from sliced shape
-        view_shape = expr.type.shape
-        view_layout = TensorView.layout_for_slice(
-            src_shape=tuple(x.type.shape),
-            axis=target.axis,
-            sliced_shape=view_shape,
-        )
-        tv = TensorView(layout=view_layout)
-        tv_type = TensorType(
-            shape=view_shape,
-            dtype=expr.type.dtype,
-            layout=view_layout,
-            storage=x.type.storage,
-        )
-        tv_call = Call(type=tv_type, target=tv, args=(x, idx))
-        sv = self._fresh(tv_type, hint="sv")
-        self._items.append(_Bind(var=sv, value=tv_call))
-        self._cache[key] = sv
-        return sv
-
-    @register_hir_lowering(HirReduce)
-    def _lower_reduce(self, target, expr) -> Var:
-        key = id(expr)
-        x = self.lower_expr(expr.args[0])
-        axes = target.axes
-        # The HIR Reduce typeinfer already computed the reduced
-        # ``ShardLayout`` (layout dims on reduced axes collapsed to
-        # size 1 / stride 0; corresponding Split attrs rewritten to
-        # Broadcast).  Reuse that layout instead of copying the
-        # input layout — otherwise the TIR output type carries an
-        # un-reduced layout shape and downstream codegen iterates
-        # the wrong per-thread count.
-        keepdim = target.keepdim
-        new_shape = list(x.type.shape)
-        for a in sorted(axes, reverse=True):
-            if keepdim:
-                new_shape[a] = 1
-            else:
-                new_shape.pop(a)
-        out_type = TensorType(
-            shape=tuple(new_shape),
-            dtype=x.type.dtype,
-            layout=getattr(expr.type, "layout", x.type.layout),
-            storage=x.type.storage,
-        )
-        r = self._fresh(out_type, hint="r")
-        alloc_r = Call(type=r.type, target=AllocTensorOp(tensor_type=r.type), args=())
-        self._items.append(_Bind(var=r, value=alloc_r))
-
-        # Analyse the input ShardLayout for cross-warp staging.
-        # A reduce axis covered by a Split
-        # on a non-``thread`` topology (i.e. ``warp`` / ``cta`` /
-        # ``cluster`` / ...) cannot be folded by ``__shfl_xor_sync``
-        # alone; the runtime needs a small staging buffer the
-        # warps cooperatively write into and read back. The buffer
-        # size is the product of the cross-warp mesh axis extents.
-        tir_args: tuple = (x, r)
-        # The cross-warp analysis must run on the *HIR* input
-        # type — its ``shape`` matches
-        # the user-facing axes the HIR Reduce was authored against
-        # (logical ``(1, 1536)``). After lowering, ``x.type.shape``
-        # may be the per-shard local form ``(1, 1, 1, 8)``; using
-        # that would silently mis-map ``axes=(-1,)`` to a non-Split
-        # layout position and skip the workspace alloc.
-        ws_size, ws_dtype, lane_reduced = _analyze_cross_warp_workspace(
-            expr.args[0].type, axes
-        )
-        if ws_size > 0:
-            # The runtime stages one warp-partial PER OUTPUT CELL: scale the
-            # workspace by the output's per-thread cell count (1 for scalar
-            # reduces — the historical size).
-            n_cells = 1
-            for dim in r.type.shape:
-                if isinstance(dim, int):
-                    n_cells *= dim
-            ws_size *= max(1, n_cells)
-            if not lane_reduced:
-                # cross-warp-only: per (warp, lane, cell) staging slots.
-                ws_size *= 32
-            ws_type = TensorType(
-                shape=(ws_size,),
-                dtype=ws_dtype,
-                layout=None,
-                storage=StorageKind.SMEM,
-            )
-            ws = self._fresh(ws_type, hint="ws")
-            alloc_ws = Call(
-                type=ws.type,
-                target=AllocTensorOp(tensor_type=ws.type),
-                args=(),
-            )
-            self._items.append(_Bind(var=ws, value=alloc_ws))
-            tir_args = (x, r, ws)
-
-        reduce_op = TirReduce(axes=axes, kind=target.kind)
-        self._items.append(_eval_call(reduce_op, tir_args))
-        self._cache[key] = r
-        return r
-
-    @register_hir_lowering(HirFunction)
-    def _lower_hir_function(self, target, expr) -> Var:
-        return self._lower_hir_call(expr, target)
-
     # ── sub-call dispatch ────────────────────────────────────────────────
     def _lower_hir_call(self, call: Call, callee_hir: HirFunction) -> Var:
         """Lower ``Call(target=HirFunction)`` into a ``tir.DispatchCall``.
@@ -1165,13 +616,7 @@ class _Lowerer:
         arg_vars: list[Var] = [self.lower_expr(a) for a in call.args]
         # Allocate output buffer matching call.type.
         out_type = call.type
-        out_var = self._fresh(out_type, hint="cr")
-        alloc_out = Call(
-            type=out_type,
-            target=AllocTensorOp(tensor_type=out_type),
-            args=(),
-        )
-        self._items.append(_Bind(var=out_var, value=alloc_out))
+        out_var = self._alloc(out_type, hint="cr")
         # Resolve the dispatch DimVar from the callee group (per the
         # canonical first-occurrence rule). All variants in a v0 group
         # share the same dispatch DimVar by construction (the validator
@@ -1269,12 +714,25 @@ class _Lowerer:
             head_count = len(variant.params) + mangled_pf.output_count
             trailing = mangled_pf.params[head_count:]
             for tp in trailing:
-                base_name, axis_int = _parse_shape_param_name(
-                    tp.name, callee_hir.name, mangled_pf.name,
+                parsed = parse_shape_var_name(tp.name)
+                if parsed is None:
+                    raise RuntimeError(
+                        f"HIR Call to {callee_hir.name!r}: mangled callee "
+                        f"{mangled_pf.name!r} has trailing param {tp.name!r} "
+                        f"that is not a <base>_shape_<axis> shape scalar"
+                    )
+                base_name, axis_int = parsed
+                user_idx = next(
+                    (i for i, p in enumerate(variant.params) if p.name == base_name),
+                    None,
                 )
-                user_idx = _find_user_param_index(
-                    variant.params, base_name, callee_hir.name, mangled_pf.name,
-                )
+                if user_idx is None:
+                    raise RuntimeError(
+                        f"HIR Call to {callee_hir.name!r}: mangled callee "
+                        f"{mangled_pf.name!r} trailing scalar references user "
+                        f"param {base_name!r} that is not in the callee "
+                        f"user-param list"
+                    )
                 caller_arg_var = arg_vars[user_idx]
                 if (
                     self._caller_fn is None
@@ -1326,6 +784,536 @@ class _Lowerer:
         )
 
 
+# ── per-op lowering handlers ─────────────────────────────────────────────
+# docs/spec/passes.md "Per-op lowering dispatch": each ``@register_hir_lowering``
+# handler is a module-level free function ``(ctx, target, expr)`` — ``ctx`` is
+# the ``_Lowerer`` and the handler uses only its public ABI (``ctx.lower`` /
+# ``ctx.fresh`` / ``ctx.alloc`` / ``ctx.emit`` / ``ctx.emit_bind``).
+
+@register_hir_lowering(Reshard)
+def _lower_reshard(ctx: "_Lowerer", target, expr) -> Var:
+    src_override = ctx._reshard_cross_cta_sync(expr)
+    src = src_override if src_override is not None else ctx.lower(expr.args[0])
+    src_ty = src.type
+    # docs/spec/hir.md §3: the dest view layout is the
+    # post-typeinfer materialized form on ``expr.type``. The
+    # source-side ``TensorView`` reads ``src`` using whichever
+    # stride form already materialized for ``src``:
+    # - ``src.type.layout`` is a ShardLayout → reuse it
+    #   verbatim (the upstream Reshard materialized it);
+    # - ``src.type.layout`` is ``None`` (plain kernel-param
+    #   surface) → fall back to shared-engine C-order over
+    #   the dest layout's canonical shape, matching the
+    #   "plain inputs are kernel-boundary shared engines"
+    #   rule in spec hir §3 / function-signature binding.
+    sl = expr.type.layout
+    dst_shape = expr.type.shape
+    view_src = src
+    if isinstance(src_ty.layout, ShardLayout):
+        src_sl = src_ty.layout
+        # Intermediate sharded source: a ShardTensor is bound for
+        # ``src``. A ``TensorView``'s memory must be a pointer (cute
+        # ``make_tensor`` needs an iterator, not a ShardTensor), so
+        # take ``PtrOf(src)`` first — same shape as the Reshape
+        # lowering below.
+        ptr_call = Call(type=src_ty, target=PtrOf(), args=(src,))
+        view_src = ctx.fresh(src_ty, hint="ptr")
+        ctx.emit_bind(view_src, ptr_call)
+    elif isinstance(sl, ShardLayout):
+        # A full (bijective) fragment layout encodes its own
+        # global gather permutation in the strides (e.g. mma A/B
+        # fragments whose lane → (m, k) mapping is non-C-order);
+        # read the source through those strides. A collapsed /
+        # per-instance layout has lost the global embedding, so
+        # fall back to the C-order shared engine.
+        if _is_full_layout(sl.layout):
+            src_strides = tuple(int(s) for s in sl.layout.strides)
+        else:
+            src_strides = _shared_engine_strides(sl)
+        src_sl = ShardLayout(
+            layout=_Layout(
+                shape=sl.layout.shape,
+                strides=src_strides,
+            ),
+            attrs=sl.attrs,
+            mesh=sl.mesh,
+        )
+    else:
+        src_sl = sl
+
+    # TensorView(memory, shard_layout) — shard view of src
+    tv = TensorView(layout=src_sl)
+    tv_type = TensorType(
+        shape=dst_shape,
+        dtype=src_ty.dtype,
+        layout=src_sl,
+        storage=src_ty.storage,
+    )
+    tv_call = Call(type=tv_type, target=tv, args=(view_src,))
+    sv = ctx.fresh(tv_type, hint="sv")
+    ctx.emit_bind(sv, tv_call)
+
+    if target.storage is None:
+        # without storage — pure shard view, no alloc / copy
+        return sv
+
+    # with storage — allocate plain dst, copy from shard view
+    # Compute per-shard physical shape: global multi-D / mesh extents at S<> axes
+    per_shard_shape = list(sl.layout.shape)
+    mesh_shape = sl.mesh.layout.shape
+    attr_idx = 0
+    for a in sl.attrs:
+        if isinstance(a, Split) and attr_idx < len(mesh_shape):
+            mext = mesh_shape[attr_idx]
+            if mext is None:
+                # Launch-provided (dynamic) CTA extent: this axis is the
+                # dynamic outer tile count; each CTA owns exactly one
+                # slice, so its per-shard extent is a static 1. The
+                # fixed inner tile lives on the non-split axes.
+                per_shard_shape[a.axis] = 1
+            else:
+                # Post-reshard typeinfer may have rewritten the
+                # ShardLayout to reg-view local form already (Split
+                # positions size 1). Use ``max(1, ...)`` so the
+                # resulting per-shard extent is at least 1 instead
+                # of collapsing to 0 via integer division.
+                per_shard_shape[a.axis] = max(
+                    1, per_shard_shape[a.axis] // mext
+                )
+        attr_idx += 1
+    per_shard_shape = tuple(per_shard_shape)
+    # ``ShardLayout.layout`` carries the global / unsharded
+    # layout shape with storage-physical strides. The TIR
+    # ``var.type.shape`` remains per-shard local — that's how
+    # downstream alloc / arith size their iteration.
+    dst_type = TensorType(
+        shape=per_shard_shape,
+        dtype=src_ty.dtype,
+        layout=sl,
+        storage=target.storage,
+    )
+    dst = ctx.alloc(dst_type, hint="t")
+    ctx.emit(_eval_call(Copy(), (sv, dst)))
+    return dst
+
+
+# HIR ``Mma_SM80_*`` / ``Wgmma_SM90_*`` are SSA value ops returning a fragment
+# tensor. Lower into ``Evaluate(tir.cuda.nn.Mma, (a, b, result))`` plus an
+# upfront ``AllocTensor`` for the accumulator (matches ``HirReLU`` / ``HirMul``
+# lowering shape).
+@register_hir_lowering(HirMmaSM80_16x8x16)
+@register_hir_lowering(HirWgmma_SM90)
+def _lower_mma(ctx: "_Lowerer", target, expr) -> Var:
+    a = ctx.lower(expr.args[0])
+    b = ctx.lower(expr.args[1])
+    # Per-thread C fragment shape: for SM80 16x8x16 each lane
+    # owns 4 f32 (the SM80_16x8_Row CLayout value layout (2, 2)
+    # at row-major strides (1, 64)). The per-shard buffer
+    # therefore stays at 4 elements in cute terms — match by
+    # allocating ``shape = (2, 2)`` so the fragment has the
+    # same multi-axis layout as the A/B operands after their
+    # own per-shard sizing.
+    if isinstance(target, HirMmaSM80_16x8x16):
+        out_shape = (2, 2)
+    else:
+        out_shape = expr.type.shape
+    out_type = TensorType(
+        shape=out_shape,
+        dtype=target.dtype_acc,
+        layout=None,
+        storage=a.type.storage,
+    )
+    r = ctx.alloc(out_type, hint="r")
+    # SSA mma is value-form: ``c = a @ b``. Zero-init the
+    # accumulator buffer so the underlying ``a*b + c`` PTX mma
+    # produces ``a @ b`` exactly. Outer-level accumulation
+    # patterns like ``add(acc, mma(a, b))`` are emitted as a
+    # separate Binary stmt later in the pipeline.
+    zero_const = Constant(
+        value=0.0, type=TensorType.meta_scalar(target.dtype_acc),
+    )
+    ctx.emit(_eval_call(Fill(), (r, zero_const)))
+    # TirMma operand order is (acc, lhs, rhs); the lowered path leaves
+    # ``atom`` implicit (None) — the SM80 codegen handler is unchanged.
+    ctx.emit(_eval_call(TirMma(), (r, a, b)))
+    return r
+
+
+@register_hir_lowering(HirReLU)
+def _lower_relu(ctx: "_Lowerer", target, expr) -> Var:
+    x = ctx.lower(expr.args[0])
+    # stmt-form pointwise: allocate output, then run ReLU as an
+    # effect stmt that reads x and writes r.
+    r = ctx.alloc(x.type, hint="r")
+    ctx.emit(_eval_call(TirReLU(), (x, r)))
+    return r
+
+
+# ── pointwise binary / unary (kinded tag dispatch) ──
+@register_hir_lowering(HirBinary)
+def _lower_binary(ctx: "_Lowerer", target, expr) -> Var:
+    lhs = ctx.lower(expr.args[0])
+    rhs = ctx.lower(expr.args[1])
+    # Build the result type from the **lowered TIR** shapes
+    # (which may already be the
+    # per-shard form after a reg-storage reshard), not the
+    # HIR-side ``expr.type`` (logical). Otherwise the TIR
+    # verifier sees Binary(src=(1,1,1,8), dst=(1,1536)).
+    out_shape = lhs.type.shape if len(lhs.type.shape) >= len(rhs.type.shape) else rhs.type.shape
+    # Destination storage follows the HIR-resolved output residency
+    # (order-independent), not the lowered operands — a materialized
+    # constant operand must not pull the result into its register
+    # buffer. An unmaterialized output is materialized at this boundary.
+    out_storage = (
+        expr.type.storage
+        if expr.type.storage is not StorageKind.UMAT
+        else StorageKind.RMEM
+    )
+    out_type = TensorType(
+        shape=out_shape,
+        dtype=expr.type.dtype,
+        layout=lhs.type.layout if lhs.type.layout is not None else rhs.type.layout,
+        storage=out_storage,
+    )
+    r = ctx.alloc(out_type, hint="r")
+    ctx.emit(_eval_call(TirBinary(kind=target.kind), (lhs, rhs, r)))
+    return r
+
+
+@register_hir_lowering(HirUnary)
+def _lower_unary(ctx: "_Lowerer", target, expr) -> Var:
+    x = ctx.lower(expr.args[0])
+    # See HirBinary above — TIR result mirrors the lowered
+    # input shape, not the HIR logical shape.
+    out_type = TensorType(
+        shape=x.type.shape,
+        dtype=expr.type.dtype,
+        layout=x.type.layout,
+        storage=x.type.storage,
+    )
+    r = ctx.alloc(out_type, hint="r")
+    ctx.emit(_eval_call(TirUnary(kind=target.kind), (x, r)))
+    return r
+
+
+@register_hir_lowering(HirReshape)
+def _lower_reshape(ctx: "_Lowerer", target, expr) -> Var:
+    # Reshape: PtrOf(src) + TensorView with same layout,
+    # new logical shape.  PtrOf gives a device pointer to
+    # the per-thread buffer (no offset for reshape).
+    x = ctx.lower(expr.args[0])
+    # Step 1: PtrOf(x) — take the pointer
+    ptr_op = PtrOf()
+    ptr_ty = x.type  # PtrOf typeinfer returns same type
+    ptr_call = Call(type=ptr_ty, target=ptr_op, args=(x,))
+    ptr_var = ctx.fresh(ptr_ty, hint="ptr")
+    ctx.emit_bind(ptr_var, ptr_call)
+    # Step 2: TensorView over the ptr, with new shape
+    out_ty = TensorType(
+        shape=target.new_shape,
+        dtype=x.type.dtype,
+        layout=x.type.layout,
+        storage=x.type.storage,
+    )
+    tv = TensorView(layout=out_ty.layout, shape=target.new_shape)
+    tv_call = Call(type=out_ty, target=tv, args=(ptr_var,))
+    r = ctx.fresh(out_ty, hint="r")
+    ctx.emit_bind(r, tv_call)
+    return r
+
+
+@register_hir_lowering(HirClamp)
+def _lower_clamp(ctx: "_Lowerer", target, expr) -> Var:
+    x = ctx.lower(expr.args[0])
+    r = ctx.alloc(x.type, hint="r")
+    ctx.emit(_eval_call(
+        TirClamp(min_val=target.min_val, max_val=target.max_val), (x, r)))
+    return r
+
+
+@register_hir_lowering(HirCast)
+def _lower_cast(ctx: "_Lowerer", target, expr) -> Var:
+    x = ctx.lower(expr.args[0])
+    out_type = TensorType(
+        shape=x.type.shape,
+        dtype=target.dtype,
+        layout=x.type.layout,
+        storage=x.type.storage,
+    )
+    r = ctx.alloc(out_type, hint="r")
+    ctx.emit(_eval_call(TirUnary(kind=UnaryKind.CAST), (x, r)))
+    return r
+
+
+@register_hir_lowering(HirTupleGetItem)
+def _lower_tuple_get_item(ctx: "_Lowerer", target, expr) -> Var:
+    # Structural select over a tuple-typed producer (a multi-carry
+    # GridRegion): lowering the producer materialises its per-field Vars in
+    # ``_tuple_parts``; this just picks one.
+    src = expr.args[0]
+    ctx.lower(src)
+    parts = ctx._tuple_parts.get(id(src))
+    if parts is None:
+        raise TypeError(
+            "hir_to_tir: TupleGetItem on a producer with no lowered tuple "
+            f"fields ({type(src).__name__})"
+        )
+    return parts[target.index]
+
+
+@register_hir_lowering(HirFullLike)
+def _lower_full_like(ctx: "_Lowerer", target, expr) -> Var:
+    # Pure type-driven alloc + fill: the input expr only donates its type
+    # (shape / dtype / layout / storage). Its LOWERED form is mirrored so
+    # that inside a mesh scope the accumulator carries the per-shard local
+    # shape (not the HIR-global one) — a global-shaped accumulator would
+    # poison downstream broadcast-shape decisions.
+    ty = expr.type
+    storage = (
+        ty.storage if ty.storage is not StorageKind.UMAT else StorageKind.RMEM
+    )
+    try:
+        tmpl = ctx.lower(expr.args[0])
+    except Exception:
+        tmpl = None
+    if tmpl is not None:
+        out_type = TensorType(
+            shape=tuple(tmpl.type.shape),
+            dtype=ty.dtype,
+            layout=tmpl.type.layout,
+            storage=(
+                tmpl.type.storage
+                if tmpl.type.storage is not StorageKind.UMAT
+                else storage
+            ),
+        )
+    else:
+        # TIR var shapes are per-shard local (see the Reshard lowering); a
+        # sharded type sizes its buffer / fill count from the layout.
+        local_shape = (
+            shard_layout_local_shape(ty.layout)
+            if isinstance(ty.layout, ShardLayout)
+            else tuple(ty.shape)
+        )
+        out_type = TensorType(
+            shape=tuple(local_shape),
+            dtype=ty.dtype,
+            layout=ty.layout,
+            storage=storage,
+        )
+    r = ctx.alloc(out_type, hint="c")
+    fill_value = Constant(
+        value=target.value,
+        type=TensorType(
+            shape=(), dtype=ty.dtype, layout=None, storage=StorageKind.RMEM
+        ),
+    )
+    ctx.emit(_eval_call(Fill(), (r, fill_value)))
+    return r
+
+
+@register_hir_lowering(HirCacheUpdate)
+def _lower_cache_update(ctx: "_Lowerer", target, expr) -> Var:
+    cache = ctx.lower(expr.args[0])
+    cur = ctx.lower(expr.args[1])  # ``cur`` position (runtime row index)
+    # expr.args[2] (``s``) is not consulted: v0 supports the decode-step
+    # shape S_CAP == 1 (exactly one row), where s must be 1.
+    new = ctx.lower(expr.args[3])
+    cache_shape = tuple(cache.type.shape)
+    new_shape = tuple(expr.args[3].type.shape)
+    if new_shape[1] != 1 or cache_shape[0] != 1:
+        raise NotImplementedError(
+            "cache_update lowering: v0 supports B == 1 and S_CAP == 1 "
+            f"(single-row decode write); got cache {cache_shape}, "
+            f"new {new_shape}"
+        )
+    # Row-slice view of the cache at runtime ``cur`` along axis 1; keep rank
+    # 4 (axis-1 extent 1) so the Copy shape check matches ``new``.
+    view_shape = (new_shape[0], 1, *cache_shape[2:])
+    cstr = c_order_strides(tuple(int(d) for d in cache_shape))
+    view_layout = _Layout(shape=view_shape, strides=cstr)
+    tv_type = TensorType(
+        shape=view_shape,
+        dtype=cache.type.dtype,
+        layout=view_layout,
+        storage=cache.type.storage,
+    )
+    tv_call = Call(type=tv_type, target=TensorView(layout=view_layout), args=(cache, cur))
+    sv = ctx.fresh(tv_type, hint="sv")
+    ctx.emit_bind(sv, tv_call)
+    # In-place per the op contract (anchored on the cache buffer): write the
+    # new row into the cache and return the cache var itself.
+    ctx.emit(_eval_call(Copy(), (new, sv)))
+    return cache
+
+
+def _insert_slice_coord(ctx: "_Lowerer", off_expr):
+    """The scalar window index for an in-place ``insert_slice``: the window
+    is one tile of the update's own extent starting at the offset, so the
+    offset is the tile index (matching the ``local_tile`` coord). A
+    compile-time offset folds to a ``Constant`` scalar (emitted as a
+    literal coordinate); a runtime scalar offset lowers to its scalar Var
+    (its single element is read at the coordinate site)."""
+    i32 = TensorType.scalar(dtype=DType.i32)
+    if isinstance(off_expr, Constant):
+        val = off_expr.value
+        elem = int(val[0]) if isinstance(val, (list, tuple)) else int(val)
+        return Constant(value=elem, type=i32)
+    # A runtime offset lowers to its scalar Var (a native scalar index, e.g.
+    # the loop induction variable).
+    return ctx.lower(off_expr)
+
+
+@register_hir_lowering(HirInsertSlice)
+def _lower_insert_slice(ctx: "_Lowerer", target, expr) -> Var:
+    dst = ctx.lower(expr.args[0])
+    upd = ctx.lower(expr.args[1])
+    # Per-axis window: an offset tuple (rank N) or a single scalar (1-D).
+    # Each window is a tile of the update's own extent starting at the
+    # offset, so each offset is that axis's tile coord. Write ``update`` into
+    # the window IN PLACE and return ``dst`` — a loop-carried
+    # ``ov = insert_slice(ov, …)`` therefore reuses the single carried buffer
+    # with no replacement allocation, and the yield aliases the carry buffer.
+    off_expr = expr.args[2]
+    upd_shape = tuple(upd.type.shape)
+    if isinstance(off_expr, Tuple):
+        coords = tuple(_insert_slice_coord(ctx, el) for el in off_expr.elements)
+    else:
+        coords = (_insert_slice_coord(ctx, off_expr),)
+    # The window carries the update's layout: for a sharded update this is a
+    # ShardLayout, so the Copy verifier sees matching ShardLayouts and the
+    # emitter derives the per-shard tile size.
+    if isinstance(upd.type.layout, ShardLayout):
+        win_layout = upd.type.layout
+    elif isinstance(off_expr, Tuple):
+        win_layout = TensorView.layout_for_slice_nd(
+            src_shape=tuple(dst.type.shape), sliced_shape=upd_shape
+        )
+    else:
+        win_layout = TensorView.layout_for_slice(
+            src_shape=tuple(dst.type.shape), axis=0, sliced_shape=upd_shape
+        )
+    win_type = TensorType(
+        shape=upd_shape,
+        dtype=dst.type.dtype,
+        layout=win_layout,
+        storage=dst.type.storage,
+    )
+    win_call = Call(
+        type=win_type, target=TensorView(layout=win_layout), args=(dst, *coords)
+    )
+    win = ctx.fresh(win_type, hint="isv")
+    ctx.emit_bind(win, win_call)
+    ctx.emit(_eval_call(Copy(), (upd, win)))
+    return dst
+
+
+# ── reduce / gather (generic tag dispatch) ──
+@register_hir_lowering(HirGather)
+def _lower_gather(ctx: "_Lowerer", target, expr) -> Var:
+    if target.batch_dims != 0:
+        # The batched contract is evaluator/typeinfer-only for now; refuse to
+        # fall through to the single-coordinate slice-view lowering below.
+        raise NotImplementedError(
+            "Gather: batched gather lowering (batch_dims>0) is not yet supported"
+        )
+    x = ctx.lower(expr.args[0])
+    idx = ctx.lower(expr.args[1])
+    # Compute view layout from sliced shape
+    view_shape = expr.type.shape
+    view_layout = TensorView.layout_for_slice(
+        src_shape=tuple(x.type.shape),
+        axis=target.axis,
+        sliced_shape=view_shape,
+    )
+    tv = TensorView(layout=view_layout)
+    tv_type = TensorType(
+        shape=view_shape,
+        dtype=expr.type.dtype,
+        layout=view_layout,
+        storage=x.type.storage,
+    )
+    tv_call = Call(type=tv_type, target=tv, args=(x, idx))
+    sv = ctx.fresh(tv_type, hint="sv")
+    ctx.emit_bind(sv, tv_call)
+    return sv
+
+
+@register_hir_lowering(HirReduce)
+def _lower_reduce(ctx: "_Lowerer", target, expr) -> Var:
+    x = ctx.lower(expr.args[0])
+    axes = target.axes
+    # The HIR Reduce typeinfer already computed the reduced
+    # ``ShardLayout`` (layout dims on reduced axes collapsed to
+    # size 1 / stride 0; corresponding Split attrs rewritten to
+    # Broadcast).  Reuse that layout instead of copying the
+    # input layout — otherwise the TIR output type carries an
+    # un-reduced layout shape and downstream codegen iterates
+    # the wrong per-thread count.
+    keepdim = target.keepdim
+    new_shape = list(x.type.shape)
+    for a in sorted(axes, reverse=True):
+        if keepdim:
+            new_shape[a] = 1
+        else:
+            new_shape.pop(a)
+    out_type = TensorType(
+        shape=tuple(new_shape),
+        dtype=x.type.dtype,
+        layout=getattr(expr.type, "layout", x.type.layout),
+        storage=x.type.storage,
+    )
+    r = ctx.alloc(out_type, hint="r")
+
+    # Analyse the input ShardLayout for cross-warp staging.
+    # A reduce axis covered by a Split
+    # on a non-``thread`` topology (i.e. ``warp`` / ``cta`` /
+    # ``cluster`` / ...) cannot be folded by ``__shfl_xor_sync``
+    # alone; the runtime needs a small staging buffer the
+    # warps cooperatively write into and read back. The buffer
+    # size is the product of the cross-warp mesh axis extents.
+    tir_args: tuple = (x, r)
+    # The cross-warp analysis must run on the *HIR* input
+    # type — its ``shape`` matches
+    # the user-facing axes the HIR Reduce was authored against
+    # (logical ``(1, 1536)``). After lowering, ``x.type.shape``
+    # may be the per-shard local form ``(1, 1, 1, 8)``; using
+    # that would silently mis-map ``axes=(-1,)`` to a non-Split
+    # layout position and skip the workspace alloc.
+    ws_size, ws_dtype, lane_reduced = _analyze_cross_warp_workspace(
+        expr.args[0].type, axes
+    )
+    if ws_size > 0:
+        # The runtime stages one warp-partial PER OUTPUT CELL: scale the
+        # workspace by the output's per-thread cell count (1 for scalar
+        # reduces — the historical size).
+        n_cells = 1
+        for dim in r.type.shape:
+            if isinstance(dim, int):
+                n_cells *= dim
+        ws_size *= max(1, n_cells)
+        if not lane_reduced:
+            # cross-warp-only: per (warp, lane, cell) staging slots.
+            ws_size *= 32
+        ws_type = TensorType(
+            shape=(ws_size,),
+            dtype=ws_dtype,
+            layout=None,
+            storage=StorageKind.SMEM,
+        )
+        ws = ctx.alloc(ws_type, hint="ws")
+        tir_args = (x, r, ws)
+
+    reduce_op = TirReduce(axes=axes, kind=target.kind)
+    ctx.emit(_eval_call(reduce_op, tir_args))
+    return r
+
+
+@register_hir_lowering(HirFunction)
+def _lower_hir_function(ctx: "_Lowerer", target, expr) -> Var:
+    return ctx._lower_hir_call(expr, target)
+
+
 def _mangle_variant_name(variant: HirFunction) -> str:
     """Mangle a dispatch variant's symbol from its single Pattern."""
     if len(variant.specializations) != 1:
@@ -1340,47 +1328,6 @@ def _mangle_variant_name(variant: HirFunction) -> str:
             f"for v0 specialization mangling"
         )
     return f"{variant.name}${pat.dim_var}${pat.lo}_{pat.hi}"
-
-
-def _parse_shape_param_name(
-    name: str, callee_name: str, mangled_name: str
-) -> tuple[str, int]:
-    """Split ``<base>_shape_<axis>`` into ``(base, axis)``.
-
-    Used to map a mangled callee's trailing kernel-scalar param back to
-    its originating user-param name and tensor axis.
-    """
-    marker = "_shape_"
-    idx = name.rfind(marker)
-    if idx < 0:
-        raise RuntimeError(
-            f"HIR Call to {callee_name!r}: mangled callee {mangled_name!r} "
-            f"has trailing param {name!r} that is not a "
-            f"<base>_shape_<axis> shape scalar"
-        )
-    base = name[:idx]
-    try:
-        axis = int(name[idx + len(marker):])
-    except ValueError as e:
-        raise RuntimeError(
-            f"HIR Call to {callee_name!r}: mangled callee {mangled_name!r} "
-            f"has trailing param {name!r} with non-integer axis suffix"
-        ) from e
-    return base, axis
-
-
-def _find_user_param_index(
-    params: tuple[Var, ...], base_name: str,
-    callee_name: str, mangled_name: str,
-) -> int:
-    for i, p in enumerate(params):
-        if p.name == base_name:
-            return i
-    raise RuntimeError(
-        f"HIR Call to {callee_name!r}: mangled callee {mangled_name!r} "
-        f"trailing scalar references user param {base_name!r} that is "
-        f"not in the callee user-param list"
-    )
 
 
 def _fold_items_to_sequential(items: list[_Item]) -> Sequential:
@@ -1536,9 +1483,6 @@ def _lower_function(
 
     inner_seq = _fold_items_to_sequential(lo._items)
     # wrap each present mesh as a MeshScope; skip ones that aren't
-
-    inner_seq = _fold_items_to_sequential(lo._items)
-    # wrap each present mesh as a MeshScope; skip ones that aren't
     # used. ``_lower_function`` no longer fabricates mesh structure beyond
     # what ``ShardLayout`` types in the body actually reference. A function
     # with no mesh information at all lowers to a bare body sequence.
@@ -1656,25 +1600,19 @@ def _build_dispatch_entry(
         call_args: list = list(forwarded_args)
         extra = pf.params[len(forwarded_args):]
         for extra_p in extra:
-            # Match "<param>_shape_<axis>" name back to (param, axis).
-            ep_name = extra_p.name
-            for entry_p in entry_params:
-                prefix = entry_p.name + "_shape_"
-                if ep_name.startswith(prefix):
-                    try:
-                        ax = int(ep_name[len(prefix):])
-                    except ValueError:
-                        continue
-                    call_args.append(
-                        ShapeOf(type=scalar_i32, param=entry_p, axis=ax)
-                    )
-                    break
-            else:
+            # Match "<base>_shape_<axis>" name back to (param, axis).
+            parsed = parse_shape_var_name(extra_p.name)
+            entry_p = next(
+                (p for p in entry_params if parsed and p.name == parsed[0]), None
+            )
+            if entry_p is None:
                 raise RuntimeError(
                     f"dispatch entry {template.name!r}: cannot resolve "
-                    f"trailing kernel param {ep_name!r} on mangled "
+                    f"trailing kernel param {extra_p.name!r} on mangled "
                     f"callee {pf.name!r}"
                 )
+            _, ax = parsed
+            call_args.append(ShapeOf(type=scalar_i32, param=entry_p, axis=ax))
         case_calls.append(symbol_call(pf, call_args))
     dispatch = DispatchCall(
         callee_name=template.name,
@@ -1698,73 +1636,77 @@ def _build_dispatch_entry(
     )
 
 
-def _derive_meshes_from_body(expr, topologies: tuple) -> tuple[Mesh | None, Mesh | None]:
+class _MeshDeriver(ExprVisitor[None]):
+    """Walk a HIR expression to find meshes, keyed by topology name.
+
+    ``cta_mesh`` / ``thread_mesh`` hold the first mesh found for each
+    topology after ``visit`` returns; each stays ``None`` if its topology
+    is never referenced.
+    """
+
+    def __init__(self) -> None:
+        self.cta_mesh: Mesh | None = None
+        self.thread_mesh: Mesh | None = None
+
+    def visit(self, expr):
+        # Short-circuit once both meshes are found — no need to keep
+        # descending into the rest of the tree.
+        if self.cta_mesh is not None and self.thread_mesh is not None:
+            return
+        super().visit(expr)
+
+    def visit_Call(self, call: Call) -> None:
+        ty = call.type
+        sl = getattr(ty, "layout", None)
+        if isinstance(sl, ShardLayout):
+            m = sl.mesh
+            # ``mesh.topology`` may be a ``Topology`` dataclass or a
+            # plain string depending on how the Mesh was authored
+            # (sugar paths pass topology names as strings).
+            primary = m.topology
+            primary_name = primary.name if hasattr(primary, "name") else str(primary)
+            if primary_name == "cta":
+                if self.cta_mesh is None:
+                    self.cta_mesh = m
+            elif self.thread_mesh is None:
+                # Any non-cta primary (``thread`` / ``warp`` / ``lane`` /
+                # ...) lives inside one CTA — wrap as the inner
+                # ``thread_mesh`` so the verifier's MeshScope check passes
+                # and codegen still threads the right Topology<scope> all
+                # the way through.
+                self.thread_mesh = m
+        self.generic_visit(call)
+
+
+def _derive_meshes_from_body(expr) -> tuple[Mesh | None, Mesh | None]:
     """Walk a HIR expression to find meshes, keyed by topology name.
 
     Returns ``(cta_mesh, thread_mesh)`` — the first mesh found for each
     topology.  Returns ``None`` for any topology not found.
     """
+    deriver = _MeshDeriver()
+    deriver.visit(expr)
+    return deriver.cta_mesh, deriver.thread_mesh
 
-    cta_mesh: Mesh | None = None
-    thread_mesh: Mesh | None = None
 
-    def walk(e):
-        nonlocal cta_mesh, thread_mesh
-        if cta_mesh is not None and thread_mesh is not None:
-            return
-        if isinstance(e, Tuple):
-            for elt in e.elements:
-                walk(elt)
-            return
-        if isinstance(e, Call):
-            ty = e.type
-            sl = getattr(ty, "layout", None)
-            if isinstance(sl, ShardLayout):
-                m = sl.mesh
-                # ``mesh.topology`` may be a ``Topology`` dataclass or a
-                # plain string depending on how the Mesh was authored
-                # (sugar paths pass topology names as strings).
-                primary = m.topology
-                primary_name = primary.name if hasattr(primary, "name") else str(primary)
-                if primary_name == "cta":
-                    if cta_mesh is None:
-                        cta_mesh = m
-                elif thread_mesh is None:
-                    # Any non-cta primary (``thread`` / ``warp`` /
-                    # ``lane`` / ...) lives
-                    # inside one CTA — wrap as the inner ``thread_mesh``
-                    # so the verifier's MeshScope check passes and
-                    # codegen still threads the right Topology<scope>
-                    # all the way through.
-                    thread_mesh = m
-            for a in e.args:
-                walk(a)
+class _CalleeCollector(ExprVisitor[None]):
+    """Collect the set of HIR function names called anywhere in an Expr."""
 
-    walk(expr)
-    return cta_mesh, thread_mesh
+    def __init__(self) -> None:
+        self.found: set[str] = set()
+
+    def visit_Call(self, call: Call) -> None:
+        tgt = call.target
+        if isinstance(tgt, HirFunction):
+            self.found.add(tgt.name)
+        self.generic_visit(call)
 
 
 def _collect_hir_callee_names(expr) -> set[str]:
     """Return the set of HIR function names called anywhere in ``expr``."""
-    found: set[str] = set()
-
-    def walk(e) -> None:
-        if isinstance(e, Call):
-            tgt = e.target
-            if isinstance(tgt, HirFunction):
-                found.add(tgt.name)
-            for a in e.args:
-                walk(a)
-            return
-        if isinstance(e, GridRegionExpr):
-            walk(e.body)
-            return
-        if isinstance(e, Tuple):
-            for elt in e.elements:
-                walk(elt)
-
-    walk(expr)
-    return found
+    collector = _CalleeCollector()
+    collector.visit(expr)
+    return collector.found
 
 
 def _topo_order_dispatch_groups(
@@ -1854,9 +1796,7 @@ class HirToTirPass(ModulePass):
             group = dispatch_view[group_name]
             lowered: list[PrimFunction] = []
             for variant in group:
-                cta_mesh, thread_mesh = _derive_meshes_from_body(
-                    variant.body, variant.topologies
-                )
+                cta_mesh, thread_mesh = _derive_meshes_from_body(variant.body)
                 if cta_mesh is None:
                     cta_mesh = self._cta
                 if thread_mesh is None:
@@ -1906,9 +1846,7 @@ class HirToTirPass(ModulePass):
                 )
                 continue
             # Static single-body path.
-            cta_mesh, thread_mesh = _derive_meshes_from_body(
-                fn.body, fn.topologies
-            )
+            cta_mesh, thread_mesh = _derive_meshes_from_body(fn.body)
             if cta_mesh is None:
                 cta_mesh = self._cta
             if thread_mesh is None:

--- a/src/tilefoundry/visitor_registry/shard_propagate.py
+++ b/src/tilefoundry/visitor_registry/shard_propagate.py
@@ -10,7 +10,12 @@ from __future__ import annotations
 
 import isl
 
-from tilefoundry.ir.types.shard import Layout, ShardLayout, try_c_order_strides
+from tilefoundry.ir.types.shard import (
+    Layout,
+    ShardLayout,
+    canonical_shard_layout,
+    try_c_order_strides,
+)
 from tilefoundry.ir.types.shard.shard_layout import (
     Broadcast,
     Partial,
@@ -312,64 +317,17 @@ def derive_output_shard_layout(
     if carriers and all(c == carriers[0] for c in carriers):
         return carriers[0]
 
-    # Otherwise synthesise the output layout from the per-mesh-axis
-    # bindings (combining partial shards from several inputs). An output
-    # logical tensor axis split by a single mesh axis stays a single layout
-    # position (flat); one split by several mesh axes factorizes into a layout
-    # sub-position per mesh extent (each bound by one mesh axis, per shard.md
-    # §6) plus a remainder, so the multi-mesh-axis split is representable.
-    # Only `Split` binds an output layout axis; a `Partial` is a mesh-axis value
-    # state with no layout axis, so it is carried through directly.
-    bindings: dict[int, list] = {}
-    for p, a in enumerate(attrs):
-        if isinstance(a, Split):
-            bindings.setdefault(a.axis, []).append((p, a))
-
-    layout_shape: list = []
-    out_attrs: list = [Broadcast() for _ in range(mesh_rank)]
-    for p, a in enumerate(attrs):
-        if isinstance(a, Partial):
-            out_attrs[p] = Partial(a.reduction)
-    pos = 0
-    for ax, size in enumerate(output_shape):
-        binds = bindings.get(ax, [])
-        if len(binds) <= 1:
-            layout_shape.append(size)
-            if binds:
-                p, a = binds[0]
-                out_attrs[p] = Split(pos)
-            pos += 1
-            continue
-        if not (isinstance(size, int) and not isinstance(size, bool)):
-            raise ValueError(
-                f"cannot factorize dynamic output axis {ax} across multiple mesh axes"
-            )
-        prod = 1
-        for p, a in binds:
-            ext = mesh.layout.shape[p]
-            if not (isinstance(ext, int) and not isinstance(ext, bool)):
-                raise ValueError(
-                    f"cannot factorize output axis {ax}: dynamic mesh extent on "
-                    f"mesh axis {p}"
-                )
-            layout_shape.append(ext)
-            out_attrs[p] = Split(pos)
-            prod *= ext
-            pos += 1
-        if size % prod != 0:
-            raise ValueError(
-                f"output axis {ax} size {size} not divisible by mesh extents {prod}"
-            )
-        rem = size // prod
-        if rem != 1:
-            layout_shape.append(rem)
-            pos += 1
-
-    return ShardLayout(
-        layout=Layout(shape=tuple(layout_shape), strides=try_c_order_strides(tuple(layout_shape))),
-        attrs=tuple(out_attrs),
-        mesh=mesh,
-    )
+    # Otherwise synthesise the output layout from the per-mesh-axis bindings
+    # (combining partial shards from several inputs) via the same
+    # canonicalizer make_shard_tensor_type uses (docs/spec/shard.md §7.1.1):
+    # an output axis split by one mesh axis is factored into an extent-sized
+    # position (+ residual) exactly like a from-scratch sharding, and one
+    # split by several mesh axes factorizes into one sub-position per mesh
+    # extent (per shard.md §6) plus a remainder — so a carried-through layout
+    # and a synthesised one for the same logical sharding always compare
+    # equal. `Split.axis` in `attrs` still names an *output tensor* axis here
+    # (canonical_shard_layout's expected input), not yet a layout position.
+    return canonical_shard_layout(output_shape, mesh, tuple(attrs))
 
 
 __all__ = ["derive_output_shard_layout", "partial_reductions_by_axis"]

--- a/tests/analysis/test_shard_propagate.py
+++ b/tests/analysis/test_shard_propagate.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import isl
 import pytest
 
-from tilefoundry.ir.types import make_tensor_type
+from tilefoundry.ir.types import make_shard_tensor_type, make_tensor_type
 from tilefoundry.ir.types.shard import Layout, Mesh, ShardLayout, Topology
 from tilefoundry.ir.types.shard.shard_layout import Broadcast, Partial, Split
 from tilefoundry.visitor_registry.access_relation import AccessRelationResult
@@ -115,6 +115,46 @@ def test_two_mesh_axes_on_same_output_axis_factorize():
     assert out.layout.shape == (2, 2, 8)
     assert out.attrs == (Split(0), Split(1))
     assert out.mesh is _GPU2
+
+
+# ── canonical-layout agreement (shard.md §7.1.1) ─────────────────────────────
+# make_shard_tensor_type (a from-scratch sharding) and derive_output_shard_layout
+# (a propagated one) both build a §7.1.1 layout through the shared
+# canonical_shard_layout; for the same logical sharding they MUST compare equal.
+
+
+def test_single_split_per_axis_matches_canonical_from_scratch():
+    # lhs splits axis 0 on mesh axis a only, rhs splits axis 1 on mesh axis b
+    # only -> neither operand alone realises the other's Split, so the carry
+    # branch fails for both and the output is synthesised. Each mesh extent
+    # (2) does not equal its axis size (8), so each axis factors into an
+    # extent position + a residual position (8 / 2 = 4) -- the
+    # single-mesh-axis-split canonical form (shard.md §7.1.1).
+    lhs_t = make_tensor_type((8, 8), layout=_shard2((8, 8), Split(0), Broadcast()))
+    rhs_t = make_tensor_type((8, 8), layout=_shard2((8, 8), Broadcast(), Split(1)))
+    ident = isl.map("{ [m, n] -> [m, n] }")
+    rel = AccessRelationResult(domain=build_domain((8, 8)), maps=(ident, ident, ident))
+    out = derive_output_shard_layout((lhs_t, rhs_t), rel, (8, 8))
+    expected = make_shard_tensor_type((8, 8), mesh=_GPU2, attrs=(Split(0), Split(1)))
+    assert out == expected.layout
+
+
+def test_multi_split_same_axis_matches_canonical_from_scratch():
+    # Both mesh axes bind logical axis 0 (make_shard_tensor_type's own
+    # attrs, one Split per mesh axis, both naming axis 0).
+    lhs_t = make_tensor_type((4, 8), layout=_shard2((4, 8), Split(0), Broadcast()))
+    rhs_t = make_tensor_type((4, 8), layout=_shard2((4, 8), Broadcast(), Split(0)))
+    out = derive_output_shard_layout((lhs_t, rhs_t), _elementwise_relation(), (4, 8))
+    expected = make_shard_tensor_type((4, 8), mesh=_GPU2, attrs=(Split(0), Split(0)))
+    assert out == expected.layout
+
+
+def test_partial_sharding_matches_canonical_from_scratch():
+    ident = isl.map("{ [m, n] -> [m, n] }")
+    rel = AccessRelationResult(domain=build_domain((4, 8)), maps=(ident, ident))
+    x_t = make_shard_tensor_type((4, 8), mesh=_GPU2, attrs=(Partial("sum"), Broadcast()))
+    out = derive_output_shard_layout((x_t,), rel, (4, 8))
+    assert out == x_t.layout
 
 
 def test_carry_candidates_disagree_falls_through_to_synthesis():

--- a/tests/passes/test_bufferize.py
+++ b/tests/passes/test_bufferize.py
@@ -6,11 +6,14 @@ pass leaves the ``PrimFunction`` body structurally unchanged.
 from __future__ import annotations
 
 from tests.fixtures.demo_ir import build_demo
-from tilefoundry.ir.core import Call
+from tilefoundry.ir.core import Call, Var
 from tilefoundry.ir.core.module import Module
+from tilefoundry.ir.tir.dispatch import DispatchCall
 from tilefoundry.ir.tir.memory import AllocTensor as AllocTensorOp
 from tilefoundry.ir.tir.prim_function import PrimFunction
-from tilefoundry.ir.tir.stmts import LetStmt, Sequential
+from tilefoundry.ir.tir.stmts import Abort, LetStmt, Sequential
+from tilefoundry.ir.types import DType, TensorType
+from tilefoundry.ir.types.storage import StorageKind
 from tilefoundry.passes.transforms import BufferizePass, HirToTirPass
 from tilefoundry.passes.transforms.bufferize import (
     BufferEntry,
@@ -80,3 +83,27 @@ def test_scheduler_assigns_independent_pool_per_buffer():
     # Trivial policy: pool_id is the buffer's own var → no pool sharing.
     pool_ids = {id(p.pool_id) for p in placements}
     assert len(pool_ids) == len(placements)
+
+
+def test_lifetime_collector_finds_buffer_inside_dispatch_call_fallback():
+    """A buffer allocated inside a ``DispatchCall``'s ``fallback`` arm must
+    be collected. A hand-rolled Stmt walk without ``DispatchCall`` coverage
+    silently skips it (docs/spec/visitor-mutator.md §1)."""
+    buf_type = TensorType(shape=(4,), dtype=DType.f32, layout=None, storage=StorageKind.RMEM)
+    buf_var = Var(type=buf_type, name="buf")
+    alloc_call = Call(type=buf_type, target=AllocTensorOp(tensor_type=buf_type), args=())
+    fallback = Sequential(
+        body=(LetStmt(var=buf_var, value=alloc_call, body=Sequential(body=(Abort(),))),)
+    )
+    dispatch = DispatchCall(
+        callee_name="f",
+        subjects=(),
+        case_patterns=(),
+        case_calls=(),
+        fallback=fallback,
+    )
+    pf = PrimFunction(name="f", params=(), body=Sequential(body=(dispatch,)))
+
+    entries = LifetimeCollector().collect(pf)
+
+    assert [e.var.name for e in entries] == ["buf"]

--- a/tests/passes/test_hir_to_tir.py
+++ b/tests/passes/test_hir_to_tir.py
@@ -19,18 +19,27 @@ from tilefoundry.dsl import (
     func,
     tf,
 )
-from tilefoundry.ir.core import Call
+from tilefoundry.ir.core import Call, Constant, Var
 from tilefoundry.ir.core.module import Module
+from tilefoundry.ir.hir.function import Function as HirFunction
+from tilefoundry.ir.hir.grid_region import GridRegionExpr
+from tilefoundry.ir.hir.nn.relu import ReLU as HirReLU
 from tilefoundry.ir.tir.arith import Binary as TirBinary
 from tilefoundry.ir.tir.memory.copy import Copy
 from tilefoundry.ir.tir.prim_function import PrimFunction
 from tilefoundry.ir.tir.reduce import Reduce as TirReduce
 from tilefoundry.ir.tir.stmts import Evaluate, LetStmt, MeshScope, Return, Sequential
-from tilefoundry.ir.types import DType
+from tilefoundry.ir.types import DType, TensorType
+from tilefoundry.ir.types.shard.layout import Layout
 from tilefoundry.ir.types.shard.shard_layout import ShardLayout as SL
+from tilefoundry.ir.types.shard.shard_layout import Split
 from tilefoundry.ir.types.storage import StorageKind
 from tilefoundry.parser.hir_parser import parse_script
 from tilefoundry.passes.transforms import HirToTirPass
+from tilefoundry.passes.transforms.hir_to_tir import (
+    _collect_hir_callee_names,
+    _derive_meshes_from_body,
+)
 
 
 def _run() -> PrimFunction:
@@ -253,3 +262,59 @@ def test_hir_reduce_no_workspace_when_only_thread_topology_split() -> None:
     assert len(reduce_call.args) == 2, (
         f"intra-warp reduce should have 2 args (src, dst), got {len(reduce_call.args)}"
     )
+
+
+# ── ExprVisitor-based HIR walks reach every child (docs/spec/visitor-mutator.md §1)
+
+
+def test_derive_meshes_from_body_finds_mesh_referenced_only_inside_grid_region() -> None:
+    """A mesh referenced only inside a ``GridRegionExpr`` body must still be
+    derived. A hand-rolled Tuple/Call-only walk silently skips
+    ``GridRegionExpr`` and misses it."""
+    mesh = Mesh(topology=Topology("cta", 4), layout=(4,))
+    sl = SL(layout=Layout(shape=(4,), strides=(1,)), attrs=(Split(0),), mesh=mesh)
+    body_ty = TensorType(shape=(4,), dtype=DType.f32, layout=sl, storage=StorageKind.GMEM)
+    body_call = Call(type=body_ty, target=HirReLU(), args=())
+    iv = Var(type=TensorType.scalar(dtype=DType.i32), name="i")
+    region = GridRegionExpr(
+        type=body_ty,
+        induction_var=iv,
+        carried_args=(),
+        init_args=(),
+        body=body_call,
+        yield_values=(),
+        extent=4,
+        step=1,
+    )
+
+    cta_mesh, thread_mesh = _derive_meshes_from_body(region)
+
+    assert cta_mesh is mesh
+    assert thread_mesh is None
+
+
+def test_collect_hir_callee_names_finds_callee_reachable_only_via_yield() -> None:
+    """A callee reachable only through ``GridRegionExpr.yield_values`` must
+    be collected. A walk that only descends into ``body`` misses it, which
+    would drop an inter-group dependency edge in dispatch-group ordering."""
+    scalar_ty = TensorType.scalar(dtype=DType.f32)
+    callee = HirFunction.build(
+        name="callee_fn",
+        params=(),
+        body=Constant(value=0.0, type=scalar_ty),
+        return_type=scalar_ty,
+    )
+    call_to_callee = Call(type=scalar_ty, target=callee, args=())
+    iv = Var(type=TensorType.scalar(dtype=DType.i32), name="i")
+    region = GridRegionExpr(
+        type=scalar_ty,
+        induction_var=iv,
+        carried_args=(),
+        init_args=(),
+        body=Constant(value=0.0, type=scalar_ty),
+        yield_values=(call_to_callee,),
+        extent=1,
+        step=1,
+    )
+
+    assert _collect_hir_callee_names(region) == {"callee_fn"}


### PR DESCRIPTION
Completes the consolidation items deferred from the earlier dedup PR, in three self-contained, individually-green commits. Every finding is from the repo-wide redundancy/consistency audit.

## What

| Commit | Area | Findings |
|---|---|---|
| `refactor(runtime/reduce)` | CUDA reduce tiers | F27, F30 |
| `refactor(shard)` | §7.1.1 layout canonicalizer + Mesh topology | F43, F46 |
| `refactor(passes)` | HIR→TIR lowering internals | F50, F52, F53, F54, F56, F59 |

## reduce (F27/F30)

Collapse the four reduce tiers (plain / intra-warp / cross-warp / intra-cta) onto one shared fold: rank-aware `local_fold<Op>(s,j,step)` + `cell_decomp`, one `reduce_traits<Op>` centralizing per-tag init/combine/finalize, and `warp_butterfly<Op>`. Delete the redundant `local_fold_sum`/`local_fold_maxabs`, `warp_sum/max_butterfly`, and the dead `rmax_op` tag.

`local_fold` flattens the whole tensor when `n_cells==1` (a bijection over all coords, including axis-factorization residual modes) and only indexes `s(j,k)` for a genuine cell split (`n_cells>1`). This is provably identical to the prior tested paths on the two existing call sites while also fixing the cross-warp tier onto the unified op set. A prior attempt at this refactor regressed sharded rmsnorm to NaN by using `s(j,k)` unconditionally for `rank(s)>1` (mistaking a residual mode for a cell axis); this version is GPU-validated no-NaN (max-abs-diff 0 on the seq_2 regression case).

## shard (F43/F46)

- **F43**: extract `canonical_shard_layout()` as the single owner of the §7.1.1 factorization. `make_shard_tensor_type` and `derive_output_shard_layout`'s synthesis fallback both consume it, so a from-scratch and a propagated layout for the same logical sharding compare structurally equal. The prior single-split divergence (utils factored, propagate kept-whole) is reconciled to the factored form. A single-split axis is kept whole (unfactored) only when it cannot be factored into a static extent + residual: a launch-provided (dynamic `None`) CTA mesh extent, or a dynamic logical axis (symbolic residual) — matching the pre-existing synthesis. A dynamic axis split by several mesh axes remains an error.
- **F46**: `Mesh.__post_init__` normalizes `topologies` to a non-empty `tuple[Topology,...]` (raw `str` rejected); add `Mesh.topology_domain()` and delete the two duplicated `_topology_domain` copies (`scope_match`, `tir/sync`). Drop the `topologies or (topology,)` fallback idiom and `hasattr`/`getattr` duck-typing now that topology is always a `Topology`.

## passes — HIR→TIR lowering internals

- **F54/F56/F59**: add `_Lowerer._alloc` (replaces ~14 alloc-and-bind triples); `_fork`/`_close` now forward **all** walk state (fixes a latent bug where forks dropped `_dispatch_groups`/`_mangled_registry`/`_caller_fn`/`_shape_param_names`); route the 3 hand-built i32 scalar-type sites through `TensorType.scalar`; delete a doubled fold, a doubled `lower_expr`, and an unused `topologies` param.
- **F52**: drop `_parse_shape_param_name`/`_find_user_param_index`; both sites use `parse_shape_var_name`.
- **F53**: rewrite the 3 hand-rolled isinstance walks as visitor subclasses (`_MeshDeriver`/`_CalleeCollector` → `ExprVisitor`, `LifetimeCollector` → `StmtVisitor`), gaining `GridRegionExpr` init_args/yield and `DispatchCall`-arm coverage; +3 regression tests for those exact blind spots.
- **F50**: give `_Lowerer` a public ABI (`lower`/`fresh`/`alloc`/`emit`/`emit_bind`) and turn the `@register_hir_lowering` handlers into module-level `(ctx, target, expr)` free functions, so the CUDA Mma extension point no longer reaches `_Lowerer` privates.

## Verification

Full suite `pytest tests/` (incl. `tests/models` and GPU `tests/e2e`): **782 passed, 0 failed**. `ruff`, `spec-rules-lint`, `spec-entropy-lint` all green.

## Deviations (disclosed)

- **F50**: 3 of 15 handlers (`_lower_reshard`, `_lower_tuple_get_item`, `_lower_hir_function`) still cooperate with pass-internal state (cross-CTA sync, tuple-carry lookup, dispatch-group resolution) — they are core ops, not target-owned extension points. `docs/spec/passes.md` documents the split: target-owned ops MUST use only the public ABI; these core exceptions MAY reach further. The finding's actual example (CUDA Mma) is fully ABI-clean.
