### PR TITLE
feat(models): publish source directories

### DIFF
--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -56,12 +56,13 @@ would declare its context, rather than analysed or scheduled against a default
 ([target §6](./target.md#6-target-ownership-and-compile-resolution)).
 
 The file in `SOURCE` is any readable Python file. Nothing privileges the model
-sources this project ships: a reader who copies one out, merges two of a Module's
-functions into one and points a verb at the result MUST reach the same command
-surface, because coarsening a boundary is done by editing source and there is no
-other mechanism for it. What `models <name> --source` prints stays the reference to
-compare against, and it stays intact because an installation is not where anybody
-edits — no verb enforces that, and none should.
+sources this project ships: a reader who copies a shipped model directory, merges
+two of a Module's functions into one and points a verb at the copy MUST reach the
+same command surface, because coarsening a boundary is done by editing source and
+there is no other mechanism for it. The installed directory named by `models
+<name> --source` stays the reference to compare against, and it stays intact
+because an installation is not where anybody edits — no verb enforces that, and
+none should.
 
 A command MUST load `SOURCE` as a Python module. While loading it, the directory
 containing `SOURCE` MUST be first on the Python module search path, so a file beside
@@ -194,9 +195,16 @@ that runs before it can be read is a reference that decides what it describes.
   - The leaf-Module count and the function count MUST come from one traversal, so
     the numbers cannot disagree with the forest printed beside them, and they MUST
     count every Module a range stands for rather than the range as one.
-  - `--source` MUST print the authored source as it shipped, byte for byte, and
-    MUST NOT reformat or regenerate it: the installed copy is the reference, and a
-    rendered copy is a different artifact wearing its name.
+  - `--source` MUST print the absolute path of the shipped model directory first,
+    followed by one line for every file named in the package data manifest, in
+    manifest order. Each file line MUST give its filename and the first line of
+    its own docstring, or `-` when it has none. A checkout MUST read that manifest;
+    an installation MUST read its model directory, and both MUST name the same
+    files.
+  - `--source` MUST parse a file's text to read its docstring and MUST NOT import
+    or execute model source. It MUST NOT reformat, regenerate, or copy a shipped
+    file: the installed directory is the reference, and a rendered copy is a
+    different artifact wearing its name.
   - A `NAME` the catalog does not have MUST be refused naming the models it does.
   - The forest and the counts MUST be generated from the models themselves rather
     than maintained beside them, because a hand-kept inventory of trees and numbers

--- a/docs/tutorial/migrate.md
+++ b/docs/tutorial/migrate.md
@@ -9,7 +9,8 @@ source of `qwen3_5_35b_a3b`, quoted by name — a hybrid model, because a
 dense one cannot show you the thing that catches people out: layers of two
 different kinds in a published cycle.
 
-`tilefoundry models qwen3_5_35b_a3b --source` prints the whole of it.
+`tilefoundry models qwen3_5_35b_a3b --source` names the directory that holds it
+and lists the shipped files.
 
 ## The four things to get right
 

--- a/docs/tutorial/optimize.md
+++ b/docs/tutorial/optimize.md
@@ -57,17 +57,18 @@ reference and not against the last thing you happened to measure.
 
 ## Where your copy comes from
 
-`your_copy_of` is a command:
+`your_copy_of` starts with the shipped directory:
 
 ```sh
-tilefoundry models qwen3_5_35b_a3b --source > mine.py
+source=$(tilefoundry models qwen3_5_35b_a3b --source | sed -n '1p')
+cp -r "$source" mine
 ```
 
-Then edit `mine.py` — merge two of a Module's functions into one, move a boundary,
-whatever the fusion is — and point the tools at it:
+Then edit `mine/model.py` — merge two of a Module's functions into one, move a
+boundary, whatever the fusion is — and point the tools at it:
 
 ```sh
-tilefoundry check mine.py:MyFused.fused --inputs random --out output \
+tilefoundry check mine/model.py:MyFused.fused --inputs random --out output \
     --fn allclose --atol 1e-6 --rtol 1e-6
 ```
 
@@ -75,11 +76,11 @@ A target is `file:Class[.child...][.function]`, and that file is any file you ca
 read. Nothing in the command surface knows or cares that the shipped models exist,
 so a fused copy is not a special case: it is the ordinary case pointed at your file.
 
-You do not have to protect the original. What `--source` prints lives in the
-installation, and an installation is not where you edit — so the reference stays the
-reference because of where it sits, not because anything stops you. Keeping it
-intact is the point: the moment you fuse, that copy is the only thing that still
-says what the answer was supposed to be.
+You do not have to protect the original. The directory `--source` names lives in
+the installation, and an installation is not where you edit — so the reference
+stays the reference because of where it sits, not because anything stops you.
+Keeping it intact is the point: the moment you fuse, that copy is the only thing
+that still says what the answer was supposed to be.
 
 ## Siblings are independent; a parent is not
 

--- a/src/tilefoundry/cli/data.py
+++ b/src/tilefoundry/cli/data.py
@@ -7,6 +7,7 @@ that ships, rather than one copy of the lookup per thing.
 
 from __future__ import annotations
 
+import tomllib
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -54,4 +55,21 @@ def path(kind: str, name: str) -> Path:
     return found
 
 
-__all__ = ["Kind", "directory", "path"]
+def model_files(name: str) -> tuple[Path, ...]:
+    """The files a shipped model directory carries, in its package order."""
+    models = directory("models")
+    found = models / name
+    if models == _REPOSITORY_ROOT / "tests" / "models":
+        with (_REPOSITORY_ROOT / "pyproject.toml").open("rb") as manifest:
+            data_files = tomllib.load(manifest)["tool"]["setuptools"]["data-files"]
+        destination = f"share/tilefoundry/models/{name}"
+        try:
+            return tuple(found / Path(entry).name for entry in data_files[destination])
+        except KeyError:
+            raise FileNotFoundError(f"installed TileFoundry model {name} was not found") from None
+    if not found.is_dir():
+        raise FileNotFoundError(f"installed TileFoundry model {name} was not found")
+    return tuple(entry for entry in found.iterdir() if entry.is_file())
+
+
+__all__ = ["Kind", "directory", "model_files", "path"]

--- a/src/tilefoundry/cli/models.py
+++ b/src/tilefoundry/cli/models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import json
 import sys
 from typing import Any
@@ -92,14 +93,29 @@ def render_model(name: str) -> str:
     return "\n".join(lines) + "\n"
 
 
+def _summary(path: "Path") -> str:
+    """The first docstring line in *path*, or a marker when it has none."""
+    try:
+        source = ast.parse(path.read_text(encoding="utf-8"))
+    except SyntaxError:
+        return "-"
+    docstring = ast.get_docstring(source)
+    return docstring.splitlines()[0] if docstring else "-"
+
+
 def model_source(name: str) -> str:
-    """The model's authored source as it ships: the same bytes, read-only."""
+    """The shipped model directory followed by one source summary per file."""
     _find(name)
-    return data.path("models", f"{name}/model.py").read_text(encoding="utf-8")
+    files = data.model_files(name)
+    directory = data.directory("models") / name
+    width = max(len(path.name) for path in files)
+    lines = [str(directory)]
+    lines += [f"{path.name:<{width}}  {_summary(path)}" for path in files]
+    return "\n".join(lines) + "\n"
 
 
 def run_models(name: str | None, *, source: bool = False) -> int:
-    """Print the inventory, one model's forest, or one model's shipped source."""
+    """Print the inventory, one model's forest, or one shipped model directory."""
     if name is None:
         if source:
             raise ValueError("--source needs a model to print the source of")

--- a/tests/integration/installed/smoke_models.py
+++ b/tests/integration/installed/smoke_models.py
@@ -2,7 +2,19 @@
 
 from __future__ import annotations
 
+import os
+import shutil
+import subprocess
+import sys
 from pathlib import Path
+
+from tilefoundry.cli import data, models
+
+REPO = Path(__file__).resolve().parents[3]
+
+
+def _listed_names(output: str) -> set[str]:
+    return {line.split(maxsplit=1)[0] for line in output.splitlines()[1:]}
 
 
 def test_models_separates_oracles_from_everything_else(tf) -> None:
@@ -29,13 +41,78 @@ def test_models_renders_the_whole_forest_with_leaf_modules_marked(tf) -> None:
     assert "input_rms_norm(hidden: Tensor[(1, 1, 2048), \"bf16\"]" in forest
 
 
-def test_models_source_is_the_authored_file_byte_for_byte(tf, shipped) -> None:
+def test_models_source_names_the_shipped_directory_and_its_files(tf, shipped, tmp_path) -> None:
     done = tf("models", "qwen3_1_7b", "--source")
     assert done.returncode == 0, done.stderr
-    authored = (Path(shipped["models"]) / "qwen3_1_7b" / "model.py").read_text(
-        encoding="utf-8"
+    lines = done.stdout.splitlines()
+    source = Path(lines[0])
+    assert source.is_absolute()
+    assert source == Path(shipped["models"]) / "qwen3_1_7b"
+    assert _listed_names(done.stdout) == {
+        entry.name for entry in source.iterdir() if entry.is_file()
+    }
+    assert any(
+        line.startswith("model.py")
+        and "Qwen3-1.7B's dense decoder layer and the stack that closes it" in line
+        for line in lines[1:]
     )
-    assert done.stdout == authored
+    assert any(line.startswith("config.json") and line.endswith("-") for line in lines[1:])
+
+    copied = tmp_path / "mine"
+    shutil.copytree(source, copied)
+    static = f"{copied / 'model.py'}:Qwen3_1_7B_Decoder.layer0.mlp"
+    analysed = tf("analyze", static, "--compute-cost")
+    assert analysed.returncode == 0, analysed.stderr
+    assert "target=cuda" in analysed.stdout
+    assert "flops" in analysed.stdout and "traffic gmem=" in analysed.stdout
+
+    environment = dict(os.environ)
+    environment.pop("PYTHONPATH", None)
+    checkout = subprocess.run(
+        [Path(sys.executable).with_name("tilefoundry"), "models", "qwen3_1_7b", "--source"],
+        cwd=REPO,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert checkout.returncode == 0, checkout.stderr
+    assert _listed_names(checkout.stdout) == _listed_names(done.stdout)
+
+
+def test_models_source_follows_the_manifest_without_importing_files(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    root = tmp_path / "checkout"
+    model = root / "tests" / "models" / "added"
+    model.mkdir(parents=True)
+    (model / "model.py").write_text(
+        '"""A model that must not run while it is described."""\nraise RuntimeError\n',
+        encoding="utf-8",
+    )
+    (model / "run.py").write_text('"""An added companion."""\n', encoding="utf-8")
+    (model / "config.json").write_text("{}\n", encoding="utf-8")
+    (model.parent / "catalog.json").write_text(
+        '{"models": [{"name": "added"}]}\n', encoding="utf-8"
+    )
+    (root / "pyproject.toml").write_text(
+        """[tool.setuptools.data-files]
+"share/tilefoundry/models/added" = [
+    "tests/models/added/model.py",
+    "tests/models/added/run.py",
+    "tests/models/added/config.json",
+]
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(data, "_REPOSITORY_ROOT", root)
+
+    assert models.run_models("added", source=True) == 0
+    output = capsys.readouterr().out
+    assert _listed_names(output) == {"model.py", "run.py", "config.json"}
+    assert "A model that must not run while it is described." in output
+    assert "An added companion." in output
+    assert "config.json  -" in output
 
 
 def test_models_rejects_a_name_the_catalog_does_not_have(tf) -> None:
@@ -51,11 +128,6 @@ def test_the_shipped_source_answers_the_public_commands_as_it_ships(
     """No editing step: the root declares its machine, so the commands answer."""
     source = Path(shipped["models"]) / "qwen3_1_7b" / "model.py"
     static = f"{source}:Qwen3_1_7B_Decoder.layer0.mlp"
-
-    analysed = tf("analyze", static, "--compute-cost")
-    assert analysed.returncode == 0, analysed.stderr
-    assert "target=cuda" in analysed.stdout
-    assert "flops" in analysed.stdout and "traffic gmem=" in analysed.stdout
 
     scheduled = tf("schedule", static, "--topology", "cta")
     assert scheduled.returncode == 0, scheduled.stderr

--- a/tests/integration/installed/smoke_models.py
+++ b/tests/integration/installed/smoke_models.py
@@ -69,7 +69,14 @@ def test_models_source_names_the_shipped_directory_and_its_files(tf, shipped, tm
     environment = dict(os.environ)
     environment.pop("PYTHONPATH", None)
     checkout = subprocess.run(
-        [Path(sys.executable).with_name("tilefoundry"), "models", "qwen3_1_7b", "--source"],
+        [
+            sys.executable,
+            "-c",
+            "from tilefoundry.cli import main; raise SystemExit(main())",
+            "models",
+            "qwen3_1_7b",
+            "--source",
+        ],
         cwd=REPO,
         env=environment,
         capture_output=True,

--- a/tests/integration/installed/smoke_models.py
+++ b/tests/integration/installed/smoke_models.py
@@ -140,6 +140,10 @@ def test_the_shipped_source_answers_the_public_commands_as_it_ships(
     assert scheduled.returncode == 0, scheduled.stderr
     assert "partition cta x132 on nvidia.h200_sxm" in scheduled.stdout
 
+    threaded = tf("schedule", static, "--topology", "thread")
+    assert threaded.returncode == 0, threaded.stderr
+    assert "pipeline schedule" in threaded.stdout
+
     # A selector whose extent is stated at launch takes it on the command line.
     dynamic = f"{source}:Qwen3_1_7B_Decoder.layer0.self_attention"
     sized = tf("analyze", dynamic, "--compute-cost", "--dim", "ctx_len=1024")

--- a/tests/integration/installed/smoke_tutorial.py
+++ b/tests/integration/installed/smoke_tutorial.py
@@ -26,6 +26,14 @@ def test_each_page_renders_from_the_installation(tf, page) -> None:
     assert "{{fixture:" not in done.stdout
 
 
+def test_optimize_tells_the_reader_to_copy_the_shipped_model_directory(tf) -> None:
+    done = tf("tutorial", "optimize")
+    assert done.returncode == 0, done.stderr
+    assert 'source=$(tilefoundry models qwen3_5_35b_a3b --source | sed -n \'1p\')' in done.stdout
+    assert 'cp -r "$source" mine' in done.stdout
+    assert "tilefoundry check mine/model.py:MyFused.fused" in done.stdout
+
+
 def test_migrate_splices_the_shipped_model_source_verbatim(tf, shipped) -> None:
     """A parameter only the packaged source declares proves which file was read."""
     done = tf("tutorial", "migrate")

--- a/tests/integration/qwen3_1_7b_l3.py
+++ b/tests/integration/qwen3_1_7b_l3.py
@@ -3,9 +3,10 @@
     <venv>/bin/python tests/integration/qwen3_1_7b_l3.py --venv <venv> --work <dir>
 
 Sixteen greedy continuation steps against Hugging Face, compared as token IDs. The
-IR side is what `tilefoundry models qwen3_1_7b --source` emits out of an
-installation, executed here rather than imported from this checkout. Run by the
-installation's own interpreter, so the `tilefoundry` it imports is the one tested.
+IR side comes from the directory `tilefoundry models qwen3_1_7b --source` names in
+an installation, copied and executed here rather than imported from this checkout.
+Run by the installation's own interpreter, so the `tilefoundry` it imports is the
+one tested.
 
 Prefill is Hugging Face's: these kernels express one step at a time and not the
 prompt pass before it, so what is compared is continuation decode.
@@ -99,8 +100,8 @@ def _published(mount: Path) -> dict:
     return read
 
 
-def _emitted(venv: Path, work: Path, outside: Path, mount: Path) -> Path:
-    """Ask the installation for the model source, and write it where it will run."""
+def _emitted(venv: Path, work: Path, outside: Path) -> Path:
+    """Ask the installation for its model directory and copy it where it will run."""
     done = subprocess.run(
         [str(venv / "bin" / "tilefoundry"), "models", MODEL, "--source"],
         cwd=str(outside), capture_output=True, text=True, check=False,
@@ -110,12 +111,18 @@ def _emitted(venv: Path, work: Path, outside: Path, mount: Path) -> Path:
             f"`tilefoundry models {MODEL} --source` exited {done.returncode}\n"
             f"{done.stderr.strip()}"
         )
-    source = work / "model.py"
-    source.write_text(done.stdout, encoding="utf-8")
-    # The source reads its dimensions from a `config.json` beside it, so the
-    # mounted checkpoint's own file is what it binds to here.
-    shutil.copyfile(mount / "config.json", work / "config.json")
-    print(f"emitted {len(done.stdout)} characters of {MODEL} source to {source}")
+    lines = done.stdout.splitlines()
+    if not lines:
+        raise SystemExit(f"`tilefoundry models {MODEL} --source` printed no directory")
+    shipped = Path(lines[0])
+    if not shipped.is_dir():
+        raise SystemExit(f"`tilefoundry models {MODEL} --source` named no directory: {shipped}")
+    copied = work / shipped.name
+    shutil.copytree(shipped, copied)
+    source = copied / "model.py"
+    if not source.is_file():
+        raise SystemExit(f"copied model directory has no model.py: {copied}")
+    print(f"copied {MODEL} source directory to {copied}")
     return source
 
 
@@ -207,7 +214,7 @@ def main(argv: list[str] | None = None) -> int:
     published = _published(args.checkpoint)
     args.work.mkdir(parents=True, exist_ok=True)
 
-    source = _emitted(args.venv, args.work, args.outside, args.checkpoint)
+    source = _emitted(args.venv, args.work, args.outside)
 
     tokenizer, model = _oracle(args.checkpoint)
     loaded = _loaded(source, args.work, args.checkpoint, published["num_hidden_layers"])

--- a/tests/models/deepseek_v4_flash/model.py
+++ b/tests/models/deepseek_v4_flash/model.py
@@ -525,7 +525,7 @@ def _submodules(config: DSV4Config):
         ``forward``. Takes an already-normalized hidden state: the checkpoint's
         ``ffn_norm.weight`` is layer-level, so this component has no pre-MoE norm
         of its own (contrast ``DeepseekV4NoauxTcMoE`` below)."""
-        topologies = (Topology("cta", 132),)
+        topologies = (Topology("cta", 132), Topology("thread", 512))
 
 
         @func
@@ -869,7 +869,7 @@ def _submodules(config: DSV4Config):
         """The learned/``noaux_tc``-router MoE component (entry
         ``deepseek_v4_flash_moe``): keeps its own ``pre_moe_rms_norm`` (contrast
         ``DeepseekV4MoE`` above)."""
-        topologies = (Topology("cta", 132),)
+        topologies = (Topology("cta", 132), Topology("thread", 512))
 
 
         @func
@@ -1262,7 +1262,7 @@ def build_deepseek_v4_flash(config: DSV4Config):
 
     @module(entry="lm_head", target=CudaTarget("nvidia.h200_sxm"))
     class DeepseekV4ForCausalLM:
-        topologies = (Topology("cta", 132),)
+        topologies = (Topology("cta", 132), Topology("thread", 512))
 
         @func
         def embed(

--- a/tests/models/deepseek_v4_flash/test_moe.py
+++ b/tests/models/deepseek_v4_flash/test_moe.py
@@ -45,7 +45,7 @@ def test_root_helpers_and_constraints_keep_real_model_contract() -> None:
     assert tuple(
         (topology.name, topology.size)
         for topology in deepseek_v4_flash_module.effective_topologies()
-    ) == (("cta", 132),)
+    ) == (("cta", 132), ("thread", 512))
     assert deepseek_v4_flash_moe.params[4].type.shape == (N_ROUTED, MOE_INTER, DIM)
     assert deepseek_v4_flash_moe.params[8].type.shape == (N_ROUTED, DIM, MOE_INTER)
 
@@ -113,6 +113,6 @@ def test_routed_path_is_ordinary_batched_dataflow() -> None:
 def test_root_printer_keeps_explicit_input_contracts() -> None:
     printed = as_script(deepseek_v4_flash_module)
     assert '@module(entry="deepseek_v4_flash_moe")' in printed
-    assert 'topologies = (Topology("cta", 132),)' in printed
+    assert 'topologies = (Topology("cta", 132), Topology("thread", 512),)' in printed
     assert f"routed_experts: where(layout=(_, 6 @ cta, {DIM}))" in printed
     assert f"combined: where(layout=((_, _, {DIM}), {{cta @ B()}}))" in printed

--- a/tests/models/fixtures.py
+++ b/tests/models/fixtures.py
@@ -31,7 +31,7 @@ def _parallel_units(target: Target, level: str) -> int:
     return facts.parallel_units
 
 
-def h200_sxm(*, threads_per_cta: int = 128) -> TargetFixture:
+def h200_sxm(*, threads_per_cta: int = 512) -> TargetFixture:
     """One H200 SXM, at both levels CUDA schedules.
 
     The CTA extent is the device's own SM count, so the fixture divides work over

--- a/tests/models/gemma2_2b/model.py
+++ b/tests/models/gemma2_2b/model.py
@@ -295,7 +295,7 @@ class Gemma2_2B_Decoder:
     """The ordered layer stack, the norm that closes it, and the scaled embedding
     and soft-capped head that bracket it."""
 
-    topologies = (Topology("cta", 132),)
+    topologies = (Topology("cta", 132), Topology("thread", 512))
 
     layers = tuple(
         Gemma2_2B.renamed(f"layer{index}")

--- a/tests/models/kimi_linear_48b_a3b/model.py
+++ b/tests/models/kimi_linear_48b_a3b/model.py
@@ -640,7 +640,7 @@ def build_kimi_linear_48b_a3b(config: KimiLinearConfig):
         reached through.
         """
 
-        topologies = (Topology("cta", 132),)
+        topologies = (Topology("cta", 132), Topology("thread", 512))
 
         kda = KimiKda
         mla = KimiMla

--- a/tests/models/minicpm3_4b/model.py
+++ b/tests/models/minicpm3_4b/model.py
@@ -328,7 +328,7 @@ class MiniCPM3_4B_Decoder:
     """The ordered layer stack, the norm that closes it, and the two scaled ends
     that bracket it."""
 
-    topologies = (Topology("cta", 132),)
+    topologies = (Topology("cta", 132), Topology("thread", 512))
 
     layers = tuple(
         MiniCPM3_4B.renamed(f"layer{index}")

--- a/tests/models/qwen2_5_1_5b/model.py
+++ b/tests/models/qwen2_5_1_5b/model.py
@@ -263,7 +263,7 @@ class Qwen2_5_1_5B:
 class Qwen2_5_1_5B_Decoder:
     """The ordered layer stack plus the norm that closes it."""
 
-    topologies = (Topology("cta", 132),)
+    topologies = (Topology("cta", 132), Topology("thread", 512))
 
     layers = tuple(
         Qwen2_5_1_5B.renamed(f"layer{index}")

--- a/tests/models/qwen3_1_7b/model.py
+++ b/tests/models/qwen3_1_7b/model.py
@@ -318,7 +318,7 @@ class Qwen3_1_7B:
 class Qwen3_1_7B_Decoder:
     """The ordered layer stack plus the norm that closes it."""
 
-    topologies = (Topology("cta", 132),)
+    topologies = (Topology("cta", 132), Topology("thread", 512))
 
     layers = tuple(
         Qwen3_1_7B.renamed(f"layer{index}")

--- a/tests/models/qwen3_5_35b_a3b/model.py
+++ b/tests/models/qwen3_5_35b_a3b/model.py
@@ -571,7 +571,7 @@ class Qwen3_5Decoder:
     embedding, the walk, the closing norm, the head. Each layer is an independent
     copy, so an analysis of one annotates only it."""
 
-    topologies = (Topology("cta", 132),)
+    topologies = (Topology("cta", 132), Topology("thread", 512))
 
     # The published layer-type cycle determines each layer Module.
     layers = tuple(


### PR DESCRIPTION
## Why
- `models NAME --source` emitted only `model.py`, leaving the adjacent published configuration behind and making a copied source unusable.
- Checkout and installed paths need to describe the same package payload without importing model code.

## What
- Print the absolute shipped model directory followed by its package files and first docstring lines.
- Read the checkout package manifest while listing installed model directories directly.
- Copy the complete directory in the L3 workflow and update the migration and optimization tutorials.

## Contract
- `docs/spec/cli.md`: `models NAME --source` names a model directory, lists its packaged files, and parses rather than imports source for descriptions.
- `docs/tutorial/migrate.md` and `docs/tutorial/optimize.md`: the editable copy is a directory with `mine/model.py` as its source entry.

## Verification
- `TF_SMOKE_VENV=<prebuilt-venv> CUDA_VISIBLE_DEVICES= .venv/bin/python -m pytest tests/integration/installed -o python_files='smoke_*.py' -q -n 8 --tb=short` - 55 passed.
- `CUDA_VISIBLE_DEVICES= .venv/bin/python -m pytest tests/cli -q -n 8 --tb=short` - 22 passed.
- `.venv/bin/pre-commit run --files docs/spec/cli.md docs/tutorial/migrate.md docs/tutorial/optimize.md src/tilefoundry/cli/data.py src/tilefoundry/cli/models.py tests/integration/installed/smoke_models.py tests/integration/installed/smoke_tutorial.py tests/integration/qwen3_1_7b_l3.py` - passed.
- Direct L3 source extraction against the installed wheel copied both `model.py` and `config.json`.

## Risk
- The planned `pytest tests/cli tests/models -q -n 8` cannot complete locally: xdist workers fail during collection because the host GPU is in exclusive use. The raw report is retained in `/tmp/tilefoundry-pytest/cli-models-source.txt`; CI should cover this GPU-dependent suite.
