### PR TITLE
refactor(plans): keep in the plan template only what is read

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     hooks:
       - id: ruff
         name: ruff
-        entry: ruff check --fix
+        entry: ruff check
         language: system
         types_or: [python]
       - id: clang-format
@@ -21,10 +21,23 @@ repos:
         entry: python scripts/spec_entropy_lint.py
         language: system
         files: ^src/.*\.py$
+      - id: forward-references
+        name: forward-references
+        entry: python scripts/forward_references_lint.py
+        language: system
+        types_or: [python]
+      - id: comment-hygiene
+        name: comment-hygiene
+        entry: python scripts/comment_hygiene_lint.py
+        language: system
+        types_or: [python]
       - id: no-machine-paths
         name: no-machine-paths
         entry: python scripts/no_machine_paths_lint.py
         language: system
-        # Every text file a commit touches, not only source: the paths that have
-        # been committed by mistake arrived in scripts, tests, and markdown.
+        exclude_types: [binary]
+      - id: english-only
+        name: english-only
+        entry: python scripts/english_only_lint.py
+        language: system
         exclude_types: [binary]

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -95,20 +95,18 @@ short bullet list — keep it that way.
 
 ### Spec impact
 
-- Every milestone declares `#### Spec Impact`, including documentation-only
-  and internal-only milestones.
-- A public-contract change lists its owning `docs/spec/*.md` files and repeats
-  those files in the milestone's effective `#### Related Files`.
-- A milestone without public-contract changes uses exactly one reasoned
-  `N/A:` entry; it never mixes `N/A:` with spec paths.
+- A milestone that changes a public contract lists its owning `docs/spec/*.md`
+  files in its `#### Related Files`; one that changes none lists no spec path.
+  There is no separate declaration to keep in step with that list.
 - Contract-changing implementation and its specification ship in the same
   milestone.
 
 ### Forward references
 
 - Break type-only import cycles with quoted forward-reference annotations.
-- Do not guard type-only imports with `typing.TYPE_CHECKING`; Ruff rejects that
-  shim.
+- Do not guard type-only imports with `typing.TYPE_CHECKING`; the
+  `forward-references` pre-commit hook rejects that shim. Ruff cannot be asked
+  to do it — its own `TC001`-`TC003` push the other way.
 - Import runtime dependencies normally or lazily at their point of use.
 
 ### Tests
@@ -122,7 +120,7 @@ short bullet list — keep it that way.
 - One workflow may evidence several acceptance criteria. An acceptance criterion
   describes behaviour, not a one-test obligation.
 - Add a new test only when no existing workflow can reach a public behaviour;
-  state that missing reachability in the plan's verification note.
+  state that missing reachability when you ask for the gate.
 - Lock contracts, not implementation detail. Do not test source text, AST shape,
   private calls, object identity, counts, or names merely to prevent a future
   refactor.

--- a/docs/plans/TEMPLATE.md
+++ b/docs/plans/TEMPLATE.md
@@ -4,31 +4,30 @@ component: <component name>
 target_repo: tilefoundry
 ---
 
+<!-- A plan is written in two passes by two different people.
+
+     Pass 1 — discussion (human + planner). Settles what "right" looks like:
+     Description, Goal, Constraints, and each milestone's Golden Reference and
+     Acceptance Criteria. `#### Plan` gets coarse steps only. The discipline
+     here is one rule: DO NOT WRITE A QUANTIFIER, `file:line`, OR `§x.y` YOU
+     HAVE NOT LOOKED UP. "the `reference.py` files that call `linear_weight`"
+     is a fine coarse step; "the four dense models' `reference.py`" is not,
+     unless the grep was run. Coarse means few steps, not vague ones.
+
+     Pass 2 — dispatch (the reviewer, before the implementer writes anything).
+     Explores the repository and corrects the plan: resolves every reference,
+     settles every quantifier by running the grep, fixes `#### Related Files`,
+     and turns the coarse steps into executable ones. The person writing the
+     steps is the person who just read the code, so the premises are built
+     rather than recalled. Then finalize and tell the implementer to start. -->
+
 # [TYPE][component] <short description>
 
 ## Description
 
-### Symptom / Motivation
-<!-- What is observed or what motivates this change. Specific, not abstract. -->
-
-### Root Cause Analysis
-<!-- Why it happens — file paths, logic gaps, missing features. "N/A" for new features. -->
-
-### Related Files
-<!-- Plan-wide touch surface. Every file the plan expects to add/modify, repo-relative.
-     `scripts/finalize_plan_context.py` reads this list to match path-scoped policies for
-     the plan-level Execution Preflight block. -->
-- <path>
-- <path>
-
-## Goal
-
-<!-- One sentence. Measurable verb; no "improve" / "make better". -->
-
-## Constraints
-
-- <!-- Constraint discovered during exploration -->
-- <!-- Boundary that distinguishes this plan from adjacent work -->
+<!-- Free prose, in whatever shape this plan needs: what is observed, why it
+     happens, what it would take. Nothing here is required and nothing reads it,
+     so say the thing rather than filling a form. -->
 
 ## Milestones
 
@@ -37,28 +36,26 @@ target_repo: tilefoundry
 #### Depends
 - None
 
-#### Related Files
-<!-- Per-milestone touch surface. Drives the policy-AC injection into this milestone's
-     `#### Acceptance Criteria → policy_ac` range. Use `- inherit: top-level` as an
-     explicit fallback to the plan-level `### Related Files`; implicit inheritance is
-     not allowed. -->
-- <path>
-
-#### Spec Impact
-<!-- List one or more owning `docs/spec/*.md` paths and repeat them in this
-     milestone's effective Related Files. If no public contract changes, use exactly
-     one reasoned entry: `- N/A: <reason>`. Do not mix paths and N/A. -->
-- N/A: <reason this milestone does not change a public contract>
-
 #### Golden Reference
 <!-- State the source of truth before describing code: an external implementation,
      measured current behaviour, existing end-to-end workflow, or a precise public
      contract. List only the functional points this milestone must preserve or
-     reach. A refactor's Golden Reference is the behaviour it preserves. -->
+     reach; naming the mechanism they land on is welcome — that is what makes the
+     coarse plan below writable. A refactor's Golden Reference is the behaviour it
+     preserves. Every reference in `Source:` must resolve; pass 2 completes it. -->
 - Source: <reference implementation, document, contract, or existing workflow>
 - Functional points: <observable behaviour determined by that source>
 
