### PR TITLE
fix(analysis): account traffic per operand

### DIFF
--- a/docs/spec/analysis.md
+++ b/docs/spec/analysis.md
@@ -343,12 +343,12 @@ class TrafficBytes:
     """Read and write byte counts for one memory hierarchy level.
 
     Attributes:
-        read_bytes: attribute; Bytes read at this level.
-        write_bytes: attribute; Bytes written at this level.
+        read: attribute; Bytes read at this level.
+        write: attribute; Bytes written at this level.
     """
 
-    read_bytes: int = 0
-    write_bytes: int = 0
+    read: int = 0
+    write: int = 0
 
 class ComputeCostMetadata(IRMetadata):
     """One Call's logical work, as the authored program states it.
@@ -357,11 +357,13 @@ class ComputeCostMetadata(IRMetadata):
         flops: attribute; Flop count per compute DType name, sorted by name.
         traffic: attribute; TrafficBytes per storage level name.
         execution_count: attribute; How many times the call runs.
+        operands: attribute; TrafficBytes per operand, positional against (*call.args, call); present only for a direct primitive call.
     """
 
     flops: tuple[tuple[str, int], ...] = ()
     traffic: tuple[tuple[str, TrafficBytes], ...] = ()
     execution_count: int = 1
+    operands: tuple[TrafficBytes, ...] = ()
 
 class LevelFootprint:
     """How much of one memory level a function needs at its peak.
@@ -464,7 +466,22 @@ class TimelineMetadata(IRMetadata):
   - The execution count MUST be the product of the execution-topology extents the
     call's value meshes carry and the owning Module declares. Conflicting extents
     for one topology name MUST raise rather than be reconciled.
-  - A call into another `Function` MUST report that function's totals.
+  - `operands` MUST be positional against `(*call.args, call)`: one entry per
+    argument in order, then the result. Each entry MUST be the amount the op's
+    cost evaluator reported for that operand, unmodified. Two operands MAY name
+    the same value; the position is what distinguishes them.
+  - Which level an operand's bytes are charged at MUST come from that operand's
+    Type. Where the Type occupies one level, the per-level `traffic` is those
+    same amounts regrouped. Where it spans several, the per-level `traffic` MUST
+    charge the whole Type at each of them, in the directions the op reported
+    movement in: no operand-level count states how the bytes divide, so the
+    aggregate takes a conservative bound while the operand entry keeps the
+    reported amount. The two MUST NOT be assumed equal in general.
+  - Operand attribution is defined for a call on a primitive op only. A call
+    into another `Function` MUST report that function's totals and MUST record
+    no operands: that traffic is an aggregate over the callee's own operands,
+    and no breakdown of this call's arguments describes it. A rendering MUST
+    omit the operand breakdown for such a call rather than emit it empty.
   - `MemoryMetadata` MUST be attached per `Function`: a peak is a property of the
     whole function's live ranges and belongs to no single expression.
   - Parameters MUST be resident from the start of the value order. A parameter

--- a/docs/spec/visitor-registry.md
+++ b/docs/spec/visitor-registry.md
@@ -492,9 +492,20 @@ candidate Types through `CostContext`; it does not select hardware resources.
 
 ```python
 @dataclass
+class TrafficBytes:
+    read: int = 0
+    write: int = 0
+
+    @property
+    def total_bytes(self) -> int: ...
+
+@dataclass
 class Cost:
     flops: Mapping[DType, int]
-    bytes: int
+    traffic: tuple[TrafficBytes, ...]
+
+    @property
+    def bytes(self) -> int: ...
 
 class CostContext(TypeInferContext):
     selected_types: Mapping[int, IRType] = {}
@@ -517,8 +528,20 @@ class CostEvaluator(ExprVisitor[Cost]): ...
     and its operand types, so it is the same on every backend; registering them
     from a target package would make one backend's presence decide whether any
     consumer can cost a program at all.
-  - `flops` MUST group leaf-local logical work by compute `DType`, and `bytes`
-    MUST be one scalar logical byte count.
+  - `flops` MUST group leaf-local logical work by compute `DType`.
+  - `traffic` MUST carry exactly one `TrafficBytes` per operand of the call, in
+    argument order with the result last, so an Op that only touches part of an
+    input says so where it knows it. `bytes` is derived: every operand's traffic
+    in either direction.
+  - an evaluator MUST NOT name a memory level. Which level an operand's bytes
+    move at follows from that operand's Type, and is the consumer's to read;
+    reporting a length that disagrees with the call's operand count MUST fail
+    naming the call and both counts.
+  - an operand whose Type spans several levels admits no split of one reported
+    count between them, so a consumer MAY charge that operand's whole Type at
+    each level instead. What the evaluator reported stands as the operand's own
+    amount; a per-level total is therefore not always the sum of the amounts
+    reported here.
   - `CostContext.local_type_of` MUST apply every resolved nested `ShardLayout`
     exactly once and MUST reject unresolved or non-concrete local extents at the
     point where the evaluator requires them.

--- a/src/tilefoundry/analysis/compute_cost.py
+++ b/src/tilefoundry/analysis/compute_cost.py
@@ -55,26 +55,47 @@ def _local_cost(call: Call, module: Module) -> Cost:
     return evaluate(call, CostContext(module=module))
 
 
-def _call_traffic(call: Call, cost: Cost) -> tuple[tuple[str, TrafficBytes], ...]:
-    """Bytes *call* reads and writes, per storage level.
+def _call_movement(
+    call: Call, cost: Cost
+) -> tuple[tuple[tuple[str, TrafficBytes], ...], tuple[TrafficBytes, ...]]:
+    """What each operand of *call* moves, and where those bytes are charged.
 
-    The operand types state global shapes, so these counts already cover every
-    instance of the call and are not scaled again. An op that moves no bytes at
-    all records no traffic rather than a row of zeroes.
+    How much moves is the op's answer; which level it moves at is a function of
+    that operand's Type.
     """
