### PR TITLE
docs(target): make target rules askable

### DIFF
--- a/docs/spec/core-ir.md
+++ b/docs/spec/core-ir.md
@@ -63,15 +63,6 @@ class Module:
     another owner MUST NOT change what the first owner's subtree resolves.
 
 - `parse_module` (see [parser §1](./parser.md)) returns a `Module`.
-- `entry` names this Module's default step — `tilefoundry.lower(...)` and the
-  emitter both start there. Other functions only enter the output if
-  they are reachable from `entry`.
-- `entry` is optional. Supplied, it MUST be the `name` of a function present in
-  `functions`, and the verifier checks this. Omitted (`None`), the Module has no
-  default step: `entry_function()` and a bare call MUST be refused saying so, and
-  every function is reached by name instead. A Module that composes children in an
-  orchestration method has no single step to nominate, and naming one anyway would
-  claim a default the execution path never takes.
 - A bare `@func` / `@prim_func` becomes an implicit single-function
   `Module` whose `entry` is set to that function. A function that declares
   execution context of its own is therefore already a `Module`.
@@ -85,10 +76,6 @@ class Module:
 *declares*, not what it resolves to; resolution is lexical over the owner
 chain and is not copied onto each Module or Function.
 
-- `resolve_target()` returns the nearest declaration at or above this Module,
-  and MUST fail when no owner in the chain declares one. Only the outermost
-  Module declares a `Target`: a child that declares its own MUST be rejected
-  when it is attached, so one tree has exactly one hardware declaration.
 - `topologies = None` declares nothing and inherits the owner's hierarchy;
   `topologies = ()` declares an explicitly topology-free domain; an explicit
   tuple replaces the inherited hierarchy whole rather than extending it. A