+#### Related Files
+<!-- Per-milestone touch surface. Drives the policy-AC injection into this milestone's
+     `#### Acceptance Criteria → policy_ac` range. Use `- inherit: top-level` as an
+     explicit fallback to the plan-level `### Related Files`; implicit inheritance is
+     not allowed. List `docs/spec/*.md` here when this milestone changes a spec. -->
+- <path>
+
 #### Plan
+<!-- Pass 1 leaves coarse steps; pass 2 makes them executable — real files, real call
+     sites, real order. -->
 - [ ] step 0.1 <action with affected files>
 - [ ] step 0.2 <action>
 
@@ -66,39 +63,29 @@ target_repo: tilefoundry
 <!-- State observable completed behaviour. An AC is not a request for its own test:
      one complete workflow may evidence several ACs. Do not specify source scans,
      private calls, object identities, line counts, or other implementation shape
-     unless that form is itself a public contract. -->
+     unless that form is itself a public contract. The evidence that an AC is met
+     belongs in the gate request, not here — before implementation there is no
+     receipt to write down. -->
 - [ ] AC-0-1: <author-written, milestone-specific observable behaviour>
 - [ ] AC-0-2: <author-written, milestone-specific observable behaviour>
 <!-- policy_ac:start -->
 - [ ] Milestone MUST name a `#### Golden Reference` before implementation steps, with the source of truth and the observable functional points it determines. <!-- policy_ac: milestone_review-0 -->
-- [ ] Verification MUST exercise the Golden Reference's functional points through the smallest real workflow; one workflow MAY cover several ACs, and a new test requires a stated reachability gap. <!-- policy_ac: milestone_review-1 -->
+- [ ] The gate request MUST show the Golden Reference's functional points exercised through the smallest real workflow, naming the retained evidence; one workflow MAY cover several ACs, and a new test requires a stated reachability gap. <!-- policy_ac: milestone_review-1 -->
 - [ ] Touched tests and comments MUST be reviewed for redundancy: remove ones superseded by the retained workflow, and do not add source-shape or hypothetical-refactor guards unless that form is a public contract. <!-- policy_ac: milestone_review-2 -->
 <!-- policy_ac:end -->
-
-#### Verification
-<!-- Prove the Golden Reference's functional points through the smallest real
-     workflow. Extend an existing workflow before adding a test. A new test needs a
-     short reason that no existing workflow reaches that point; do not add one merely
-     to make an AC individually test-shaped. -->
-- Golden point(s) exercised: <the point(s) above>
-- Evidence: <command, test, or end-to-end path>
-- New coverage: N/A — <why the existing workflow is sufficient>
 
 ### Milestone M1: <name>
 
 #### Depends
 - M0
 
-#### Related Files
-- <path>
-- `docs/spec/<name>.md`
-
-#### Spec Impact
-- `docs/spec/<name>.md`
-
 #### Golden Reference
 - Source: <reference implementation, document, contract, or existing workflow>
 - Functional points: <observable behaviour determined by that source>
+
+#### Related Files
+- <path>
+- `docs/spec/<name>.md`
 
 #### Plan
 - [ ] step 1.1 <action>
@@ -107,32 +94,9 @@ target_repo: tilefoundry
 - [ ] AC-1-1: <author-written observable behaviour>
 <!-- policy_ac:start -->
 - [ ] Milestone MUST name a `#### Golden Reference` before implementation steps, with the source of truth and the observable functional points it determines. <!-- policy_ac: milestone_review-0 -->
-- [ ] Verification MUST exercise the Golden Reference's functional points through the smallest real workflow; one workflow MAY cover several ACs, and a new test requires a stated reachability gap. <!-- policy_ac: milestone_review-1 -->
+- [ ] The gate request MUST show the Golden Reference's functional points exercised through the smallest real workflow, naming the retained evidence; one workflow MAY cover several ACs, and a new test requires a stated reachability gap. <!-- policy_ac: milestone_review-1 -->
 - [ ] Touched tests and comments MUST be reviewed for redundancy: remove ones superseded by the retained workflow, and do not add source-shape or hypothetical-refactor guards unless that form is a public contract. <!-- policy_ac: milestone_review-2 -->
 <!-- policy_ac:end -->
-
-#### Verification
-- Golden point(s) exercised: <the point(s) above>
-- Evidence: <command, test, or end-to-end path>
-- New coverage: N/A — <why the existing workflow is sufficient>
-
-## Execution Preflight
-
-<!-- This block is auto-filled by `scripts/finalize_plan_context.py`.
-     It surfaces the policy entries from `docs/policies/project-policy.json`
-     whose `when.path_glob` matches the plan-level `### Related Files`
-     above, so the implementer and reviewer can see the cross-cutting
-     rules / knowledge for this plan in one place. It also validates each
-     milestone's `Spec Impact`, `Golden Reference`, and `Verification`
-     sections. Leave the marker pair below and run the finalizer; do not
-     hand-edit the body. -->
-<!-- policy_preflight:start -->
-
-### Policy Rules & Knowledge
-
-- Scope discipline — One commit touches only what the current task requires; unrelated edits / submodule bumps / autoformat go in separate commits or are called out explicitly. (see `docs/develop.md § Scope`) <!-- policy_rules: scope_discipline -->
-- Milestone review — Each milestone names its Golden Reference, verifies its functional points through real workflows, and removes redundant test/comment scaffolding. (see `docs/develop.md § Tests`, `docs/develop.md § Code comments`) <!-- policy_rules: milestone_review -->
-<!-- policy_preflight:end -->
 
 ## Final Gate
 
@@ -140,5 +104,6 @@ target_repo: tilefoundry
      plan. It holds repository-wide checks such as spec discipline and
      clang-format; do not repeat those gates in every milestone. -->
 <!-- final_gate:start -->
+- [ ] Spec section MUST NOT enumerate test names; the pre-commit `spec-rules-lint` and `english-only` hooks already reject forbidden section headers, plan / milestone / task / PR / commit references, agent names, and non-English text. <!-- policy_final: spec_discipline-0 -->
 - [ ] No touched C++/CUDA files in this plan — clang-format gate N/A <!-- policy_final: clang_format-na -->
 <!-- final_gate:end -->

