### PR TITLE
docs(hir): document CacheUpdate contract

### DIFF
--- a/docs/spec/hir.md
+++ b/docs/spec/hir.md
@@ -691,6 +691,44 @@ class InsertSlice(Op):
     the write result cannot preserve that secondary value state. An explicit
     `Reshard(update, Broadcast)` completes it.
 
+##### CacheUpdate
+```python
+class CacheUpdate(Op):
+    """Write a window of ``new`` into ``cache``; produces a same-shape cache.
+
+    Attributes:
+        cache: input; cache that receives the write.
+        cur_pos: input; i32 scalar where the write begins.
+        s: input; i32 scalar number of positions to write.
+        new: input; source positions, taken as ``new[:, :s]``.
+    """
+
+    cache: Tensor
+    cur_pos: Tensor
+    s: Tensor
+    new: Tensor
+```
+- constraints:
+  - `cache` and `new` MUST be rank-4 `[B, len, kv_heads, head_dim]` tensors
+    with the same dtype and equal `B`, `kv_heads`, and `head_dim`; typeinfer
+    rejects a mismatch. When both lengths are static, `new.len` MUST NOT exceed
+    `cache.len`.
+  - `cur_pos` and `s` MUST be i32 scalar tensors. A scalar is rank-0 or has
+    only literal size-1 dimensions; typeinfer rejects another dtype or shape.
+  - The write interval is runtime data, never a shape dimension. The result has
+    `cache`'s same static shape; no context-length `DimVar` grows with a write.
+  - `cur_pos >= 0`, `1 <= s <= new.len`, and `cur_pos + s <= cache.len` MUST
+    be checked at eval/runtime, not typeinfer, because their operands are
+    runtime values.
+  - This is a pure value-form op. Lowering MAY realize the output in place on
+    `cache`'s buffer.
+  - A `cache` carrying `Partial(reduction)` on a mesh axis requires `new` to
+    carry the identical mesh and per-mesh-axis state; a complete `cache`
+    rejects a `new` carrying `Partial`. Typeinfer rejects either mismatch.
+  - No affine access relation is registered because the data-dependent write
+    boundaries are opaque. Traffic analysis therefore charges the full tensor
+    types.
+
 ##### TopK
 ```python
 class TopK(Op):

--- a/docs/tutorial/migrate.md
+++ b/docs/tutorial/migrate.md
@@ -42,8 +42,16 @@ bound is one past the longest prior cache the model admits, which for this model
 differs between published models.
 
 The step takes `k_cache` / `v_cache` and hands back the entry its caller appends.
-There is a `cache_update` operation in the IR; no model here uses it, and its name
-is the only reason anybody reaches for it. Concatenation belongs to the caller.
+Two forms fit different callers; which one fits is a property of the caller, not
+a preference.
+
+| Form | Fits when | Cost |
+|---|---|---|
+| Caller-managed concat | The cache grows each step, execution is eager, or `ctx_len` participates in types as a `DimVar`. | Each step replaces the cache buffer, so one fixed-address graph cannot replay it. |
+| `cache_update` | The cache has fixed capacity, its write window advances each step, or it must be captured and replayed in a CUDA graph. | Shape stays static, the write window is runtime data, and traffic falls back to the whole tensor when its bounds cannot be derived. |
+
+See [spec hir § CacheUpdate](../spec/hir.md#cacheupdate) for the operation's
+contract.
 
 {{fixture: qwen3_5_35b_a3b/model.py:Qwen3_5FullAttention.full_attention}}
 

--- a/src/tilefoundry/ir/hir/tensor/cache_update.py
+++ b/src/tilefoundry/ir/hir/tensor/cache_update.py
@@ -1,11 +1,6 @@
-"""Functional KV-cache update HIR primitive.
+"""KV-cache update: write ``new[:, :s]`` at ``cache[:, cur_pos : cur_pos + s]``.
 
-Returns a new cache of the **same** (static) shape with ``new[:, :s]`` written at
-``cache[:, cur_pos : cur_pos + s]`` and all other positions unchanged. The write
-region (``cur_pos`` / ``s``) is runtime scalar data, never a shape dim, so the
-cache shape stays static (no compound ``DimVar`` context axis). It is a pure
-value-form op; an in-place realization is a lowering concern (the output is
-anchored on the input cache buffer).
+Contract and constraints: `spec hir § CacheUpdate`.
 """
 from __future__ import annotations
 
@@ -19,14 +14,10 @@ from tilefoundry.ir.hir._shard_checks import require_matching_partial_state
 from tilefoundry.ir.types import DType, TensorType
 from tilefoundry.visitor_registry import register_typeinfer
 
-# Data-dependent write region (``cur_pos`` / ``s`` are runtime values), so no
-# affine access relation is registered — the boundaries are opaque.
-
 
 @register_op(name="cache_update")
 class CacheUpdate(Op):
-    """Write ``new[:, :s]`` into ``cache[:, cur_pos : cur_pos + s]``; return the
-    updated cache (same shape). ``cur_pos`` / ``s`` are runtime scalar tensors."""
+    """Cache-update HIR operation; see `spec hir § CacheUpdate`."""
     cache = ParamDef(kind="input", pattern=Tensor)
     cur_pos = ParamDef(kind="input", pattern=Tensor)
     s = ParamDef(kind="input", pattern=Tensor)

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -120,6 +120,17 @@ def test_spec_prints_one_section_and_the_keys_beside_it(capsys) -> None:
     assert "class RMSNorm(Op):" not in section
 
 
+def test_spec_lists_and_prints_cache_update(capsys) -> None:
+    """The CacheUpdate contract is discoverable from the HIR outline and its key."""
+    assert cli.main(["spec", "hir"]) == 0
+    assert "CacheUpdate" in capsys.readouterr().out
+
+    assert cli.main(["spec", "hir", "cacheupdate"]) == 0
+    section = capsys.readouterr().out
+    assert "class CacheUpdate(Op):" in section
+    assert "eval/runtime, not typeinfer" in section
+
+
 def test_spec_separates_two_sections_that_would_share_a_key(capsys) -> None:
     """Two sections numbered 3.2 are each reachable, and the bare key is refused."""
     assert cli.main(["spec", "parser", "shared-parsing-machinery/3.2"]) == 0


### PR DESCRIPTION
## Why
- `cache_update` had a complete implementation but no discoverable HIR specification, while the migration tutorial discouraged its valid fixed-capacity use case.

## What
- Add the CacheUpdate contract to the HIR specification and expose it through the spec CLI.
- Keep source comments local and update the migration tutorial with caller-managed concat versus fixed-capacity cache selection criteria.

## Contract
- CacheUpdate's static-shape, runtime-bound, value-form, lowering, and traffic-analysis semantics are now part of `spec hir`.

## Verification
- `PATH=/usr/local/cuda-12.8/bin:$PATH timeout 1500 .venv/bin/python -m pytest tests/cli tests/ops -q -n 8 --tb=short --junitxml=/tmp/tilefoundry-pytest/run.xml` - 215 passed in 112.94s; JUnit: 0 skipped, 0 failures, 0 errors, including CUDA oracle cases.
- `PATH=/usr/local/cuda-12.8/bin:$PATH .venv/bin/tilefoundry spec hir cacheupdate` - printed the CacheUpdate section and all constraints.
- `PATH=/usr/local/cuda-12.8/bin:$PATH .venv/bin/tilefoundry tutorial migrate` - rendered the cache-form decision table with no unresolved fixture directives.
- `.venv/bin/ruff check src/tilefoundry/ir/hir/tensor/cache_update.py tests/cli/test_cli.py` - All checks passed.

## Risk
- No corpus model uses CacheUpdate yet; this change documents the existing operation without adding a model-level consumer.