@@ -130,6 +117,41 @@ chain and is not copied onto each Module or Function.
   base only during authoring, before the base enters a `Module`; once
   sealed, adding a variant is an error
   ([hir.md §1.1](./hir.md#11-function)).
+
+#### Target inheritance
+
+A Module's target declaration belongs to its execution domain and is resolved
+through its owner chain.
+
+- constraints:
+  - `resolve_target()` MUST return this Module's declared target when it has
+    one; otherwise it MUST return the nearest target declared by an owner.
+  - Only the outermost Module of a tree MAY declare a target. A child Module
+    that declares a target of its own MUST be refused when it is attached, and
+    MUST inherit its owner's target instead.
+  - A Module with no declaration anywhere in its owner chain MUST be refused
+    when its target is resolved. Its root Module MUST declare one, for example
+    with `target="cuda"`.
+  - A Module reused as an owned child and as an independently analysed root
+    declares a target only in the latter role.
+
+#### Default step
+
+A Module's optional `entry` determines whether it exposes a default execution
+step.
+
+- constraints:
+  - When `entry` is present, it MUST name a function in `functions`.
+    `entry_function()` MUST return that function, and `tilefoundry.lower(...)`
+    and the emitter MUST start there. Other functions enter the output only when
+    reachable from `entry`.
+  - When `entry` is omitted (`None`), the Module MUST have no default step.
+    `entry_function()` and a bare call MUST be refused, naming the Module's
+    functions and explaining that one is selected with `lookup('<name>')`.
+    Each function remains reachable by name. A Module that composes children in
+    an orchestration method has no single step to nominate.
+  - A bare `@func` / `@prim_func` MUST become an implicit single-function
+    Module whose `entry` names that function.
 
 ### 1.1 Function access
 

--- a/docs/spec/target.md
+++ b/docs/spec/target.md
@@ -184,11 +184,6 @@ class CudaTarget(Target):
     supplied directly carries no document, so it has no ID or digest and is
     exempt from that check: it is a distinct hardware value rather than a
     revision of an installed one.
-  - `topology_levels` MUST be `("cta", "thread")` for this single-device
-    target. Warp/lane/warpgroup structure belongs in thread mesh layouts.
-  - `topology_limit("cta")` MUST be `None`: the CUDA grid is a launch shape
-    rather than an SM allocation, so its static extent is unbounded here.
-    `topology_limit("thread")` MUST equal `architecture.max_threads_per_cta`.
   - CUDA MUST register one scheduling algorithm per level it schedules, and both
     at the exact `(CudaTarget, level)` pair
     ([schedule §1.1](./schedule.md#11-algorithm-registration)): the pipeline
@@ -210,6 +205,26 @@ class CudaTarget(Target):
     `ScheduleOptions` ([schedule §2.1](./schedule.md#21-scheduleoptions)); it MUST
     NOT be projected here, because a Facts value that already encodes a policy
     cannot be read as what the hardware is.
+
+#### Topology levels
+
+A target's topology levels define the names a program may declare. The program
+hierarchy stops at those levels; warp, lane, and warpgroup structure belongs in
+thread mesh layouts.
+
+- constraints:
+  - `CudaTarget.topology_levels` MUST be `("cta", "thread")` for this
+    single-device target.
+  - A declared program topology name MUST be one of its target's
+    `topology_levels`. A name outside that set MUST be refused naming the levels
+    the target declares.
+  - `topology_limit("cta")` MUST be `None`: the CUDA grid is a launch shape
+    rather than an SM allocation, so its static extent is unbounded here.
+    `topology_limit("thread")` MUST equal `architecture.max_threads_per_cta`.
+  - Only `cta` MAY have a launch-provided (`None`) extent; every other level
+    MUST have a static extent.
+  - A launch-provided level MUST NOT be scheduled, because scheduling requires
+    its static extent.
   - Static declared topology extents MUST be positive integers within their
     target resource limits. `Topology("cta", None)` MUST remain valid for the
     handwritten dynamic-launch compile path.
@@ -237,16 +252,9 @@ class CpuTarget(Target):
   `resolve_target("amx")` MUST return a default `AmxTarget`,
   `resolve_target("cpu")` MUST return a `CpuTarget`, and a Target object MUST
   pass through unchanged.
-- A `Target` MUST be declared by the `Module` that owns the functions running
-  on it, never by an authored HIR `Function`. Analyze, Schedule, and compile
-  MUST obtain it through `Module.resolve_target()`
-  ([core-ir §1](./core-ir.md#1-module)).
-- Only the outermost `Module` of a tree declares a `Target`; every Module
-  below it inherits that one declaration and MUST NOT declare its own. A
-  Module that is reused both as an owned child and as an independently
-  analysed root therefore declares its Target only in the second role.
-- `Module.resolve_target()` MUST fail when no Module in the owner chain
-  declares a Target.
+- A `Target` belongs to a `Module` rather than an authored HIR `Function`.
+  Target inheritance and its declaration rules are defined by
+  [core-ir `target-inheritance`](./core-ir.md#target-inheritance).
 - Analyze and Schedule MUST obtain the Target from `Module.resolve_target()`
   and from nowhere else. Neither accepts a bare `Function`, and neither
   resolves an undeclared Target to a default: both report hardware-dependent

--- a/src/tilefoundry/ir/core/module.py
+++ b/src/tilefoundry/ir/core/module.py
@@ -109,7 +109,8 @@ class Module:
                 raise ValueError(
                     f"Module {self.name!r}: child module {child.name!r} declares "
                     f"its own target {child.target!r}; only the root module "
-                    f"declares a target and children inherit it"
+                    "declares a target and children inherit it. The rule: "
+                    "tilefoundry spec core-ir target-inheritance"
                 )
         # Own the subtree rather than sharing it. A child links back to its
         # owner to resolve inherited context, so one child value placed under
@@ -129,8 +130,10 @@ class Module:
         return ".".join(reversed(names))
 
     def resolve_target(self) -> Target:
-        """The effective Target: this Module's declaration, else the nearest
-        owner's. Raises when no owner in the chain declares one."""
+        """Resolve this Module's owner-chain target lookup.
+
+        See docs/spec/core-ir.md § Target inheritance.
+        """
         node: "Module | None" = self
         while node is not None:
             if node.target is not None:
@@ -138,7 +141,8 @@ class Module:
             node = getattr(node, "_parent", None)
         raise ValueError(
             f"Module {self._owner_path()!r}: no target is declared by this "
-            f"module or any of its owners; the root module must declare one"
+            "module or any of its owners; declare target=\"cuda\" on the root "
+            "module. The rule: tilefoundry spec core-ir target-inheritance"
         )
 
     def effective_topologies(self) -> tuple[Topology, ...]:
@@ -275,10 +279,12 @@ class Module:
 
     def entry_function(self) -> ModuleFunction:
         if self.entry is None:
+            names = ", ".join(fn.name for fn in self.functions) or "no functions"
             raise ValueError(
                 f"Module {self.name!r} declares no entry, so it has no default "
-                f"step; name the function to use -- lookup('<name>') for the node, "
-                f"or <module>.<name>(...) to run it"
+                f"step. It declares {names}; name the function to use -- "
+                "lookup('<name>') for the node, or <module>.<name>(...) to run "
+                "it. The rule: tilefoundry spec core-ir default-step"
             )
         matches = self.function_named(self.entry)
         if not matches:

--- a/src/tilefoundry/ir/types/shard/mesh.py
+++ b/src/tilefoundry/ir/types/shard/mesh.py
@@ -5,16 +5,14 @@ from dataclasses import dataclass
 from tilefoundry.ir.types.shape_dim import ShapeDim
 from tilefoundry.ir.types.shard.layout import ComposedLayout, Layout
 
-# A ``cta`` topology may declare ``size=None`` to mean its extent is provided by
-# the host launch (a runtime grid); only that topology kind supports it.
+# The local validation exception is defined by docs/spec/target.md § Topology levels.
 _LAUNCH_PROVIDED_TOPOLOGY = "cta"
 
 
 @dataclass(frozen=True)
 class Topology:
     name: str
-    # ``int`` for a static extent, a scalar ``ShapeDim`` expression, or ``None``
-    # for a launch-provided (dynamic) ``cta`` extent.
+    # ``None`` reaches the local launch-provided extent check.
     size: "ShapeDim | None"
 
     def __post_init__(self) -> None:

--- a/src/tilefoundry/ir/types/shard/mesh.py
+++ b/src/tilefoundry/ir/types/shard/mesh.py
@@ -19,7 +19,8 @@ class Topology:
         if self.size is None and self.name != _LAUNCH_PROVIDED_TOPOLOGY:
             raise ValueError(
                 f"Topology {self.name!r}: only a {_LAUNCH_PROVIDED_TOPOLOGY!r} "
-                f"topology may have a launch-provided (None) extent"
+                "topology may have a launch-provided (None) extent. The rule: "
+                "tilefoundry spec target topology-levels"
             )
 
 

--- a/src/tilefoundry/schedule/api.py
+++ b/src/tilefoundry/schedule/api.py
@@ -49,12 +49,9 @@ class ScheduleResult:
 
 
 def _topology(module: Module, name: str) -> Topology:
-    """The one level of *module*'s hierarchy called *name*.
+    """Return one named level after the local scheduling preconditions.
 
-    A level whose extent arrives at launch is rejected: an algorithm places work
-    across a level by counting it, and there is nothing to count yet. What comes
-    back is the level the program declared, not a normalized copy of it, so the
-    caller sees its own hierarchy rather than one this layer rewrote.
+    The launch-extent rule is defined by docs/spec/target.md § Topology levels.
     """
     if not isinstance(name, str) or not name:
         raise ScheduleError(
@@ -69,7 +66,7 @@ def _topology(module: Module, name: str) -> Topology:
         raise ScheduleError(
             f"schedule: topology {name!r} has extent {level.size!r}, which is "
             "not known until launch; scheduling a level requires its static "
-            "extent"
+            "extent. The rule: tilefoundry spec target topology-levels"
         )
     if extent < 1:
         raise ScheduleError(

--- a/src/tilefoundry/target/__init__.py
+++ b/src/tilefoundry/target/__init__.py
@@ -30,7 +30,10 @@ def default_target() -> Target:
 
 
 def validate_cuda_topology_levels(names) -> None:
-    """Validate topology names against the default CUDA target."""
+    """Validate names at the CUDA lowering boundary.
+
+    See docs/spec/target.md § Topology levels.
+    """
     target = CudaTarget()
     for name in names:
         if name not in target.topology_levels:

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -160,6 +160,40 @@ def test_spec_answers_the_target_and_default_step_rules(
     assert expected in capsys.readouterr().out
 
 
+def test_schedule_refusal_of_a_launch_provided_level_points_to_the_spec(
+    tmp_path, capsys
+) -> None:
+    """A schedule refusal points to the rule that distinguishes launch shape."""
+    path = _write_module(
+        tmp_path,
+        _VALID_MODULE.replace(
+            'Topology("cta", 168)', 'Topology("cta", None)', 1
+        ),
+    )
+
+    assert cli.main(["schedule", str(path), "--topology", "cta"]) == 1
+
+    error = capsys.readouterr().err
+    assert "not known until launch" in error
+    assert "The rule: tilefoundry spec target topology-levels" in error
+
+
+def test_module_without_an_entry_names_its_functions_and_rule(tmp_path, capsys) -> None:
+    """An absent default step names both the callable choices and its contract."""
+    path = _write_module(
+        tmp_path,
+        _VALID_MODULE.replace(
+            '@module(entry="main", target=CudaTarget())', '@module(target=CudaTarget())'
+        ),
+    )
+
+    assert cli.main(["schedule", str(path), "--topology", "cta"]) == 1
+
+    error = capsys.readouterr().err
+    assert "declares no entry, so it has no default step. It declares main" in error
+    assert "The rule: tilefoundry spec core-ir default-step" in error
+
+
 def test_inspect_capabilities_is_compact(tmp_path, capsys) -> None:
     path = _write_module(tmp_path)
     assert cli.main(["inspect", "capabilities", f"{path}:Model.main"]) == 0

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -143,6 +143,23 @@ def test_spec_rejects_a_section_that_does_not_exist(capsys) -> None:
     assert "silu" in error
 
 
+@pytest.mark.parametrize(
+    ("topic", "section", "expected"),
+    (
+        ("target", "topology-levels", "Only `cta` MAY have a launch-provided"),
+        ("core-ir", "target-inheritance", 'with `target="cuda"`'),
+        ("core-ir", "default-step", "MUST have no default step"),
+    ),
+)
+def test_spec_answers_the_target_and_default_step_rules(
+    topic, section, expected, capsys
+) -> None:
+    """The rules' stable slug keys are directly askable."""
+    assert cli.main(["spec", topic, section]) == 0
+
+    assert expected in capsys.readouterr().out
+
+
 def test_inspect_capabilities_is_compact(tmp_path, capsys) -> None:
     path = _write_module(tmp_path)
     assert cli.main(["inspect", "capabilities", f"{path}:Model.main"]) == 0


### PR DESCRIPTION
## Why
- Topology, target-inheritance, and default-step refusals required authors to inspect source code before they could correct their module.

## What
- Publish the three rules under stable, askable spec keys.
- Point the corresponding topology, target, and default-step refusals at those keys.
- Name a module's functions when no default step is declared.

## Contract
- `tilefoundry spec target topology-levels`, `tilefoundry spec core-ir target-inheritance`, and `tilefoundry spec core-ir default-step` are stable rule entry points.

## Verification
- `.venv/bin/python -c "import torch; print(torch.cuda.is_available(), torch.cuda.device_count())"` - `True 5`
- `.venv/bin/ruff check src/tilefoundry/ir/core/module.py src/tilefoundry/ir/types/shard/mesh.py src/tilefoundry/schedule/api.py tests/cli/test_cli.py` - All checks passed.
- `PATH=/usr/local/cuda-12.8/bin:$PATH timeout 1500 .venv/bin/python -m pytest tests/cli tests/schedule -q -n 8 --tb=short --junitxml=/tmp/tilefoundry-pytest/m1.xml` - 91 passed in 132.96s.
- `PATH=/usr/local/cuda-12.8/bin:$PATH timeout 1500 .venv/bin/python -m pytest tests/ -q -n 8 --tb=short --junitxml=/tmp/tilefoundry-pytest/full.xml` - 1081 passed, 5 skipped, 1 xfailed in 305.04s.

## Risk
- None.
