### PR TITLE
fix(cli): make every level self-describing

### DIFF
--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -9,10 +9,13 @@ reference, and what an authored program costs. Python authoring syntax and
 grammar productions remain in the [parser specification](./parser.md); the
 authored IR itself is the [HIR specification](./hir.md).
 
-Naming no command MUST print an overview rather than an error: a one-line
-project summary taken from installed package metadata, the usage form, the
-commands in the order the work is done, and the options. The summary MUST NOT
-be restated in the command surface, so there is one copy of it.
+Naming no command at any command level MUST print that level's overview rather
+than an error. The top-level overview MUST include a one-line project summary
+taken from installed package metadata, the usage form, the commands in the order
+the work is done, and the options. A command overview MUST include its
+description, usage form, subcommands, and options, and its description MUST be
+the one shown by the command above it. The project summary MUST NOT be restated
+in the command surface, so there is one copy of it.
 
 ## Commands
 
@@ -32,7 +35,7 @@ tilefoundry schedule model.py[:Module[.child_module...][.function]] --topology L
     [--dim NAME=EXTENT ...] [--solver-timeout SECONDS] [--solver-workers COUNT]
     [--first-plan]
 
-tilefoundry inspect capabilities model.py[:Module[.child_module...][.function]]
+tilefoundry inspect [capabilities [SOURCE]]
 ```
 
 `SOURCE` is a Python file followed optionally by
@@ -349,8 +352,12 @@ decided different things.
 
 ## Inspect Capabilities
 
-`inspect capabilities` resolves the target from the selected Module and prints
-the installed compact hardware capability record. It does not emit compiler
+`inspect capabilities` with no `SOURCE` lists the installed architecture and
+device documents, including each document's compatibility declarations, and the
+target names a Module may declare. It also states how to ask for one selection.
+
+With a `SOURCE`, it resolves the target from the selected Module and prints the
+installed compact hardware capability record. It does not emit compiler
 operation coverage. The record names both the architecture and the device
 document behind the target, each with its content digest, then every recorded
 fact by its path. A fact identifies its unit, the conditions it holds under,

--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -17,6 +17,9 @@ description, usage form, subcommands, and options, and its description MUST be
 the one shown by the command above it. The project summary MUST NOT be restated
 in the command surface, so there is one copy of it.
 
+A command usage error MUST print the error followed by that command's complete
+help to standard error and exit with status 2.
+
 ## Commands
 
 ```text

--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -28,8 +28,8 @@ tilefoundry models [NAME] [--source]
 tilefoundry spec [TOPIC [SECTION]]
 
 tilefoundry check TARGET (--inputs random | --inputs real --ckpt DIR | --input=PATH ...)
-    [--expected=PATH ...] --out PATH --fn F [bounds] [--fn F [bounds]] ...
-    [--out PATH ...] [--dim NAME=V[,V...] ...] [--json]
+    [--expected=PATH ...] --out OUTPUT --fn F [bounds] [--fn F [bounds]] ...
+    [--out OUTPUT ...] [--dim NAME=V[,V...] ...] [--json]
 
 tilefoundry analyze model.py[:Module[.child_module...][.function]]
     [--roofline] [--footprint] [--timeline] [--dim NAME=EXTENT ...]
@@ -82,6 +82,10 @@ when there is one, its reference, and says of every output whether it meets the
 bounds the caller stated.
 
 - constraints:
+  - Repeated `--input` values MUST bind the function's inputs in parameter
+    declaration order. Output names MUST come from return position: one tensor is
+    `output`; a tuple's tensors are `output[0]`, `output[1]`, and so on in return
+    order. These are positions, not names authored in the function.
   - Every output MUST be judged by at least one predicate the caller states, and
     there MUST be no default predicate and no default bound. A bound nobody can
     meet is worse than none: a single `f32`→`bf16` rounding already measures

--- a/src/tilefoundry/cli/__init__.py
+++ b/src/tilefoundry/cli/__init__.py
@@ -42,6 +42,13 @@ _INSPECT_COMMANDS = {
 }
 
 