--- a/docs/policies/project-policy.json
+++ b/docs/policies/project-policy.json
@@ -2,22 +2,6 @@
   "version": 1,
   "policies": [
     {
-      "id": "comment_hygiene",
-      "name": "Comment hygiene",
-      "description": "Code comments only describe local logic; no plan / milestone / version / review / discussion narration.",
-      "when": {
-        "path_glob": ["src/**", "tests/**"]
-      },
-      "rules": {
-        "implementer": [
-          {"path": "docs/develop.md", "section": "Code comments"}
-        ],
-        "reviewer": [
-          {"path": "docs/develop.md", "section": "Code comments"}
-        ]
-      }
-    },
-    {
       "id": "scope_discipline",
       "name": "Scope discipline",
       "description": "One commit touches only what the current task requires; unrelated edits / submodule bumps / autoformat go in separate commits or are called out explicitly.",
@@ -42,7 +26,7 @@
       },
       "ac": [
         "Milestone MUST name a `#### Golden Reference` before implementation steps, with the source of truth and the observable functional points it determines.",
-        "Verification MUST exercise the Golden Reference's functional points through the smallest real workflow; one workflow MAY cover several ACs, and a new test requires a stated reachability gap.",
+        "The gate request MUST show the Golden Reference's functional points exercised through the smallest real workflow, naming the retained evidence; one workflow MAY cover several ACs, and a new test requires a stated reachability gap.",
         "Touched tests and comments MUST be reviewed for redundancy: remove ones superseded by the retained workflow, and do not add source-shape or hypothetical-refactor guards unless that form is a public contract."
       ],
       "rules": {
@@ -59,12 +43,12 @@
     {
       "id": "spec_impact",
       "name": "Spec impact",
-      "description": "Every source milestone explicitly classifies whether it changes a public contract and names the owning specifications when it does.",
+      "description": "Every source milestone names the specifications it changes among its Related Files, so the public-contract surface is declared once.",
       "when": {
         "path_glob": ["src/**", "include/**"]
       },
       "ac": [
-        "Milestone MUST classify public-contract impact in `#### Spec Impact`: list owning `docs/spec/*.md` paths or exactly one reasoned `N/A:` entry."
+        "A milestone that changes a public contract MUST list the owning `docs/spec/*.md` path in its `#### Related Files`; one that changes none lists no spec path."
       ],
       "rules": {
         "implementer": [
@@ -72,22 +56,6 @@
         ],
         "reviewer": [
           {"path": "docs/develop.md", "section": "Spec impact"}
-        ]
-      }
-    },
-    {
-      "id": "forward_references",
-      "name": "Forward references",
-      "description": "Python type-only cycles use quoted forward references without `typing.TYPE_CHECKING` shims.",
-      "when": {
-        "path_glob": ["**/*.py"]
-      },
-      "rules": {
-        "implementer": [
-          {"path": "docs/develop.md", "section": "Forward references"}
-        ],
-        "reviewer": [
-          {"path": "docs/develop.md", "section": "Forward references"}
         ]
       }
     },
@@ -142,10 +110,7 @@
         "path_glob": ["docs/spec/**"]
       },
       "final_ac": [
-        "Spec section MUST NOT reference plans, milestones, task IDs, commit hashes, PR numbers, agent / human names, or thread / message IDs.",
-        "Spec section MUST NOT carry a `Non-Goals` / `Future / TODO` / `Out of scope` section.",
-        "Spec section MUST NOT carry a `Tests` / `Testing` / `Test plan` section or a list of test names.",
-        "Spec section MUST be in English."
+        "Spec section MUST NOT enumerate test names; the pre-commit `spec-rules-lint` and `english-only` hooks already reject forbidden section headers, plan / milestone / task / PR / commit references, agent names, and non-English text."
       ],
       "rules": {
         "implementer": [

--- a/scripts/comment_hygiene_lint.py
+++ b/scripts/comment_hygiene_lint.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Reject a comment that narrates the process instead of the code.
+
+A comment earns its place by saying something the surrounding lines cannot say
+for themselves. "AC-4-1", "milestone M2", "as review asked" say nothing about
+the code: they point at a document the reader does not have, which will be
+merged and deleted, after which the comment is a dangling reference that still
+looks authoritative. The reason a line exists belongs in the line, the commit
+message, or the spec -- three places that outlive the plan that prompted it.
+
+The patterns here were calibrated against the tree rather than guessed. Two
+tempting rules are deliberately absent:
+
+* A bare `plan` is a domain term in this project -- a schedule plan -- and every
+  one of the fourteen comments mentioning it describes the code. Only a plan
+  *reference* (`plan 18`, `docs/plans/...`) is matched.
+* History words (`no longer`, `previously`, `used to`) read as narration but in
+  this tree describe current logic: "a function that no longer exists" is about
+  a stale cache entry, not about an edit.
+
+Run over the files a commit touches (the pre-commit hook passes them); the exit
+status is non-zero if any was found.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+#: Process references that cannot mean anything to a reader of the code alone.
+_NARRATION: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"\bAC-\d+-\d+\b"), "an acceptance-criterion id"),
+    (re.compile(r"\bmilestones?\s+M\d+\b", re.IGNORECASE), "a milestone reference"),
+    (re.compile(r"\bplans?\s+`?\d+`?\b", re.IGNORECASE), "a plan reference"),
+    (re.compile(r"docs/plans/"), "a plan path"),
+    (re.compile(r"\b(?:PR|pull request|issue)\s*#?\d+\b", re.IGNORECASE), "a PR/issue reference"),
+    (re.compile(r"\bcommit\s+[0-9a-f]{7,40}\b", re.IGNORECASE), "a commit hash"),
+    (
+        re.compile(
+            r"\b(?:as discussed|per review|review(?:er)? (?:said|asked|wants|requested)"
+            r"|address(?:ed|ing) (?:the )?(?:review|feedback)|as agreed)\b",
+            re.IGNORECASE,
+        ),
+        "review narration",
+    ),
+]
+
+#: A `#` inside a string literal is not a comment. This is deliberately crude --
+#: it takes the first `#` that has no quote before it on the line, which is wrong
+#: only for a line whose comment follows a quote-containing expression. Such a
+#: line is skipped rather than mis-parsed: a linter that invents violations is
+#: worse than one that misses a few.
+_COMMENT = re.compile(r"^(?P<code>[^'\"#]*)#(?P<body>.*)$")
+
+#: A line that legitimately names one of these shapes says so.
+_ALLOW = re.compile(r"comment-hygiene:\s*allow")
+
+#: This file states the patterns, so its own source is not scanned for them.
+_SELF = Path(__file__).resolve()
+
+
+def findings(path: Path) -> list[tuple[int, str, str]]:
+    """Every narrating comment in *path*, as (line number, what, line)."""
+    if path.resolve() == _SELF or path.suffix != ".py":
+        return []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []  # unreadable or binary: nothing to claim about it
+    found = []
+    for number, line in enumerate(text.splitlines(), start=1):
+        if _ALLOW.search(line):
+            continue
+        match = _COMMENT.match(line)
+        if match is None:
+            continue
+        body = match.group("body")
+        for pattern, what in _NARRATION:
+            if pattern.search(body):
+                found.append((number, what, line.strip()))
+                break
+    return found
+
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        print(
+            "usage: comment_hygiene_lint.py <path> ...  "
+            "(the pre-commit hook passes the staged files)",
+            file=sys.stderr,
+        )
+        return 2
+    failed = False
+    for name in argv:
+        path = Path(name)
+        for number, what, line in findings(path):
+            failed = True
+            print(f"{path}:{number}: comment carries {what}")
+            print(f"    {line}")
+    if failed:
+        print(
+            "\nA comment MUST describe the code around it. Why a line exists "
+            "belongs in the line, the commit message, or the spec -- the plan it "
+            "came from will be merged and deleted. A line that genuinely names "
+            "one of these shapes can say 'comment-hygiene: allow'.",
+            file=sys.stderr,
+        )
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/english_only_lint.py
+++ b/scripts/english_only_lint.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Reject non-Latin script in anything this repository commits.
+
+`docs/SPEC-RULES.md` states it for spec text; the reason is not specific to
+specs. Everything committed here is read by contributors and by agents that were
+handed this checkout and nothing else: an identifier, a comment, a docstring, or
+a document in a script the reader cannot type is a dead end for them. Discussion
+happens in whatever language suits the people having it; what lands in the tree
+is English.
+
+Detected by script, not by language: CJK, Hangul, Cyrillic, Arabic and Hebrew
+ranges. This catches the case that actually occurs -- notes written in the
+author's own language -- without trying to judge English prose. Latin-1 accented
+letters are left alone, so a name like `Müller` or a word like `naïve` passes.
+Greek is left alone too, and deliberately: it is mathematical notation here
+(`Σ`, `Π` in the layout algebra and in `spec runtime`), read the same way by
+everyone.
+
+Run over the files a commit touches (the pre-commit hook passes them); the exit
+status is non-zero if any was found.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import unicodedata
+from pathlib import Path
+
+#: Scripts a reader of this repository is not assumed to have.
+_NON_LATIN = re.compile(
+    "["
+    "　-〿"  # CJK punctuation
+    "぀-ヿ"  # Hiragana, Katakana
+    "㐀-䶿"  # CJK extension A
+    "一-鿿"  # CJK unified ideographs
+    "가-힯"  # Hangul syllables
+    "＀-￯"  # fullwidth and halfwidth forms
+    "Ѐ-ӿ"  # Cyrillic
+    "֐-׿"  # Hebrew
+    "؀-ۿ"  # Arabic
+    "]"
+)
+
+#: A line that legitimately carries such a character -- a test of this very
+#: behaviour, an encoding fixture -- says so.
+_ALLOW = re.compile(r"english-only:\s*allow")
+
+#: This file states the ranges, so its own source is not scanned.
+_SELF = Path(__file__).resolve()
+
+
+def findings(path: Path) -> list[tuple[int, str, str]]:
+    """Every non-Latin character in *path*, as (line number, name, line)."""
+    if path.resolve() == _SELF:
+        return []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []  # unreadable or binary: nothing to claim about it
+    found = []
+    for number, line in enumerate(text.splitlines(), start=1):
+        if _ALLOW.search(line):
+            continue
+        match = _NON_LATIN.search(line)
+        if match is not None:
+            char = match.group(0)
+            name = unicodedata.name(char, f"U+{ord(char):04X}")
+            found.append((number, f"{char!r} ({name})", line.strip()))
+    return found
+
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        print(
+            "usage: english_only_lint.py <path> ...  "
+            "(the pre-commit hook passes the staged files)",
+            file=sys.stderr,
+        )
+        return 2
+    failed = False
+    for name in argv:
+        path = Path(name)
+        for number, char, line in findings(path):
+            failed = True
+            print(f"{path}:{number}: non-Latin character {char}")
+            print(f"    {line}")
+    if failed:
+        print(
+            "\nWhat lands in this tree is English -- a reader handed this "
+            "checkout and nothing else has to be able to read it. Discuss in any "
+            "language; commit in English. A line that genuinely needs such a "
+            "character can say 'english-only: allow'.",
+            file=sys.stderr,
+        )
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/finalize_plan_context.py
+++ b/scripts/finalize_plan_context.py
@@ -1,27 +1,27 @@
 #!/usr/bin/env python3
 """Plan finalizer for `docs/plans/<name>.md`.
 
-Reads a plan written against `docs/plans/TEMPLATE.md`, matches the
-plan-level and per-milestone ``Related Files`` against
+Reads a plan written against `docs/plans/TEMPLATE.md`, matches each
+milestone's ``#### Related Files`` against
 `docs/policies/project-policy.json`, and rewrites two kinds of
 generated regions:
 
-- the plan-level ``<!-- policy_preflight:start --> ... <!-- policy_preflight:end -->``
-  block carries the plan-wide ``### Policy Rules & Knowledge``
-  subsection (refs-only — never the actual rule / knowledge text);
 - each milestone's ``<!-- policy_ac:start --> ... <!-- policy_ac:end -->``
   range carries the policy ACs whose ``when.path_glob`` matches that
-  milestone's ``#### Related Files`` (with explicit
-  ``- inherit: top-level`` fallback).
+  milestone's ``#### Related Files``;
 - the plan-level ``<!-- final_gate:start --> ... <!-- final_gate:end -->``
   range carries final-tree gates such as spec discipline and formatting.
 
+Rules and knowledge are NOT injected into the plan. They are asked for
+when they are needed: ``scripts/get_policy.py --type rules --role
+implementer --paths ...``. A rule restated in every plan is a rule
+nobody rereads.
+
 The finalizer never touches handwritten content outside the marker
 ranges. A ``policy_*`` HTML comment appearing outside any allowed
-range is a hard validation failure. Every milestone must declare its
-public-contract impact in ``Spec Impact`` as either owning
-``docs/spec/*.md`` paths or one reasoned ``N/A:`` entry, and must name
-its Golden Reference and behavioural verification boundary.
+range is a hard validation failure. Every milestone must name its
+Golden Reference; a milestone that changes a public contract declares
+so by listing the owning ``docs/spec/*.md`` path in its Related Files.
 """
 from __future__ import annotations
 