-    if cost.bytes == 0:
-        return ()
+    operands = (*call.args, call)
+    if len(cost.traffic) != len(operands):
+        raise AnalysisError(
+            f"{describe(call)}: cost reports {len(cost.traffic)} operands, "
+            f"the call has {len(operands)}"
+        )
     reads: dict[str, int] = {}
     writes: dict[str, int] = {}
-    for arg in call.args:
-        for name, value in bytes_by_storage(arg.type).items():
-            reads[name] = reads.get(name, 0) + value
-    for name, value in bytes_by_storage(call.type).items():
-        writes[name] = writes.get(name, 0) + value
-    return tuple(
-        (name, TrafficBytes(reads.get(name, 0), writes.get(name, 0)))
-        for name in sorted(set(reads) | set(writes))
+    charged: list[TrafficBytes] = []
+    for operand, moved in zip(operands, cost.traffic):
+        by_level = bytes_by_storage(operand.type)
+        charged.append(moved)
+        if len(by_level) == 1:
+            (level,) = by_level
+            reads[level] = reads.get(level, 0) + moved.read
+            writes[level] = writes.get(level, 0) + moved.write
+            continue
+        # A Type spanning several levels states no split, so the aggregate
+        # charges the whole Type at each, in the directions the op reported.
+        for level, value in by_level.items():
+            if moved.read:
+                reads[level] = reads.get(level, 0) + value
+            if moved.write:
+                writes[level] = writes.get(level, 0) + value
+    levels = (
+        ()
+        if cost.bytes == 0
+        else tuple(
+            (level, TrafficBytes(reads.get(level, 0), writes.get(level, 0)))
+            for level in sorted(set(reads) | set(writes))
+        )
     )
+    return levels, tuple(charged)
 
 
 def _accumulate(
@@ -87,8 +108,8 @@ def _accumulate(
     for level, value in record.traffic:
         current = traffic.get(level, TrafficBytes())
         traffic[level] = TrafficBytes(
-            current.read_bytes + value.read_bytes,
-            current.write_bytes + value.write_bytes,
+            current.read + value.read,
+            current.write + value.write,
         )
 
 
@@ -120,6 +141,7 @@ def _call_record(
         return _scaled(child.flops, child.traffic, trips)
     count = execution_count(call, fn, topologies)
     cost = _local_cost(call, module)
+    traffic, operands = _call_movement(call, cost)
     return ComputeCostMetadata(
         flops=tuple(
             sorted(
@@ -127,8 +149,9 @@ def _call_record(
                 for dtype, value in cost.flops.items()
             )
         ),
-        traffic=_scale_traffic(_call_traffic(call, cost), trips),
+        traffic=_scale_traffic(traffic, trips),
         execution_count=count * trips,
+        operands=_scale_moved(operands, trips),
     )
 
 
@@ -138,8 +161,18 @@ def _scale_traffic(
     if trips == 1:
         return traffic
     return tuple(
-        (level, TrafficBytes(value.read_bytes * trips, value.write_bytes * trips))
+        (level, TrafficBytes(value.read * trips, value.write * trips))
         for level, value in traffic
+    )
+
+
+def _scale_moved(
+    operands: tuple[TrafficBytes, ...], trips: int
+) -> tuple[TrafficBytes, ...]:
+    if trips == 1:
+        return operands
+    return tuple(
+        TrafficBytes(item.read * trips, item.write * trips) for item in operands
     )
 
 

--- a/src/tilefoundry/analysis/memory.py
+++ b/src/tilefoundry/analysis/memory.py
@@ -155,8 +155,8 @@ def _function_traffic(fn: Function) -> tuple[tuple[str, TrafficBytes], ...]:
         for level, value in record.traffic:
             current = totals.get(level, TrafficBytes())
             totals[level] = TrafficBytes(
-                current.read_bytes + value.read_bytes,
-                current.write_bytes + value.write_bytes,
+                current.read + value.read,
+                current.write + value.write,
             )
     return tuple(sorted(totals.items()))
 

--- a/src/tilefoundry/analysis/metadata.py
+++ b/src/tilefoundry/analysis/metadata.py
@@ -22,19 +22,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from tilefoundry.ir.core.metadata import IRMetadata
-
-
-@dataclass(frozen=True)
-class TrafficBytes:
-    """Read and write byte counts for one memory hierarchy level."""
-
-    read_bytes: int = 0
-    write_bytes: int = 0
-
-    @property
-    def total_bytes(self) -> int:
-        """Bytes moved at this level in either direction."""
-        return self.read_bytes + self.write_bytes
+from tilefoundry.visitor_registry.contexts import TrafficBytes
 
 
 @dataclass(frozen=True)
@@ -45,6 +33,12 @@ class ComputeCostMetadata(IRMetadata):
     that mixes precisions does not have one flop count -- and which of those
     counts dominates is a question about hardware, asked later.
 
+    ``operands`` breaks ``traffic`` down the other way: per operand rather than
+    per level, positional against ``(*call.args, call)``. It is present only for
+    a direct call on a primitive op; a call into another Function carries that
+    callee's aggregate traffic, which no breakdown of this call's operands
+    describes.
+
     Nothing here reads a Target. The same authored call carries the same record
     on every backend.
     """
@@ -52,6 +46,7 @@ class ComputeCostMetadata(IRMetadata):
     flops: tuple[tuple[str, int], ...] = ()
     traffic: tuple[tuple[str, TrafficBytes], ...] = ()
     execution_count: int = 1
+    operands: tuple[TrafficBytes, ...] = ()
 
     @property
     def total_flops(self) -> int:
@@ -68,7 +63,7 @@ class ComputeCostMetadata(IRMetadata):
         flop_text = ",".join(f"{name}:{value}" for name, value in self.flops) or "0"
         traffic_text = (
             ",".join(
-                f"{level}:r{value.read_bytes}/w{value.write_bytes}"
+                f"{level}:r{value.read}/w{value.write}"
                 for level, value in self.traffic
             )
             or "0"

--- a/src/tilefoundry/analysis/roofline.py
+++ b/src/tilefoundry/analysis/roofline.py
@@ -129,8 +129,8 @@ def analyze_roofline(
             for name, value in cost.flops:
                 total_flops[name] = total_flops.get(name, 0) + value
             total_traffic = TrafficBytes(
-                total_traffic.read_bytes + traffic.read_bytes,
-                total_traffic.write_bytes + traffic.write_bytes,
+                total_traffic.read + traffic.read,
+                total_traffic.write + traffic.write,
             )
         # The function's bound sums each side first and compares once. Taking the
         # per-Call bounds and adding them would charge the machine twice for work

--- a/src/tilefoundry/inspection/analysis_report.py
+++ b/src/tilefoundry/inspection/analysis_report.py
@@ -24,7 +24,7 @@ from tilefoundry.analysis import (
 )
 from tilefoundry.analysis.api import AnalysisResult
 from tilefoundry.analysis.registry import ANALYSES
-from tilefoundry.analysis.walk import postorder
+from tilefoundry.analysis.walk import postorder, tensor_types
 from tilefoundry.ir.core import Call, IRMetadata, binding_name, get_metadata
 from tilefoundry.ir.hir.function import Function
 from tilefoundry.ir.hir.specialize import bound_dims_of, origin_of
@@ -32,20 +32,63 @@ from tilefoundry.ir.hir.specialize import bound_dims_of, origin_of
 
 def _traffic(traffic: tuple[tuple[str, TrafficBytes], ...]) -> dict[str, dict[str, int]]:
     return {
-        level: {"read_bytes": value.read_bytes, "write_bytes": value.write_bytes}
+        level: {"read": value.read, "write": value.write}
         for level, value in traffic
     }
 
 
-def _compute_cost(record: ComputeCostMetadata) -> dict[str, object]:
-    return {
+def _type_text(type_: object) -> str:
+    """One operand's type, short enough to sit on a report line."""
+    tensors = tensor_types(type_)
+    if not tensors:
+        return str(type_)
+    first = tensors[0]
+    shape = ",".join(str(dim) for dim in first.shape)
+    more = "+" if len(tensors) > 1 else ""
+    storage = "" if first.storage is None else f" {first.storage}"
+    return f"{first.dtype.name}[{shape}]{more}{storage}"
+
+
+def _operand_name(operand: object) -> str:
+    """What to call this operand, from the program rather than from the record."""
+    name = binding_name(operand) or getattr(operand, "name", None)
+    if name:
+        return name
+    if isinstance(operand, Call):
+        return type(operand.target).__name__.lower()
+    return type(operand).__name__.lower()
+
+
+def _operands(record: ComputeCostMetadata, expr: object) -> list[dict[str, object]]:
+    """Each recorded amount, against the operand it was charged to."""
+    if not isinstance(expr, Call):
+        return []
+    operands = (*expr.args, expr)
+    return [
+        {
+            "arg": "result" if index == len(expr.args) else index,
+            "name": _operand_name(operand),
+            "type": _type_text(operand.type),
+            "read": moved.read,
+            "write": moved.write,
+        }
+        for index, (operand, moved) in enumerate(zip(operands, record.operands))
+    ]
+
+
+def _compute_cost(record: ComputeCostMetadata, expr: object) -> dict[str, object]:
+    projected: dict[str, object] = {
         "flops": dict(record.flops),
         "traffic": _traffic(record.traffic),
         "execution_count": record.execution_count,
     }
+    operands = _operands(record, expr)
+    if operands:
+        projected["operands"] = operands
+    return projected
 
 
-def _roofline(record: RooflineMetadata) -> dict[str, object]:
+def _roofline(record: RooflineMetadata, expr: object) -> dict[str, object]:
     return {
         "compute_ns": record.compute_ns,
         "memory_ns": record.memory_ns,
@@ -54,7 +97,7 @@ def _roofline(record: RooflineMetadata) -> dict[str, object]:
     }
 
 
-def _timeline(record: TimelineMetadata) -> dict[str, object]:
+def _timeline(record: TimelineMetadata, expr: object) -> dict[str, object]:
     return {
         "grid_units": record.grid_units,
         "waves": record.waves,
@@ -63,7 +106,7 @@ def _timeline(record: TimelineMetadata) -> dict[str, object]:
     }
 
 
-def _memory(record: MemoryMetadata) -> dict[str, object]:
+def _memory(record: MemoryMetadata, expr: object) -> dict[str, object]:
     return {
         "footprint": [
             {
@@ -108,7 +151,7 @@ def _records_of(expr: object, selected: frozenset[type[IRMetadata]]) -> dict[str
             continue
         record = get_metadata(expr, metadata_type)
         if record is not None:
-            result[name] = project(record)
+            result[name] = project(record, expr)
     return result
 
 
@@ -291,8 +334,8 @@ def _work_totals(function: Function) -> dict[str, object]:
         for level, value in record.traffic:
             current = traffic.get(level, TrafficBytes())
             traffic[level] = TrafficBytes(
-                current.read_bytes + value.read_bytes,
-                current.write_bytes + value.write_bytes,
+                current.read + value.read,
+                current.write + value.write,
             )
     return {
         "flops": dict(sorted(flops.items())),
@@ -307,10 +350,17 @@ def _flop_text(flops: dict[str, int]) -> str:
 def _traffic_text(traffic: dict[str, dict[str, int]]) -> str:
     return (
         ", ".join(
-            f"{level}=r{value['read_bytes']}/w{value['write_bytes']}"
+            f"{level}=r{value['read']}/w{value['write']}"
             for level, value in sorted(traffic.items())
         )
         or "0"
+    )
+
+
+def _operand_text(operand: dict[str, object]) -> str:
+    return (
+        f"{operand['arg']}:{operand['name']}="
+        f"r{operand['read']}/w{operand['write']}"
     )
 
 
@@ -373,6 +423,12 @@ def render_text(data: dict[str, object]) -> str:
                 f"units={timeline['grid_units']} waves={timeline['waves']}"
             )
         lines.append(" ".join(parts))
+        operands = call.get("compute-cost", {}).get("operands")
+        if operands is not None:
+            lines.append(
+                "  operands "
+                + ", ".join(_operand_text(operand) for operand in operands)
+            )
     return "\n".join(f"# {line}" for line in lines)
 
 

--- a/src/tilefoundry/visitor_registry/contexts.py
+++ b/src/tilefoundry/visitor_registry/contexts.py
@@ -141,23 +141,47 @@ class CostContext(TypeInferContext):
 
 
 @dataclass(frozen=True)
+class TrafficBytes:
+    """Bytes one operand moves, read and write kept apart."""
+
+    read: int = 0
+    write: int = 0
+
+    @property
+    def total_bytes(self) -> int:
+        """Bytes moved in either direction."""
+        return self.read + self.write
+
+
+@dataclass(frozen=True)
 class Cost:
     """Leaf-local logical work for one selected ``OpCandidate``.
 
     ``flops`` groups leaf-local logical work by compute ``DType`` so one Op
     can report mixed work without selecting an ALU/TensorCore
-    implementation. ``bytes`` is scalar logical byte traffic. Neither field
-    selects a hardware implementation.
+    implementation. ``traffic`` carries one entry per operand in call order
+    with the result last, so an Op that reads part of an input says so where
+    it knows it. Neither field selects a hardware implementation, and neither
+    names a memory level: that is a function of the operand's Type.
     """
 
     flops: Mapping[DType, int]
-    bytes: int
+    traffic: tuple[TrafficBytes, ...]
+
+    @property
+    def bytes(self) -> int:
+        """Every operand's traffic, in either direction."""
+        return sum(moved.total_bytes for moved in self.traffic)
 
     def __post_init__(self) -> None:
         if any(not isinstance(value, int) or value < 0 for value in self.flops.values()):
             raise ValueError("Cost flops must be non-negative integers")
-        if not isinstance(self.bytes, int) or self.bytes < 0:
-            raise ValueError("Cost bytes must be a non-negative integer")
+        if any(
+            not isinstance(value, int) or value < 0
+            for moved in self.traffic
+            for value in (moved.read, moved.write)
+        ):
+            raise ValueError("Cost traffic must be non-negative integers")
 
 
 __all__ = [
@@ -165,4 +189,5 @@ __all__ = [
     "VerifyContext",
     "CostContext",
     "Cost",
+    "TrafficBytes",
 ]

--- a/src/tilefoundry/visitor_registry/op_cost.py
+++ b/src/tilefoundry/visitor_registry/op_cost.py
@@ -44,7 +44,7 @@ from tilefoundry.ir.hir.tensor.tuple_get_item import TupleGetItem
 from tilefoundry.ir.hir.tensor.zeros import Zeros
 from tilefoundry.ir.types import DType, TensorType, Type, numel, tensor_bytes
 
-from .contexts import Cost, CostContext
+from .contexts import Cost, CostContext, TrafficBytes
 from .registries import register_cost_evaluator
 
 
@@ -56,8 +56,25 @@ def _output_type(call: Call, ctx: CostContext) -> Type:
     return ctx.local_output_type(call)
 
 
-def _traffic(inputs: tuple[Type, ...], output: Type) -> int:
-    return sum(tensor_bytes(type) for type in inputs) + tensor_bytes(output)
+def _traffic(inputs: tuple[Type, ...], output: Type) -> tuple[TrafficBytes, ...]:
+    """One entry per operand: every input read whole, the result written whole.
+
+    The default an Op gets by saying nothing about which part it touches.
+    """
+    return (
+        *(TrafficBytes(read=tensor_bytes(type)) for type in inputs),
+        TrafficBytes(write=tensor_bytes(output)),
+    )
+
+
+def _row(table: Type) -> int:
+    """One position's worth of a cache whose leading axis is the position."""
+    return tensor_bytes(table) // table.shape[0]
+
+
+def _idle(call: Call) -> tuple[TrafficBytes, ...]:
+    """No operand moves, but every operand still has a slot."""
+    return tuple(TrafficBytes() for _ in range(len(call.args) + 1))
 
 
 def _elementwise(call: Call, ctx: CostContext, *, dtype: DType | None = None) -> Cost:
@@ -105,11 +122,12 @@ def _reduce(call: Call, ctx: CostContext) -> Cost:
 
 @register_cost_evaluator(RMSNorm)
 def _rms_norm(call: Call, ctx: CostContext) -> Cost:
-    source = _input_types(call, ctx)[0]
+    inputs = _input_types(call, ctx)
     output = _output_type(call, ctx)
+    source = inputs[0]
     if not isinstance(source, TensorType):
         raise ValueError("RMSNorm cost requires a tensor input")
-    return Cost({DType.f32: 8 * numel(source)}, _traffic((source,), output))
+    return Cost({DType.f32: 8 * numel(source)}, _traffic(inputs, output))
 
 
 @register_cost_evaluator(Binary)
@@ -177,12 +195,12 @@ def _slice(call: Call, ctx: CostContext) -> Cost:
     """A slice selects elements and computes none.
 
     Its traffic is what it actually moves -- the selected region, not the tensor
-    it came from -- so the cost is read off the output rather than the input. A
-    model that splits a wide projection into unequal parts does that once per
-    part, and charging each one for the whole projection would report a kernel
-    reading its input as many times as it has pieces.
+    it came from. A model that splits a wide projection into unequal parts does
+    that once per part, and charging each one for the whole projection would
+    report a kernel reading its input as many times as it has pieces.
     """
-    return Cost({}, tensor_bytes(_output_type(call, ctx)) * 2)
+    kept = tensor_bytes(_output_type(call, ctx))
+    return Cost({}, (TrafficBytes(read=kept), TrafficBytes(write=kept)))
 
 
 @register_cost_evaluator(SoftMax)
@@ -206,13 +224,24 @@ def _rope(call: Call, ctx: CostContext) -> Cost:
     Each rotated element costs one multiply against the cosine, one against
     the sine of its partner, and the add that combines them. The output is the
     pair, so its element count already covers both q and k.
+
+    The position-indexed caches contribute one row per call.
     """
-    inputs = _input_types(call, ctx)
+    query, key, cos_cache, sin_cache, pos_ids = _input_types(call, ctx)
     output = _output_type(call, ctx)
-    query = inputs[0]
     if not isinstance(query, TensorType):
         raise ValueError("RoPE cost requires a tensor query input")
-    return Cost({query.dtype: 3 * numel(output)}, _traffic(inputs, output))
+    return Cost(
+        {query.dtype: 3 * numel(output)},
+        (
+            TrafficBytes(read=tensor_bytes(query)),
+            TrafficBytes(read=tensor_bytes(key)),
+            TrafficBytes(read=_row(cos_cache)),
+            TrafficBytes(read=_row(sin_cache)),
+            TrafficBytes(read=tensor_bytes(pos_ids)),
+            TrafficBytes(write=tensor_bytes(output)),
+        ),
+    )
 
 
 @register_cost_evaluator(TopK)
@@ -226,9 +255,16 @@ def _topk(call: Call, ctx: CostContext) -> Cost:
 
 @register_cost_evaluator(Gather)
 def _gather(call: Call, ctx: CostContext) -> Cost:
-    inputs = _input_types(call, ctx)
-    output = _output_type(call, ctx)
-    return Cost({}, _traffic(inputs, output))
+    indices = _input_types(call, ctx)[1]
+    rows = tensor_bytes(_output_type(call, ctx))
+    return Cost(
+        {},
+        (
+            TrafficBytes(read=rows),
+            TrafficBytes(read=tensor_bytes(indices)),
+            TrafficBytes(write=rows),
+        ),
+    )
 
 
 @register_cost_evaluator(ArgMax)
@@ -255,20 +291,19 @@ def _quant(call: Call, ctx: CostContext) -> Cost:
 
 @register_cost_evaluator(TupleGetItem)
 def _tuple_get_item(call: Call, ctx: CostContext) -> Cost:
-    return Cost({}, 0)
+    return Cost({}, _idle(call))
 
 
 @register_cost_evaluator(FullLike)
 def _full_like(call: Call, ctx: CostContext) -> Cost:
-    output = _output_type(call, ctx)
-    return Cost({}, tensor_bytes(output))
+    return Cost({}, _traffic(_input_types(call, ctx), _output_type(call, ctx)))
 
 
 @register_cost_evaluator(Zeros)
 def _zeros(call: Call, ctx: CostContext) -> Cost:
     """Materialise a tensor of zeros: no arithmetic, one full write."""
     output = _output_type(call, ctx)
-    return Cost({}, tensor_bytes(output))
+    return Cost({}, (TrafficBytes(write=tensor_bytes(output)),))
 
 
 @register_cost_evaluator(RepeatInterleave)
@@ -280,19 +315,22 @@ def _repeat_interleave(call: Call, ctx: CostContext) -> Cost:
 
 @register_cost_evaluator(Reshape)
 def _reshape(call: Call, ctx: CostContext) -> Cost:
-    return Cost({}, 0)
+    return Cost({}, _idle(call))
 
 
 @register_cost_evaluator(Transpose)
 def _transpose(call: Call, ctx: CostContext) -> Cost:
-    return Cost({}, 0)
+    return Cost({}, _idle(call))
 
 
 @register_cost_evaluator(Reshard)
 def _reshard(call: Call, ctx: CostContext) -> Cost:
     source = _input_types(call, ctx)[0]
     destination = _output_type(call, ctx)
-    return Cost({}, tensor_bytes(source) + tensor_bytes(destination))
+    return Cost({}, (
+        TrafficBytes(read=tensor_bytes(source)),
+        TrafficBytes(write=tensor_bytes(destination)),
+    ))
 
 
 __all__ = ["tensor_bytes"]

--- a/tests/analysis/test_analysis_families.py
+++ b/tests/analysis/test_analysis_families.py
@@ -34,6 +34,8 @@ from tilefoundry.ir.hir.sharding.reshard import Reshard
 from tilefoundry.ir.types import DType, numel
 from tilefoundry.target import AmxTarget, CudaTarget
 from tilefoundry.target.facts import TARGET_FACTS
+from tilefoundry.visitor_registry import cost_evaluator_registry
+from tilefoundry.visitor_registry.contexts import Cost
 
 
 @module(entry="main", target="cuda")
@@ -113,6 +115,18 @@ class _BatchedOnTheRight:
         blocks: Tensor[(5, 4, 3), "f32"],
     ):
         return tf.matmul(token, blocks)
+
+
+@module(entry="main", target="cuda")
+class _Gathered:
+    topologies = (Topology("cta", 1),)
+
+    @func
+    def main(
+        table: ConstTensor[(1024, 64), "f32"],
+        rows: ConstTensor[(4,), "i32"],
+    ):
+        return tf.gather(table, rows, axis=0)
 
 
 @func(target="cuda", topologies=(Topology("cta", 168),))
@@ -264,8 +278,42 @@ def test_the_two_operations_a_decoder_stops_on_cost_what_they_do() -> None:
     assert zeros is not None
     assert zeros.flops == ()
     traffic = zeros.traffic_at("gmem")
-    assert traffic.write_bytes == 64 * 4
-    assert traffic.read_bytes == 0
+    assert traffic.write == 64 * 4
+    assert traffic.read == 0
+
+
+def test_a_gather_reads_the_rows_it_names_and_not_the_table() -> None:
+    result, entry = _run(_Gathered, "compute-cost")
+
+    record = get_metadata(_calls(entry)[-1], ComputeCostMetadata)
+    assert record is not None
+    traffic = record.traffic_at("gmem")
+    rows = 4 * 64 * 4
+    assert traffic.read == rows + 4 * 4
+    assert traffic.write == rows
+
+    payload = json.loads(render_json(report([result])))
+    table, indices, produced = payload["calls"][-1]["compute-cost"]["operands"]
+    assert table == {
+        "arg": 0,
+        "name": "table",
+        "type": "f32[1024,64] gmem",
+        "read": rows,
+        "write": 0,
+    }
+    assert (indices["arg"], indices["read"]) == (1, 16)
+    assert (produced["arg"], produced["read"], produced["write"]) == ("result", 0, rows)
+
+
+def test_an_evaluator_that_misses_an_operand_is_refused(monkeypatch) -> None:
+    monkeypatch.setattr(
+        cost_evaluator_registry, "lookup", lambda cls: lambda call, ctx: Cost({}, ())
+    )
+
+    with pytest.raises(
+        AnalysisError, match="op=Binary: cost reports 0 operands, the call has 3"
+    ):
+        _run(_wide_grid, "compute-cost")
 
 
 def test_memory_holds_a_weight_resident_past_its_last_reader() -> None:

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -237,7 +237,7 @@ def test_analyze_json_and_text_report_the_same_conclusions(tmp_path, capsys) -> 
     assert payload["function"] == "main"
     assert payload["executed"] == ["compute-cost", "memory", "roofline", "timeline"]
     for level, value in payload["totals"]["traffic"].items():
-        assert f"{level}=r{value['read_bytes']}/w{value['write_bytes']}" in text
+        assert f"{level}=r{value['read']}/w{value['write']}" in text
     for item in payload["function_records"]["memory"]["footprint"]:
         assert f"{item['level']}={item['peak_bytes']}" in text
     assert f"by={payload['function_records']['roofline']['bound_by']}" in text

--- a/tests/models/test_analysis_is_hand_checkable.py
+++ b/tests/models/test_analysis_is_hand_checkable.py
@@ -144,19 +144,12 @@ def test_the_layer_costs_its_two_halves_and_nothing_else() -> None:
 def test_the_layer_reads_at_least_its_weights_and_its_cache() -> None:
     """Traffic is what a decode step is actually about, so it is checked too.
 
-    A lower bound only, and the reason is a defect this measurement found rather
-    than a limit of the arithmetic. `_call_traffic` derives its per-level bytes from
-    each operand's whole type and discards the evaluator's own byte count, so a call
-    that reads part of a table cannot say so: the two rotary tables are charged whole
-    at each of the two calls that take them, which is 67,108,864 B for a step that
-    gathers one position -- 1,024 B. Intermediates are likewise charged in full at
-    every consumer. So the reported total is above the truth by an amount this file
-    cannot derive, and an upper bound here would either encode the overcount as
-    expected or be too loose to catch anything.
-
-    What is still worth holding: the step cannot read *less* than its weights and the
-    cache it attends, and those are exactly derivable. A step that read a weight
-    matrix per output element, or forgot the cache, fails this.
+    A lower bound, because an intermediate is charged in full at every consumer
+    that reads it, so the reported total sits above the truth by an amount this
+    file cannot derive. What is exactly derivable is the floor: the step cannot
+    read *less* than its weights, the cache it attends, and the rotary rows its
+    position lands on. A step that read a weight matrix per output element, or
+    forgot the cache, fails this.
     """
     data = _analysed("decoder_layer", {"ctx_len": CTX})
 
@@ -166,11 +159,13 @@ def test_the_layer_reads_at_least_its_weights_and_its_cache() -> None:
         + 2 * CONFIG.hidden_size * KV_PROJ               # k, v
     )
     cache = BYTES_PER * 2 * CTX * CONFIG.num_key_value_heads * CONFIG.head_dim
-    read = data["totals"]["traffic"]["gmem"]["read_bytes"]
+    # The layer rotates q and k, and each call indexes a cos and a sin cache.
+    rope_rows = 2 * 2 * CONFIG.head_dim * BYTES_PER
+    read = data["totals"]["traffic"]["gmem"]["read"]
 
-    assert read >= weights + cache, (
-        f"the step reads {read} B, less than the {weights} B of weights and "
-        f"{cache} B of cache it must read"
+    assert read >= weights + cache + rope_rows, (
+        f"the step reads {read} B, less than the {weights} B of weights, "
+        f"{cache} B of cache and {rope_rows} B of rotary rows it must read"
     )
 
 
@@ -190,7 +185,7 @@ def test_a_decode_step_is_bound_by_memory() -> None:
     bound = data["function_records"]["roofline"]
     assert bound["bound_by"] == "memory", (
         f"a one-token decode step is reported as {bound['bound_by']}-bound; it "
-        f"moves {data['totals']['traffic']['gmem']['read_bytes']} B to do "
+        f"moves {data['totals']['traffic']['gmem']['read']} B to do "
         f"{data['totals']['flops']['f32']} flops"
     )
     assert bound["theoretical_ns"] > 0

--- a/tests/models/test_max_context_coverage.py
+++ b/tests/models/test_max_context_coverage.py
@@ -71,7 +71,7 @@ def test_the_largest_context_is_reasoned_about_and_not_allocated(model) -> None:
     def reads(result) -> int:
         record = get_metadata(result.function, MemoryMetadata)
         assert record is not None, "the memory analysis wrote no record"
-        return sum(item.read_bytes for _level, item in record.traffic)
+        return sum(item.read for _level, item in record.traffic)
 
     tracemalloc.start()
     try:


### PR DESCRIPTION
## Why
- Two layers both computed traffic and disagreed. `op_cost._traffic` charged every input's whole type, while `analysis/compute_cost._call_traffic` threw the op's number away and recomputed from whole types, using `cost.bytes` only for a zero check. An op that reads part of an input had no way to say so, and `Slice`'s already-correct formula never reached the report.
- The consequence was measurable: two rotary caches charged whole at each of the two calls that index them, and three expert tables charged whole for a gather that takes eight rows.

## What
- `Cost.traffic` is `tuple[TrafficBytes, ...]`, one entry per operand in call order with the result last; `Cost.bytes` becomes a derived property, so `schedule/partition/problem.py` needs no change.
- `_call_traffic` zips `(*call.args, call)` with that tuple, validates the length with an `AnalysisError` naming the call and both counts, and takes **only** the storage level from the operand's Type. No second byte arithmetic.
- `Gather`, `RoPE` and `Slice` charge the part they touch: the rows the indices name plus the indices, one cache row per position, and the selected region. The bounds come from the types alone — there is no input by which an author states them.
- `ComputeCostMetadata.operands` records the per-operand amounts; the report renders `{arg, name, type, read, write}` for a direct op call and omits the key for an aggregate `Function` call, whose traffic is the callee's and admits no caller-operand attribution.
- `TrafficBytes` fields are `read`/`write` — the class name already says bytes.

Two latent inconsistencies surfaced when the length check went in and are fixed here: `_rms_norm` costed only its first input (2 slots for a 3-operand call), and `_full_like` counted only its write while the report charged its template whole. Both are resolved toward what the report already said, so neither moves a number.

## Contract
- Public JSON key change: `traffic.<level>.read_bytes`/`write_bytes` → `read`/`write`. No old key remains.
- New public JSON: `compute-cost.operands`, present only for a direct call on a primitive op.
- `docs/spec/analysis.md` and `docs/spec/visitor-registry.md` updated: `Cost`/`TrafficBytes` shape, operand positionality, and the one place the two views legitimately differ — an operand whose Type spans several storage levels keeps its reported amount in its operand entry while the per-level aggregate takes the conservative whole-Type bound.

## Verification
- `pytest tests/analysis tests/cli tests/models tests/inspection -q -n 8 --junitxml` — 497 passed; 1 failed + 1 error, both `torch.AcceleratorError: cudaErrorDevicesUnavailable`, zero non-CUDA entries in the JUnit XML.
- `pytest tests/ -q -n 8 --tb=short --junitxml` (frozen tree) — 1003 passed; 14 non-passing, all raw `cudaErrorDevicesUnavailable` at tensor allocation, no code failure. Local GPU 0 is `Exclusive_Process` and `tests/conftest.py:105` pins worker *gwN* to device *N % count*; the identical failure set reproduces on unmodified `main`.
- `tilefoundry analyze tests/models/qwen3_1_7b/model.py:Qwen3_1_7B_Decoder.layer0.self_attention --compute-cost --dim ctx_len=1024 --json` — exit 0; both RoPE calls report six operands with `cos_cache`/`sin_cache` read 256 of a 10,485,760 whole; the `hidden_norm` Function call carries no `operands` key.
- `tilefoundry analyze tests/models/qwen3_5_35b_a3b/model.py:Qwen3_5Decoder.layer0.moe.routed_experts --compute-cost --json` — exit 0; the three expert-weight gathers each report table read 16,777,216 of 536,870,912; `routed_experts` memory bound 356,560 ns → 31,501 ns.
- `pre-commit run --files <13 changed files>` — ruff Passed, clang-format Skipped (no C/C++), spec-rules-lint Passed, spec-entropy-lint Passed, no-machine-paths Passed.

## Risk
- The remaining gap to a tight bound is named and out of scope here: an intermediate is still charged in full at every consumer that reads it, so `test_the_layer_reads_at_least_its_weights_and_its_cache` stays a lower bound.
- The multi-storage fallback is unreachable in the current corpus — measured 0 such operands across all 38 selected functions and the 72 operands of the synthetic analysis/schedule modules — so it is covered by construction rather than by a test.