+class _Parser(argparse.ArgumentParser):
+    def error(self, message: str) -> None:
+        self._print_message(f"{self.prog}: error: {message}\n\n", sys.stderr)
+        self.print_help(sys.stderr)
+        self.exit(2)
+
+
 def _project_summary() -> str:
     """The packaged one-line description of the project.
 
@@ -110,9 +117,9 @@ def _add_source_argument(
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(prog="tilefoundry")
+    parser = _Parser(prog="tilefoundry")
     # Not required: naming no command is how the overview is asked for.
-    commands = parser.add_subparsers(dest="command")
+    commands = parser.add_subparsers(dest="command", parser_class=_Parser)
 
     models = commands.add_parser("models", help=_COMMANDS["models"])
     models.add_argument(
@@ -211,7 +218,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
 
     inspect = commands.add_parser("inspect", help=_COMMANDS["inspect"])
-    inspect_commands = inspect.add_subparsers(dest="inspect_command")
+    inspect_commands = inspect.add_subparsers(dest="inspect_command", parser_class=_Parser)
     capabilities = inspect_commands.add_parser(
         "capabilities", help=_INSPECT_COMMANDS["capabilities"]
     )

--- a/src/tilefoundry/cli/__init__.py
+++ b/src/tilefoundry/cli/__init__.py
@@ -34,6 +34,13 @@ _COMMANDS = {
     "inspect": "inspect installed target facts",
 }
 
+_INSPECT_COMMANDS = {
+    "capabilities": (
+        "the facts a selection's target was composed from, or the installed "
+        "hardware documents there are"
+    ),
+}
+
 
 def _project_summary() -> str:
     """The packaged one-line description of the project.
@@ -66,11 +73,39 @@ def overview() -> str:
     )
 
 
-def _add_source_argument(parser: argparse.ArgumentParser) -> None:
+def _inspect_overview() -> str:
+    """What ``tilefoundry inspect`` prints without a subcommand."""
+    width = max(len(name) for name in _INSPECT_COMMANDS)
+    commands = "\n".join(
+        f"  {name:<{width}}  {description}"
+        for name, description in _INSPECT_COMMANDS.items()
+    )
+    return (
+        f"tilefoundry inspect — {_COMMANDS['inspect']}\n"
+        f"\n"
+        f"Usage:\n"
+        f"  tilefoundry inspect <command> [options]\n"
+        f"\n"
+        f"Commands:\n"
+        f"{commands}\n"
+        f"\n"
+        f"Options:\n"
+        f"  -h, --help  print this, or a command's own help after the command\n"
+    )
+
+
+def _add_source_argument(
+    parser: argparse.ArgumentParser, *, optional: bool = False
+) -> None:
+    arguments = {
+        "metavar": "SOURCE",
+        "help": "model.py[:Module[.child_module...][.function]]",
+    }
+    if optional:
+        arguments["nargs"] = "?"
     parser.add_argument(
         "source",
-        metavar="SOURCE",
-        help="model.py[:Module[.child_module...][.function]]",
+        **arguments,
     )
 
 
@@ -176,9 +211,11 @@ def build_parser() -> argparse.ArgumentParser:
     )
 
     inspect = commands.add_parser("inspect", help=_COMMANDS["inspect"])
-    inspect_commands = inspect.add_subparsers(dest="inspect_command", required=True)
-    capabilities = inspect_commands.add_parser("capabilities", help="print target capabilities")
-    _add_source_argument(capabilities)
+    inspect_commands = inspect.add_subparsers(dest="inspect_command")
+    capabilities = inspect_commands.add_parser(
+        "capabilities", help=_INSPECT_COMMANDS["capabilities"]
+    )
+    _add_source_argument(capabilities, optional=True)
 
     return parser
 
@@ -213,6 +250,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             print(f"tilefoundry check: error: {error}", file=sys.stderr)
             return 1
     if args.command == "inspect":
+        if args.inspect_command is None:
+            sys.stdout.write(_inspect_overview())
+            return 0
         try:
             return run_capabilities(args.source)
         except Exception as error:

--- a/src/tilefoundry/cli/check.py
+++ b/src/tilefoundry/cli/check.py
@@ -59,14 +59,24 @@ def add_arguments(parser: argparse.ArgumentParser) -> None:
         help="how activations and weights are made: random, or real from --ckpt",
     )
     parser.add_argument(
-        "--input", action="append", metavar="PATH", help="an activation file; repeat per input"
+        "--input",
+        action="append",
+        metavar="PATH",
+        help="an activation file; repeat per input, in the parameter's declared order",
     )
     parser.add_argument("--ckpt", metavar="DIR", help="a prepared checkpoint directory")
     parser.add_argument(
         "--expected", action="append", metavar="PATH", help="compare against this file"
     )
     parser.add_argument(
-        "--out", action=Ordered, metavar="PATH", help="which output the following --fn apply to"
+        "--out",
+        action=Ordered,
+        metavar="OUTPUT",
+        help=(
+            "which output the following --fn apply to: `output` when the function "
+            "returns one tensor, `output[0]` `output[1]` ... in return order when "
+            "it returns a tuple -- positions, not the names your code gives them"
+        ),
     )
     parser.add_argument(
         "--fn", action=Ordered, metavar="F", choices=sorted(PREDICATES), help="a comparison to make"

--- a/src/tilefoundry/cli/inspect.py
+++ b/src/tilefoundry/cli/inspect.py
@@ -7,8 +7,8 @@ import sys
 from tilefoundry.cli.source import load_authored_ir, selected_target
 from tilefoundry.ir.core.module import Module
 from tilefoundry.ir.hir.function import Function
-from tilefoundry.target import CudaTarget
-from tilefoundry.target.hardware import format_capabilities, hardware_documents
+from tilefoundry.target import _STRING_TARGETS, CudaTarget
+from tilefoundry.target.hardware import HARDWARE_SPECS, format_capabilities, hardware_documents
 
 
 def _grid_cta_count(ir: Module | Function) -> int | None:
@@ -22,8 +22,36 @@ def _grid_cta_count(ir: Module | Function) -> int | None:
     return next(iter(counts)) if len(counts) == 1 else None
 
 
-def run_capabilities(source: str) -> int:
+def _installed_capabilities() -> str:
+    """Describe the hardware documents and target names available to a module."""
+    documents = sorted(
+        (HARDWARE_SPECS.document(spec_id) for spec_id in HARDWARE_SPECS.installed_ids()),
+        key=lambda document: (document.kind, document.id),
+    )
+    lines = ["Installed hardware documents:"]
+    for document in documents:
+        compatibility = ""
+        if document.compatibility:
+            compatible_kind = "architectures" if document.kind == "device" else "devices"
+            compatibility = f"     {compatible_kind}: {', '.join(document.compatibility)}"
+        lines.append(
+            f"  {document.kind:<12}  {document.id:<17}{document.schema}{compatibility}"
+        )
+    lines += [
+        "",
+        f"Targets a module may declare: {', '.join(sorted(_STRING_TARGETS))}",
+        "",
+        "Name a SOURCE for the facts of the target that selection declares:",
+        "  tilefoundry inspect capabilities model.py:Model",
+    ]
+    return "\n".join(lines)
+
+
+def run_capabilities(source: str | None) -> int:
     """Print the capabilities of the target the selection declares."""
+    if source is None:
+        sys.stdout.write(_installed_capabilities() + "\n")
+        return 0
     ir = load_authored_ir(source)
     target = selected_target(ir)
     if not isinstance(target, CudaTarget):

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -223,6 +223,30 @@ def test_module_without_an_entry_names_its_functions_and_rule(tmp_path, capsys) 
     assert "The rule: tilefoundry spec core-ir default-step" in error
 
 
+def test_inspect_describes_its_commands(capsys) -> None:
+    assert cli.main(["inspect"]) == 0
+
+    captured = capsys.readouterr()
+    assert captured.out.startswith("tilefoundry inspect — inspect installed target facts\n")
+    assert "Usage:\n  tilefoundry inspect <command> [options]\n" in captured.out
+    assert "capabilities  the facts a selection's target was composed from" in captured.out
+    assert captured.err == ""
+
+
+def test_inspect_capabilities_lists_installed_documents(capsys) -> None:
+    assert cli.main(["inspect", "capabilities"]) == 0
+
+    captured = capsys.readouterr()
+    assert captured.out.startswith("Installed hardware documents:\n")
+    for document in ("apple.amx", "apple.m2_pro", "nvidia.sm90", "nvidia.h200_sxm"):
+        assert document in captured.out
+    assert "architectures: apple.amx" in captured.out
+    assert "architectures: nvidia.sm90" in captured.out
+    assert "Targets a module may declare: amx, cpu, cuda" in captured.out
+    assert "tilefoundry inspect capabilities model.py:Model" in captured.out
+    assert captured.err == ""
+
+
 def test_inspect_capabilities_is_compact(tmp_path, capsys) -> None:
     path = _write_module(tmp_path)
     assert cli.main(["inspect", "capabilities", f"{path}:Model.main"]) == 0

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -247,6 +247,21 @@ def test_inspect_capabilities_lists_installed_documents(capsys) -> None:
     assert captured.err == ""
 
 
+def test_usage_errors_include_the_command_help(capsys) -> None:
+    with pytest.raises(SystemExit) as error:
+        cli.main(["analyze"])
+
+    assert error.value.code == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err.startswith(
+        "tilefoundry analyze: error: the following arguments are required: SOURCE\n\n"
+    )
+    assert "usage: tilefoundry analyze" in captured.err
+    assert "SOURCE" in captured.err
+    assert "model.py[:Module[.child_module...][.function]]" in captured.err
+
+
 def test_inspect_capabilities_is_compact(tmp_path, capsys) -> None:
     path = _write_module(tmp_path)
     assert cli.main(["inspect", "capabilities", f"{path}:Model.main"]) == 0

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -262,6 +262,21 @@ def test_usage_errors_include_the_command_help(capsys) -> None:
     assert "model.py[:Module[.child_module...][.function]]" in captured.err
 
 
+def test_check_help_explains_input_and_output_positions(capsys) -> None:
+    with pytest.raises(SystemExit) as error:
+        cli.main(["check", "--help"])
+
+    assert error.value.code == 0
+    captured = capsys.readouterr()
+    assert "--input PATH" in captured.out
+    assert "parameter's declared order" in captured.out
+    assert "--out OUTPUT" in captured.out
+    assert "`output[0]`" in captured.out
+    assert "return order" in captured.out
+    assert "positions, not the names your code gives them" in captured.out
+    assert captured.err == ""
+
+
 def test_inspect_capabilities_is_compact(tmp_path, capsys) -> None:
     path = _write_module(tmp_path)
     assert cli.main(["inspect", "capabilities", f"{path}:Model.main"]) == 0


### PR DESCRIPTION
## Why
- Nested CLI levels did not consistently explain their available commands, usage errors only showed terse usage, and `check` did not document how inputs and outputs are named.

## What
- Add overview and installed-target discovery for `inspect` and `inspect capabilities`.
- Include each command's full help after an argument error while preserving stderr and exit status 2.
- Document and test declaration-order inputs and return-position outputs in `check --help`.

## Contract
- Empty command levels are inquiries that return an overview on stdout; argument errors remain exit status 2 on stderr with command-local help.
- `check` input values bind in parameter declaration order; outputs are `output` or tuple return positions such as `output[0]`.

## Verification
- `.venv/bin/python -c "import torch; print(torch.cuda.is_available(), torch.cuda.device_count())"` — `True 5`
- `.venv/bin/ruff check src/tilefoundry/cli/__init__.py src/tilefoundry/cli/inspect.py src/tilefoundry/cli/check.py tests/cli/test_cli.py` — `All checks passed!`
- `TEST_REPORT_DIR="${RUNNER_TEMP:-/tmp}/tilefoundry-pytest/plan11-gpu-verify-20260731"; mkdir -p "$TEST_REPORT_DIR"; PATH=/usr/local/cuda-12.8/bin:$PATH timeout 1500 .venv/bin/python -m pytest tests/cli tests/runtime -q -n 8 --tb=short --junitxml="$TEST_REPORT_DIR/run.xml" >"$TEST_REPORT_DIR/run.txt" 2>&1` — `65 passed in 82.58s`

## Risk
- None.