@@ -43,8 +43,6 @@ from get_policy import filter_policies, load_policies  # noqa: E402
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_POLICY = REPO_ROOT / "docs" / "policies" / "project-policy.json"
 
-PREFLIGHT_START = "<!-- policy_preflight:start -->"
-PREFLIGHT_END = "<!-- policy_preflight:end -->"
 MILESTONE_AC_START = "<!-- policy_ac:start -->"
 MILESTONE_AC_END = "<!-- policy_ac:end -->"
 FINAL_GATE_START = "<!-- final_gate:start -->"
@@ -87,6 +85,24 @@ def _split_lines(text: str) -> list[str]:
 
 def _join_lines(lines: list[str]) -> str:
     return "\n".join(lines)
+
+
+def _mask_fenced(lines: list[str]) -> list[str]:
+    """The same lines with fenced blocks blanked, positions preserved.
+
+    Structure is read off this copy, so a fenced line is content whatever it
+    starts with. A plan quotes command output whose lines begin with `#`, and
+    reading one as a heading would end the section it belongs to.
+    """
+    masked: list[str] = []
+    in_fence = False
+    for line in lines:
+        if FENCE_RE.match(line):
+            in_fence = not in_fence
+            masked.append("")
+            continue
+        masked.append("" if in_fence else line)
+    return masked
 
 
 def _heading_level(line: str) -> int | None:
