### PR TITLE
fix(cli): load authored sources as modules

### DIFF
--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -57,6 +57,11 @@ other mechanism for it. What `models <name> --source` prints stays the reference
 compare against, and it stays intact because an installation is not where anybody
 edits — no verb enforces that, and none should.
 
+A command MUST load `SOURCE` as a Python module. While loading it, the directory
+containing `SOURCE` MUST be first on the Python module search path, so a file beside
+it MAY be imported by its module name. A command MUST capture and suppress standard
+output that `SOURCE` emits while loading.
+
 `check` reads the same `SOURCE` shape and one thing more: its selector MAY name a
 runtime twin instead of an authored Module. A twin generated from an authored
 Module states which Module that is ([runtime §1.1](./runtime.md#11-runtimemodule)),

--- a/src/tilefoundry/cli/source.py
+++ b/src/tilefoundry/cli/source.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import contextlib
+import importlib.util
 import io
-import runpy
+import sys
 from pathlib import Path
 from typing import Sequence
 
@@ -83,16 +84,50 @@ def select_ir(namespace: dict[str, object], selector: str | None) -> Module:
 
 
 def load_namespace(source: str) -> tuple[dict[str, object], str | None]:
-    """Execute one authored file, returning what it defined and its selector.
+    """Load one authored file, returning what it defined and its selector.
 
-    Executing it is how an authored file produces anything at all, so its own
+    Loading it is how an authored file produces anything at all, so its own
     output is captured: what the command prints is its answer, not the file's.
     """
     path, selector = _split_source(source)
-    captured_stdout = io.StringIO()
-    with contextlib.redirect_stdout(captured_stdout):
-        namespace = runpy.run_path(str(path))
-    return namespace, selector
+    directory = str(path.parent)
+    sibling_names = {
+        child.stem for child in path.parent.glob("*.py")
+    } | {
+        child.name
+        for child in path.parent.iterdir()
+        if child.is_dir() and (child / "__init__.py").is_file()
+    }
+    previous_modules = {
+        name: module
+        for name, module in tuple(sys.modules.items())
+        if name.partition(".")[0] in sibling_names
+    }
+    sys.path.insert(0, directory)
+    try:
+        for name in previous_modules:
+            del sys.modules[name]
+        spec = importlib.util.spec_from_file_location(path.stem, path)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"could not load source module {path}")
+        module = importlib.util.module_from_spec(spec)
+        captured_stdout = io.StringIO()
+        with contextlib.redirect_stdout(captured_stdout):
+            try:
+                spec.loader.exec_module(module)
+            except ModuleNotFoundError as error:
+                raise ValueError(
+                    f"{path.name} imports {error.name!r}, which is not importable.\n"
+                    f"  sys.path got: {directory} (the file's own directory)\n"
+                    "  a sibling module must sit in that directory"
+                ) from None
+        return vars(module), selector
+    finally:
+        for name in tuple(sys.modules):
+            if name.partition(".")[0] in sibling_names:
+                del sys.modules[name]
+        sys.modules.update(previous_modules)
+        sys.path.remove(directory)
 
 
 def load_authored_ir(source: str) -> Module:

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import sys
 import textwrap
 from pathlib import Path
 
@@ -30,6 +31,23 @@ def _write_module(tmp_path, source: str = _VALID_MODULE):
     path = tmp_path / "model.py"
     path.write_text(textwrap.dedent(source), encoding="utf-8")
     return path
+
+
+def _write_sibling_module(tmp_path: Path, directory: str, name: str) -> Path:
+    source = tmp_path / directory
+    source.mkdir()
+    (source / "model.py").write_text(
+        _VALID_MODULE.replace("class Model:", f"class {name}:"), encoding="utf-8"
+    )
+    runtime = source / "runtime_model.py"
+    runtime.write_text(
+        f"from model import {name}\n"
+        "if __spec__ is None:\n"
+        "    raise RuntimeError('source was not loaded as a module')\n"
+        "print('source output')\n",
+        encoding="utf-8",
+    )
+    return runtime
 
 
 def test_models_separates_oracles_from_everything_else(capsys) -> None:
@@ -274,6 +292,35 @@ def test_analyze_failure_reports_line_variable_and_reason(tmp_path, capsys) -> N
     assert f"{path}:9:" in captured.err
     assert "variable 'wrong'" in captured.err
     assert "dtype mismatch" in captured.err
+
+
+def test_analyze_loads_sibling_modules_without_leaking_paths_or_output(
+    tmp_path, capsys
+) -> None:
+    first = _write_sibling_module(tmp_path, "first", "First")
+    second = _write_sibling_module(tmp_path, "second", "Second")
+    before = sys.path.copy()
+
+    assert cli.main(["analyze", f"{first}:First", "--memory"]) == 0
+    first_output = capsys.readouterr().out
+    assert "source output" not in first_output
+    assert sys.path == before
+
+    assert cli.main(["analyze", f"{second}:Second", "--memory"]) == 0
+    second_output = capsys.readouterr().out
+    assert "source output" not in second_output
+    assert sys.path == before
+
+
+def test_analyze_names_the_source_directory_when_a_sibling_is_missing(tmp_path, capsys) -> None:
+    source = tmp_path / "runtime_model.py"
+    source.write_text("from model import Model\n", encoding="utf-8")
+
+    assert cli.main(["analyze", str(source), "--memory"]) == 1
+
+    error = capsys.readouterr().err
+    assert str(tmp_path) in error
+    assert "a sibling module must sit in that directory" in error
 
 
 def test_parse_dims_reads_one_extent_per_dimension() -> None:

--- a/tests/integration/installed_wheel.py
+++ b/tests/integration/installed_wheel.py
@@ -44,16 +44,15 @@ _SMOKES = (
     (("check", "--help"), "--dim"),
 )
 
-# A file the installation never shipped: one authored function and its twin, which
-# is the least that reaches `check` at all.
-_MINE = '''\
+# Files the installation never shipped: one authored function and a twin in a
+# sibling module, which is the least that reaches `check` at all.
+_MINE_MODEL = '''\
 from tilefoundry import module
 from tilefoundry.dsl import Mesh, Tensor, Topology, func, tf
-from tilefoundry.runtime import runtime_func, runtime_module
-from tilefoundry.target import CudaTarget
+from tilefoundry.target import CpuTarget
 
 
-@module(entry="main", target=CudaTarget())
+@module(entry="main", target=CpuTarget())
 class Mine:
     topologies = (Topology("cta", 168),)
 
@@ -62,6 +61,12 @@ class Mine:
         with Mesh(Topology("cta", 168), (168,), ("block",)) as cta:
             local = tf.reshard(x, (168 @ cta.block,), "rmem")
             return tf.reshard(tf.square(local), (168 @ cta.block,), "gmem")
+'''
+
+
+_MINE_RUNTIME = '''\
+from model import Mine
+from tilefoundry.runtime import runtime_func, runtime_module
 
 
 @runtime_module(Mine)
@@ -146,19 +151,22 @@ def smoke(command: Path, outside: Path) -> None:
 
 
 def own_file(command: Path, work: Path) -> None:
-    """`check` compares a Module in a file the installation never shipped."""
-    source = work / "mine.py"
-    source.write_text(_MINE, encoding="utf-8")
+    """`check` compares Modules in files the installation never shipped."""
+    source = work / "mine"
+    source.mkdir(exist_ok=True)
+    (source / "model.py").write_text(_MINE_MODEL, encoding="utf-8")
+    runtime = source / "runtime_model.py"
+    runtime.write_text(_MINE_RUNTIME, encoding="utf-8")
     printed = _run(
         [
-            str(command), "check", f"{source}:MineTwin.main", "--inputs", "random",
+            str(command), "check", f"{runtime}:MineTwin.main", "--inputs", "random",
             "--out", "output", "--fn", "allclose", "--atol", "1e-6", "--rtol", "1e-6",
         ],
         work,
     )
     if "reference: evaluator on Mine.main" not in printed or "PASS" not in printed:
         raise SystemExit(f"`check` on a file of one's own did not pass:\n{printed}")
-    print(f"  tilefoundry check {source.name}:MineTwin.main: PASS")
+    print(f"  tilefoundry check {runtime.name}:MineTwin.main: PASS")
 
 
 def main(argv: list[str] | None = None) -> int:


### PR DESCRIPTION
## Why
- Split authored sources could not import a sibling `model.py` when a CLI command loaded `runtime_model.py`, so an authored module and its runtime twin could not live in separate files.

## What
- Load `SOURCE` with `importlib` as a module, temporarily putting its directory first on `sys.path` and restoring path and sibling-module state afterwards.
- Explain missing sibling imports, document the SOURCE loading contract, and cover the two-file workflow in CLI and installed-wheel smoke tests.

## Contract
- A SOURCE file is loaded as a Python module; its directory is first on the module search path while loading, emitted stdout is suppressed, and sibling imports by module name are supported.
- Package-relative imports remain outside the SOURCE contract.

## Verification
- `PATH=/usr/local/cuda-12.8/bin:$PATH timeout 1500 .venv/bin/python -m pytest tests/ -q -n 8 --tb=short --junitxml=/tmp/tilefoundry-pytest/post-rebase-full.xml` - `1017 passed in 444.44s`; JUnit has no skips
- `PATH=/usr/local/cuda-12.8/bin:$PATH timeout 1500 .venv/bin/python -m pip wheel . --no-deps --no-build-isolation --wheel-dir /tmp/tilefoundry-wheel-post-rebase.CLIFMa/wheel` - `Successfully built tilefoundry`
- `PATH=/usr/local/cuda-12.8/bin:$PATH timeout 1500 .venv/bin/python tests/integration/installed_wheel.py --wheel /tmp/tilefoundry-wheel-post-rebase.CLIFMa/wheel --venv /tmp/tilefoundry-wheel-post-rebase.CLIFMa/venv` - installed-console two-file `check`: `PASS`
- `PATH=/usr/local/cuda-12.8/bin:$PATH timeout 1500 /tmp/tilefoundry-wheel-post-rebase.CLIFMa/venv/bin/python tests/integration/qwen3_1_7b_l3.py --venv /tmp/tilefoundry-wheel-post-rebase.CLIFMa/venv --work /tmp/tilefoundry-wheel-post-rebase.CLIFMa/l3 --checkpoint /data3/shared/qihang.zheng/models/Qwen3-1.7B` - `16 greedy steps agree` with the Hugging Face oracle
- `PATH=/data3/shared/qihang.zheng/conda-envs/tilefoundry-dev/bin:/usr/local/cuda-12.8/bin:$PATH timeout 1500 .venv/bin/pre-commit run --all-files` - all hooks passed

## Risk
- The loader intentionally supports sibling absolute imports, not package-relative imports.