@@ -175,52 +191,24 @@ def _strip_path_bullet(item: str) -> str:
     return s
 
 
-def _is_spec_path(path: str) -> bool:
-    """Return whether *path* is a repo-relative Markdown spec path."""
-    parts = Path(path).parts
-    return (
-        len(parts) >= 3
-        and parts[:2] == ("docs", "spec")
-        and all(part not in ("", ".", "..") for part in parts)
-        and path.endswith(".md")
-    )
-
-
 class PlanModel:
     def __init__(self, plan_path: Path) -> None:
         self.path = plan_path
         self.text = plan_path.read_text()
         self.lines = _split_lines(self.text)
+        # Headings, bullets and markers are located on the masked copy; the
+        # verbatim lines are what gets rewritten.
+        self.scan = _mask_fenced(self.lines)
         self._parse()
 
     def _parse(self) -> None:
-        lines = self.lines
+        lines = self.scan
 
-        # Plan-level Description / Related Files.
-        desc = _find_section(lines, 2, "Description")
-        if desc is None:
-            raise FinalizeError(
-                f"{self.path}: missing required `## Description` section."
-            )
-        rel = _find_section(lines, 3, "Related Files", desc[0] + 1, desc[1])
-        if rel is None:
-            raise FinalizeError(
-                f"{self.path}: missing required `### Related Files` under `## Description`."
-            )
-        rel_items = _related_files_from_section(lines, rel[0], rel[1])
-        if not rel_items:
-            raise FinalizeError(
-                f"{self.path}: `### Related Files` is empty."
-            )
-        self.plan_related_files: list[str] = [_strip_path_bullet(r) for r in rel_items]
+        # There is no plan-level touch surface to write down: it is the union of
+        # the milestones', filled in after they are parsed. `## Description`
+        # above is free prose, and nothing here reads it.
+        self.plan_related_files: list[str] = []
 
-        # Plan-level Preflight range.
-        self.preflight_start_idx = self._require_unique_line(PREFLIGHT_START)
-        self.preflight_end_idx = self._require_unique_line(PREFLIGHT_END)
-        if self.preflight_end_idx <= self.preflight_start_idx:
-            raise FinalizeError(
-                f"{self.path}: `policy_preflight:end` precedes `policy_preflight:start`."
-            )
         self.final_gate_start_idx = self._require_unique_line(FINAL_GATE_START)
         self.final_gate_end_idx = self._require_unique_line(FINAL_GATE_END)
         if self.final_gate_end_idx <= self.final_gate_start_idx:
@@ -234,9 +222,7 @@ class PlanModel:
         # Plan-level template sections: every level-2 heading the
         # template promises must exist (and have a non-empty body for
         # the prose ones).
-        for name in (
-            "Goal", "Constraints", "Milestones", "Execution Preflight", "Final Gate"
-        ):
+        for name in ("Description", "Milestones", "Final Gate"):
             span = _find_section(lines, 2, name)
             if span is None:
                 raise FinalizeError(
@@ -270,8 +256,17 @@ class PlanModel:
                 f"{self.path}: `## Milestones` block contains no `### Milestone …` entries."
             )
 
+        # The plan's touch surface is what its milestones touch -- stated once,
+        # per milestone, and unioned here in first-mention order.
+        seen: set[str] = set()
+        for m in self.milestones:
+            for path in m["related_files"]:
+                if path not in seen:
+                    seen.add(path)
+                    self.plan_related_files.append(path)
+
     def _require_unique_line(self, marker: str) -> int:
-        idxs = [i for i, line in enumerate(self.lines) if line.strip() == marker]
+        idxs = [i for i, line in enumerate(self.scan) if line.strip() == marker]
         if not idxs:
             raise FinalizeError(
                 f"{self.path}: marker {marker!r} missing — finalize_plan_context "
@@ -285,20 +280,18 @@ class PlanModel:
         return idxs[0]
 
     def _parse_milestone(self, ms_start: int, ms_end: int) -> dict[str, Any]:
-        lines = self.lines
-        name = _heading_text(lines[ms_start])  # e.g. "Milestone M0: Schema"
+        lines = self.scan
+        name = _heading_text(lines[ms_start])  # e.g. "Milestone M0: Schema"  comment-hygiene: allow
 
         # Every level-4 heading the template promises must exist and
         # carry a non-empty body.
         sections: dict[str, tuple[int, int]] = {}
         for required in (
             "Depends",
-            "Related Files",
-            "Spec Impact",
             "Golden Reference",
+            "Related Files",
             "Plan",
             "Acceptance Criteria",
-            "Verification",
         ):
             span = _find_section(lines, 4, required, ms_start + 1, ms_end)
             if span is None:
@@ -323,22 +316,18 @@ class PlanModel:
 
         related = sections["Related Files"]
         rel_items = _related_files_from_section(lines, related[0], related[1])
-
-        # Resolve inheritance.
         effective_paths: list[str] = []
         for item in rel_items:
             if item.lower() == "inherit: top-level":
-                effective_paths.extend(self.plan_related_files)
-            else:
-                effective_paths.append(_strip_path_bullet(item))
+                raise FinalizeError(
+                    f"{self.path}: milestone {name!r} says `inherit: top-level`, "
+                    "but there is no plan-level `Related Files` to inherit from -- "
+                    "the plan's touch surface is the union of its milestones'. "
+                    "List the paths this milestone touches."
+                )
+            effective_paths.append(_strip_path_bullet(item))
 
-        self._validate_spec_impact(
-            name,
-            sections["Spec Impact"],
-            effective_paths,
-        )
         self._validate_golden_reference(name, sections["Golden Reference"])
-        self._validate_verification(name, sections["Verification"])
 
         ac_section = sections["Acceptance Criteria"]
 
@@ -374,7 +363,7 @@ class PlanModel:
     def _validate_golden_reference(
         self, milestone_name: str, section: tuple[int, int]
     ) -> None:
-        items = _list_bullets(self.lines, section[0] + 1, section[1])
+        items = _list_bullets(self.scan, section[0] + 1, section[1])
         label = f"{self.path}: milestone {milestone_name!r} `#### Golden Reference`"
         required = ("Source:", "Functional points:")
         missing = [prefix for prefix in required if not any(item.startswith(prefix) for item in items)]
@@ -383,63 +372,6 @@ class PlanModel:
                 f"{label} must contain {', '.join(repr(prefix) for prefix in missing)} "
                 "bullet(s)."
             )
-
-    def _validate_verification(
-        self, milestone_name: str, section: tuple[int, int]
-    ) -> None:
-        items = _list_bullets(self.lines, section[0] + 1, section[1])
-        label = f"{self.path}: milestone {milestone_name!r} `#### Verification`"
-        required = ("Golden point(s) exercised:", "Evidence:")
-        missing = [prefix for prefix in required if not any(item.startswith(prefix) for item in items)]
-        if missing:
-            raise FinalizeError(
-                f"{label} must contain {', '.join(repr(prefix) for prefix in missing)} "
-                "bullet(s)."
-            )
-
-    def _validate_spec_impact(
-        self,
-        milestone_name: str,
-        section: tuple[int, int],
-        related_files: list[str],
-    ) -> None:
-        items = _list_bullets(self.lines, section[0] + 1, section[1])
-        label = f"{self.path}: milestone {milestone_name!r} `#### Spec Impact`"
-        if not items:
-            raise FinalizeError(
-                f"{label} must contain one or more bullet entries."
-            )
-
-        na_items = [item for item in items if item.upper().startswith("N/A")]
-        if na_items:
-            if len(items) != 1:
-                raise FinalizeError(
-                    f"{label} cannot mix an `N/A:` entry with spec paths."
-                )
-            if re.fullmatch(r"N/A:\s+\S(?:.*\S)?", items[0], re.IGNORECASE) is None:
-                raise FinalizeError(
-                    f"{label} must use one reasoned `N/A: <reason>` entry."
-                )
-            return
-
-        spec_paths: list[str] = []
-        for item in items:
-            path = _strip_path_bullet(item)
-            if not _is_spec_path(path):
-                raise FinalizeError(
-                    f"{label} entry {item!r} must be a `docs/spec/*.md` path "
-                    "or one reasoned `N/A:` entry."
-                )
-            spec_paths.append(path)
-
-        missing = [path for path in spec_paths if path not in related_files]
-        if missing:
-            formatted = ", ".join(repr(path) for path in missing)
-            raise FinalizeError(
-                f"{label} path(s) {formatted} must also appear in the milestone's "
-                "effective `#### Related Files`."
-            )
-
 
 # ---------------------------------------------------------------------------
 # Render
@@ -450,28 +382,6 @@ def _refs_phrase(refs: list[dict[str, str]]) -> str:
     parts = [f"`{r['path']} § {r['section']}`" for r in refs]
     return ", ".join(parts)
 
-
-def render_preflight_body(matched: list[dict[str, Any]], role: str) -> list[str]:
-    """Return the lines that go between the preflight markers
-    (exclusive). Empty list when no rules / knowledge applies.
-
-    The body is rendered deterministically: policies appear in their
-    original order in the policy file; within each policy, rules
-    precede knowledge.
-    """
-    items: list[str] = []
-    for p in matched:
-        for kind, marker in (("rules", "policy_rules"), ("knowledge", "policy_knowledge")):
-            refs = p.get(kind, {}).get(role) or []
-            if not refs:
-                continue
-            items.append(
-                f"- {p['name']} — {p['description']} (see {_refs_phrase(refs)}) "
-                f"<!-- {marker}: {p['id']} -->"
-            )
-    if not items:
-        return []
-    return ["", "### Policy Rules & Knowledge", "", *items]
 
 
 def render_policy_ac_body(
@@ -543,17 +453,15 @@ def finalize_plan(
     plan = PlanModel(plan_path)
     policies = load_policies(policy_path)
 
-    # Plan-level scope.
+    # Plan-level scope: the union of what the milestones touch, used for the
+    # final-tree gates.
     plan_matched = filter_policies(policies, plan.plan_related_files)
-    preflight_body = render_preflight_body(plan_matched, role)
 
     # Build the full list of (start, end, body) rewrites, then apply
     # them from highest-index to lowest. Higher-index rewrites do not
     # shift the positions of lower-index ranges, so a single descending
     # sort lets us splice without recomputing indices.
-    rewrites: list[tuple[int, int, list[str]]] = [
-        (plan.preflight_start_idx, plan.preflight_end_idx, preflight_body)
-    ]
+    rewrites: list[tuple[int, int, list[str]]] = []
     for m in plan.milestones:
         matched = filter_policies(policies, m["related_files"])
         body = render_policy_ac_body(matched, m["policy_states"])
@@ -579,13 +487,7 @@ def finalize_plan(
     # so a stale tag inside the now-generated range is naturally caught
     # as "inside an allowed range" while a tag living in author-written
     # prose is caught here.
-    final_preflight_start = next(
-        i for i, line in enumerate(new_lines) if line.strip() == PREFLIGHT_START
-    )
-    final_preflight_end = next(
-        i for i, line in enumerate(new_lines) if line.strip() == PREFLIGHT_END
-    )
-    allowed: list[tuple[int, int]] = [(final_preflight_start, final_preflight_end)]
+    allowed: list[tuple[int, int]] = []
     final_gate_start = next(
         i for i, line in enumerate(new_lines) if line.strip() == FINAL_GATE_START
     )

--- a/scripts/forward_references_lint.py
+++ b/scripts/forward_references_lint.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Reject `typing.TYPE_CHECKING` as a way to break an import cycle.
+
+A type-only cycle has two shapes. One puts the import behind
+``if TYPE_CHECKING:`` and quotes the annotation; the other just quotes the
+annotation and does not import at all. Both type-check. Only the second is
+honest about what the module needs at runtime: the first states an import that
+never happens, so a reader cannot tell a real dependency from a spelling aid,
+and any tool that walks imports sees an edge that is not there.
+
+`from __future__ import annotations` is already on in this project, so every
+annotation is a string and the quoted form costs nothing.
+
+Ruff's own TC001-TC003 push the opposite way -- they move runtime imports *into*
+a `TYPE_CHECKING` block -- so this rule cannot be delegated to it.
+
+Run over the files a commit touches (the pre-commit hook passes them); the exit
+status is non-zero if any was found.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+#: Both the import of the flag and any use of it. Importing it and never
+#: branching on it is dead weight; branching on it is the shim itself.
+_TYPE_CHECKING = re.compile(r"(?:^|[^\w.])(TYPE_CHECKING)\b")
+
+#: This file states the pattern, so its own source is not scanned for it.
+_SELF = Path(__file__).resolve()
+
+
+def findings(path: Path) -> list[tuple[int, str]]:
+    """Every `TYPE_CHECKING` mention in *path*, as (line number, line)."""
+    if path.resolve() == _SELF or path.suffix != ".py":
+        return []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []  # unreadable or binary: nothing to claim about it
+    return [
+        (number, line.strip())
+        for number, line in enumerate(text.splitlines(), start=1)
+        if _TYPE_CHECKING.search(line)
+    ]
+
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        print(
+            "usage: forward_references_lint.py <path> ...  "
+            "(the pre-commit hook passes the staged files)",
+            file=sys.stderr,
+        )
+        return 2
+    failed = False
+    for name in argv:
+        path = Path(name)
+        for number, line in findings(path):
+            failed = True
+            print(f"{path}:{number}: `TYPE_CHECKING` shim")
+            print(f"    {line}")
+    if failed:
+        print(
+            "\nA type-only cycle MUST be broken by quoting the annotation and "
+            "dropping the import, not by hiding the import behind "
+            "`if TYPE_CHECKING:`. The module's import list is then what it "
+            "actually needs to run.",
+            file=sys.stderr,
+        )
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/spec_rules_lint.py
+++ b/scripts/spec_rules_lint.py
@@ -40,6 +40,14 @@ _TOKEN_RULES: list[tuple[re.Pattern, str]] = [
     (re.compile(r"\bM\d+[a-z]?\b"), "a milestone identifier (e.g. M0 / M1a)"),
     (re.compile(r"\btask #\d+"), "a task id (task #N)"),
     (re.compile(r"\bPR #?\d+\b"), "a pull-request number (PR #N)"),
+    (
+        # A sha carries both a letter and a digit; requiring both keeps a plain
+        # decimal constant (`value = 4800000000000`) from reading as one.
+        re.compile(
+            r"\b(?=[0-9a-f]{7,40}\b)(?=[0-9a-f]*[a-f])(?=[0-9a-f]*[0-9])[0-9a-f]{7,40}\b"
+        ),
+        "a commit hash",
+    ),
     (re.compile(r"\b(?:Alice|Bob|ZhengQiHang)\b"), "an agent / human name"),
     (
         re.compile(r"\bV\d+\b"),
@@ -51,8 +59,7 @@ _TOKEN_RULES: list[tuple[re.Pattern, str]] = [
 # Forbidden section-header terms (matched only on heading lines, so ordinary
 # prose like "in the future" is never flagged).
 _HEADER_TERMS = re.compile(
-    r"\b(?:Non-goals?|非目标|Future|TODO|Out of scope|Tests|Testing|"
-    r"Test plan|测试要求)\b",
+    r"\b(?:Non-goals?|Future|TODO|Out of scope|Tests|Testing|Test plan)\b",
     re.IGNORECASE,
 )
 _HEADING = re.compile(r"^\s*#{1,6}\s")

--- a/tests/scripts/test_finalize_plan_context.py
+++ b/tests/scripts/test_finalize_plan_context.py
@@ -15,9 +15,9 @@ def test_template_finalizer_keeps_milestone_and_final_gate_scoped(
     before, after = finalize_plan(plan, write=False)
     assert before != after
     assert after.count("Milestone MUST name a `#### Golden Reference`") == 2
-    assert after.count("Verification MUST exercise the Golden Reference") == 2
+    assert after.count("The gate request MUST show the Golden Reference") == 2
     assert after.count("Touched tests and comments MUST be reviewed") == 2
-    assert after.count("Milestone MUST classify public-contract impact") == 2
+    assert after.count("MUST list the owning `docs/spec/*.md` path") == 2
     assert after.count("Spec section MUST NOT reference plans") == 0
     assert after.count("No touched C++/CUDA files in this plan") == 1
 
@@ -29,3 +29,24 @@ def test_template_finalizer_keeps_milestone_and_final_gate_scoped(
     plan.write_text(checked)
     _, preserved = finalize_plan(plan, write=False)
     assert "- [x] Milestone MUST name a `#### Golden Reference`" in preserved
+
+
+def test_a_fenced_comment_line_is_quoted_output_not_a_heading(tmp_path: Path) -> None:
+    """A plan quotes analyze output, whose lines begin with `#`."""
+    template = Path(__file__).parents[2] / "docs/plans/TEMPLATE.md"
+    canonical, _ = finalize_plan(template, write=False)
+    quoted = canonical.replace(
+        "## Description",
+        "## Description\n\n"
+        "```console\n"
+        "$ tilefoundry analyze model.py:Model.layer\n"
+        "# traffic gmem=r3322101984/w100868096\n"
+        "```",
+        1,
+    ).replace("<path>", "src/example.py")
+
+    plan = tmp_path / "quoting.md"
+    plan.write_text(quoted)
+    _, after = finalize_plan(plan, write=False)
+    assert after.count("Milestone MUST name a `#### Golden Reference`") == 2
+    assert "# traffic gmem=r3322101984/w100868096" in after

--- a/tests/target/test_amx_target.py
+++ b/tests/target/test_amx_target.py
@@ -88,11 +88,6 @@ def bf16_gemm(
     return h
 
 
-# ---------------------------------------------------------------------------
-# AC-4-1
-# ---------------------------------------------------------------------------
-
-
 def test_amx_target_reports_and_validates_its_own_topology_levels():
     """The AMX levels are the core a tile stream runs on and the AMX unit inside
     it that issues one atom. The core limit is the measured performance-core
@@ -127,11 +122,6 @@ def test_amx_target_reports_and_validates_its_own_topology_levels():
         target.validate_program_topology(Topology("core", 0))
     with pytest.raises(ValueError, match="requires a positive static integer"):
         target.validate_program_topology(Topology("core", DimVar("cores", 1, 8)))
-
-
-# ---------------------------------------------------------------------------
-# AC-4-2
-# ---------------------------------------------------------------------------
 
 
 def test_both_catalogue_atoms_are_priced_at_their_own_measured_rates():
@@ -237,12 +227,8 @@ def test_the_hard_filter_is_per_atom_and_covers_storage_shape_and_dtype():
     assert candidate_atoms(bf16_gemm.entry_function().body, bf16_gemm.resolve_target()) == []
 
 
-# ---------------------------------------------------------------------------
-# AC-4-3
-# ---------------------------------------------------------------------------
-
 def test_amx_values_stand_on_the_installed_documents_and_say_how_they_were_got():
-    """AC-4-3: the architecture carries the ISA geometry, the device the per-part
+    """The architecture carries the ISA geometry, the device the per-part
     resources, each built from its own installed document -- so a number moved to
     the other side would be claimed of the wrong thing.
 


### PR DESCRIPTION
## Why

A plan restates the same fact many times. In one recent plan, `§1.5` appeared in
nine places across six section types; correcting it once meant editing all nine,
and by the third reading the repetition passes for corroboration when it is only
one recollection copied out. The template asked for the restatement: `#### Spec
Impact` listed the spec files that `#### Related Files` already listed, and
`## Execution Preflight` reprinted, into every plan, rules that live in
`docs/develop.md` and that `scripts/get_policy.py` already serves on request.

Three of those rules never needed a human reader at all. "No `TYPE_CHECKING`
shim", "comments describe the code, not the plan", and "spec text is English"
are decidable by a program, and were instead sentences an implementer had to
remember.

## What

**The plan template keeps only what something reads.** Gone: `## Goal`, the
plan-level `### Related Files`, `#### Spec Impact`, `#### Verification`, and the
whole `## Execution Preflight` block. A milestone now reads Depends -> Golden
Reference -> Related Files -> Plan -> Acceptance Criteria, and `## Description`
is free prose with no required shape.

The plan's touch surface is now the union of its milestones', so a spec path is
written once. That makes `- inherit: top-level` circular, so the finalizer
refuses it with an explanation instead of resolving it.

Verification moved out of the plan and into the gate request: before there is an
implementation there is no receipt to write down, which is why that section
could only ever say "the existing tests cover it".

**Three prose rules became hooks.** `forward-references` rejects a
`TYPE_CHECKING` shim (ruff cannot be asked -- its `TC001`-`TC003` push the other
way), `comment-hygiene` rejects a comment carrying a plan id / milestone / PR
number / commit hash / review narration, and `english-only` rejects non-Latin
script in anything committed. Their patterns were calibrated against the tree:
a bare `plan` is a schedule plan here and all fourteen mentions are legitimate,
so only a plan *reference* matches; Greek stays legal because it is the layout
algebra's notation.

The ruff hook drops `--fix`. A hook that rewrites the tree reports "files were
modified", which reads as "commit again" rather than "you wrote this wrong".

## Contract

`docs/plans/TEMPLATE.md` changes shape, and `scripts/finalize_plan_context.py`
enforces the new one: a milestone missing `#### Spec Impact` or
`#### Verification` is now fine, and `- inherit: top-level` is now an error. Every
plan in flight validates unchanged except for that one construct.

`docs/develop.md § Spec impact` now states the single-declaration rule, and
`§ Forward references` no longer claims ruff enforces it -- it never did.

No `src/` or `include/` file is touched; no runtime behaviour changes.

## Verification

- `pytest tests/scripts -q -n 4` -- 20 passed
- `pytest tests/target/test_amx_target.py -q -n 4` -- 6 passed (the file lost
  three banner comments)
- `pre-commit run --all-files` -- 8 hooks pass, including the three added here
- `finalize_plan_context.py --check` over the template and every plan in this
  working tree -- 16/16 canonical
- Each new lint was shown to fail on a file containing what it forbids, and the
  finalizer test was shown to fail when the policy text it asserts is altered

The full suite was not run: this touches no `src/`, no `include/`, and no test
other than the two above.

## Risk

`comment-hygiene` and `english-only` are token matchers, so a new legitimate use
of one of these shapes needs an inline `comment-hygiene: allow` /
`english-only: allow`. Both were run over the whole tree before landing.

"A spec section MUST NOT enumerate test names" stays prose: `docs/spec/inspection.md`
legitimately names `test_results/`, and no pattern separates that from a test list.
