### PR TITLE
fix(models,cli,docs): correct MiniCPM scale and explain check failures

### DIFF
--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -120,6 +120,14 @@ bounds the caller stated.
     It MUST also say the actual and declared dtype of every activation and of
     every weight the selected Module declares, plus the tensor count and shape
     tree each `--input` file supplied.
+  - A FAIL with `--inputs random` MUST state that the draw makes each activation
+    independently; a target that relies on semantic relationships between
+    activations MAY differ at ulp scale without either implementation being wrong,
+    and `--inputs real` is the re-run that decides the comparison.
+  - A FAIL measured against a reference MUST state that it proves disagreement,
+    not which side is closer to truth. A reference MAY carry its own rounding, and
+    establishing accuracy needs an independent high-precision reference that
+    `check` does not run.
   - Reaching one leaf MUST read only that leaf Module's own weights. A comparison
     of one kernel MUST NOT materialise a whole model. A Module is the unit that
     loads, so what a run binds is everything the selected Module declares, not the

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -543,6 +543,13 @@ def check(candidate: Callable, reference: Callable | None, inputs: tuple, *,
     `RuntimeModule` bound method, a raw torch callable, or an evaluator
     closure — anything callable on *inputs*.
 
+### 1.7 Missing prepared weight
+
+- constraints:
+  - `Module.load` MUST reject a resource that has no tensor for a weight the
+    Module declares. The refusal MUST name that weight and state that `prepare`
+    produces it ([runtime §1.1.2](#112-weight-converter-and-prepare--forward)).
+
 ## 2. C++ Runtime Surface
 
 Generated CUDA source includes the umbrella runtime header:

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -543,13 +543,6 @@ def check(candidate: Callable, reference: Callable | None, inputs: tuple, *,
     `RuntimeModule` bound method, a raw torch callable, or an evaluator
     closure — anything callable on *inputs*.
 
-### 1.7 Missing prepared weight
-
-- constraints:
-  - `Module.load` MUST reject a resource that has no tensor for a weight the
-    Module declares. The refusal MUST name that weight and state that `prepare`
-    produces it ([runtime §1.1.2](#112-weight-converter-and-prepare--forward)).
-
 ## 2. C++ Runtime Surface
 
 Generated CUDA source includes the umbrella runtime header:

--- a/docs/tutorial/migrate.md
+++ b/docs/tutorial/migrate.md
@@ -94,6 +94,8 @@ a reader of the fixture has to work out.
 
 ## When step one is finished
 
-When the authored Module agrees with the published implementation on real weights,
-at production dimensions. That is a comparison, which is what step two's tool does
-— so the next page is the one that runs it, and you will use it here first.
+Prepare real weights first ([runtime §1.1.2](../spec/runtime.md#112-weight-converter-and-prepare--forward)).
+Step one is finished when the authored Module agrees with the published
+implementation at production dimensions. That is a comparison, which is what step
+two's tool does — so the next page is the one that runs it, and you will use it here
+first.

--- a/src/tilefoundry/cli/check.py
+++ b/src/tilefoundry/cli/check.py
@@ -6,6 +6,7 @@ import argparse
 import inspect
 import json
 import sys
+import textwrap
 from pathlib import Path
 from typing import Any, Sequence
 
@@ -610,6 +611,7 @@ def _one_run(
         "inputs": {
             "activations": {
                 "source": provided,
+                "kind": arguments.inputs,
                 "actual_dtypes": _dtype_names(activations),
                 "declared_dtypes": (
                     []
@@ -677,6 +679,28 @@ def _shown_files(files: Sequence[dict[str, Any]]) -> str:
         for file in files
     ]
     return "; files " + "; ".join(descriptions)
+
+
+def _failure_warnings(runs: Sequence[dict[str, Any]]) -> list[str]:
+    """The limits that qualify a failed command-level comparison."""
+    if all(run["passed"] for run in runs):
+        return []
+
+    warnings = []
+    if any(run["inputs"]["activations"]["kind"] == "random" for run in runs):
+        warnings.append(
+            "--inputs random makes each activation independently. A target that relies on "
+            "semantic relationships between activations can differ at ulp scale without either "
+            "implementation being wrong. Rerun with --inputs real to decide the comparison."
+        )
+    if any(run["reference"] is not None for run in runs):
+        warnings.append(
+            "FAIL says the candidate and reference differ, not which side is closer to truth. "
+            "The reference may carry its own rounding; check compares only against it. "
+            "Establishing accuracy needs an independent high-precision reference, which check "
+            "does not run."
+        )
+    return warnings
 
 
 def _render(target: Target, runs: list[dict[str, Any]], level: dict[str, Any] | None) -> str:
@@ -750,6 +774,9 @@ def _render(target: Target, runs: list[dict[str, Any]], level: dict[str, Any] | 
             "           PASS here means your implementation matches this Module — not",
             "           that the Module matches what it describes.",
         ]
+    for warning in _failure_warnings(runs):
+        wrapped = textwrap.wrap(warning, width=74)
+        lines += ["", f"  warning: {wrapped[0]}", *(f"           {line}" for line in wrapped[1:])]
     return "\n".join(lines) + "\n"
 
 
@@ -774,6 +801,7 @@ def run_check(arguments: argparse.Namespace) -> int:
         for combination in _combinations(stated)
     ]
     level = _level(target.path)
+    warnings = _failure_warnings(runs)
 
     if arguments.json:
         payload = {
@@ -783,6 +811,8 @@ def run_check(arguments: argparse.Namespace) -> int:
         }
         if level is not None:
             payload["verification"] = {"model": level["model"], "level": level["level"]}
+        if warnings:
+            payload["warnings"] = warnings
         sys.stdout.write(json.dumps(payload, indent=2, sort_keys=False) + "\n")
     else:
         sys.stdout.write(_render(target, runs, level))

--- a/src/tilefoundry/cli/check.py
+++ b/src/tilefoundry/cli/check.py
@@ -611,7 +611,6 @@ def _one_run(
         "inputs": {
             "activations": {
                 "source": provided,
-                "kind": arguments.inputs,
                 "actual_dtypes": _dtype_names(activations),
                 "declared_dtypes": (
                     []
@@ -681,13 +680,13 @@ def _shown_files(files: Sequence[dict[str, Any]]) -> str:
     return "; files " + "; ".join(descriptions)
 
 
-def _failure_warnings(runs: Sequence[dict[str, Any]]) -> list[str]:
+def _failure_warnings(runs: Sequence[dict[str, Any]], input_kind: str | None) -> list[str]:
     """The limits that qualify a failed command-level comparison."""
     if all(run["passed"] for run in runs):
         return []
 
     warnings = []
-    if any(run["inputs"]["activations"]["kind"] == "random" for run in runs):
+    if input_kind == "random":
         warnings.append(
             "--inputs random makes each activation independently. A target that relies on "
             "semantic relationships between activations can differ at ulp scale without either "
@@ -703,7 +702,12 @@ def _failure_warnings(runs: Sequence[dict[str, Any]]) -> list[str]:
     return warnings
 
 
-def _render(target: Target, runs: list[dict[str, Any]], level: dict[str, Any] | None) -> str:
+def _render(
+    target: Target,
+    runs: list[dict[str, Any]],
+    level: dict[str, Any] | None,
+    warnings: Sequence[str],
+) -> str:
     """The runs as a person reads them: what ran, what it measured, the verdict."""
     where = f"{target.path.name}:{target.selector}" if target.selector else str(target.path.name)
     lines = [where]
@@ -774,7 +778,7 @@ def _render(target: Target, runs: list[dict[str, Any]], level: dict[str, Any] | 
             "           PASS here means your implementation matches this Module — not",
             "           that the Module matches what it describes.",
         ]
-    for warning in _failure_warnings(runs):
+    for warning in warnings:
         wrapped = textwrap.wrap(warning, width=74)
         lines += ["", f"  warning: {wrapped[0]}", *(f"           {line}" for line in wrapped[1:])]
     return "\n".join(lines) + "\n"
@@ -801,7 +805,7 @@ def run_check(arguments: argparse.Namespace) -> int:
         for combination in _combinations(stated)
     ]
     level = _level(target.path)
-    warnings = _failure_warnings(runs)
+    warnings = _failure_warnings(runs, arguments.inputs)
 
     if arguments.json:
         payload = {
@@ -815,7 +819,7 @@ def run_check(arguments: argparse.Namespace) -> int:
             payload["warnings"] = warnings
         sys.stdout.write(json.dumps(payload, indent=2, sort_keys=False) + "\n")
     else:
-        sys.stdout.write(_render(target, runs, level))
+        sys.stdout.write(_render(target, runs, level, warnings))
     return 0 if all(run["passed"] for run in runs) else 1
 
 

--- a/src/tilefoundry/ir/core/module.py
+++ b/src/tilefoundry/ir/core/module.py
@@ -19,7 +19,7 @@ from tilefoundry.utils.spec_ref import spec_ref_render
 
 ModuleFunction = Union[HirFunction, PrimFunction]
 
-_MISSING_PREPARED_WEIGHT = "[runtime §1.7](docs/spec/runtime.md#17-missing-prepared-weight)"
+_MISSING_PREPARED_WEIGHT = "[runtime §1.1.2](docs/spec/runtime.md#112-weight-converter-and-prepare--forward)"
 
 
 def _validate_declared(module_name, source, value, decl_type) -> None:

--- a/src/tilefoundry/ir/core/module.py
+++ b/src/tilefoundry/ir/core/module.py
@@ -15,8 +15,11 @@ from tilefoundry.ir.tir.prim_function import PrimFunction
 from tilefoundry.ir.types.shard.mesh import Topology
 from tilefoundry.ir.types.tensor_type import TensorType
 from tilefoundry.target import Target
+from tilefoundry.utils.spec_ref import spec_ref_render
 
 ModuleFunction = Union[HirFunction, PrimFunction]
+
+_MISSING_PREPARED_WEIGHT = "[runtime §1.7](docs/spec/runtime.md#17-missing-prepared-weight)"
 
 
 def _validate_declared(module_name, source, value, decl_type) -> None:
@@ -327,7 +330,10 @@ class Module:
             try:
                 value = resource.load(name)
             except KeyError as e:
-                raise KeyError(f"Module {self.name!r}: missing weight {name!r}") from e
+                raise KeyError(
+                    f"Module {self.name!r}: missing declared weight {name!r}; prepare produces it "
+                    f"({spec_ref_render(_MISSING_PREPARED_WEIGHT)})"
+                ) from e
             _validate_declared(self.name, f"weight {name!r}", value, decl_type)
             constants[name] = value
         return LoadedModule(

--- a/tests/cli/test_cli_check.py
+++ b/tests/cli/test_cli_check.py
@@ -279,6 +279,42 @@ def test_a_model_below_the_oracle_level_passes_with_a_warning(routing, capsys) -
 
     assert "warning: qwen3_5_35b_a3b has no L3 verification on record" in reported
     assert "not\n           that the Module matches what it describes" in reported
+    assert "--inputs random makes each activation independently" not in reported
+    assert "FAIL says the candidate and reference differ" not in reported
+
+
+def test_a_random_input_fail_against_a_reference_states_its_limits(routing, capsys) -> None:
+    """A failed random-input comparison qualifies both limits through the CLI."""
+    argv = [
+        "check", ROUTING,
+        "--inputs", "random",
+        "--expected", str(routing["zeros"]),
+        "--expected", str(routing["indices"]),
+        "--out", "output[0]", "--fn", "allclose", "--atol", "1e-3", "--rtol", "4e-3",
+        "--out", "output[1]", "--fn", "equal",
+    ]
+
+    assert cli.main(argv) == 1
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    reported = captured.out
+    assert "--inputs random makes each activation independently" in reported
+    assert "Rerun with --inputs real" in reported
+    assert "FAIL says the candidate and reference differ" in reported
+    assert "Establishing accuracy needs an independent high-precision" in reported
+    assert "reference, which check does not run" in reported
+
+    assert cli.main([*argv, "--json"]) == 1
+    warnings = json.loads(capsys.readouterr().out)["warnings"]
+    assert warnings == [
+        "--inputs random makes each activation independently. A target that relies on "
+        "semantic relationships between activations can differ at ulp scale without either "
+        "implementation being wrong. Rerun with --inputs real to decide the comparison.",
+        "FAIL says the candidate and reference differ, not which side is closer to truth. "
+        "The reference may carry its own rounding; check compares only against it. "
+        "Establishing accuracy needs an independent high-precision reference, which check "
+        "does not run.",
+    ]
 
 
 def test_a_nested_child_reads_only_its_own_part_of_the_checkpoint(routing, capsys) -> None:

--- a/tests/dsl/test_module_decorator.py
+++ b/tests/dsl/test_module_decorator.py
@@ -184,7 +184,7 @@ def test_the_runner_on_an_authored_module_takes_the_weights_too():
     assert "missing declared weight 'w'" in refused
     assert "prepare produces it" in refused
     assert spec_ref_render(
-        "[runtime §1.7](docs/spec/runtime.md#17-missing-prepared-weight)"
+        "[runtime §1.1.2](docs/spec/runtime.md#112-weight-converter-and-prepare--forward)"
     ) in refused
 
 

--- a/tests/dsl/test_module_decorator.py
+++ b/tests/dsl/test_module_decorator.py
@@ -19,6 +19,7 @@ from tilefoundry.dsl import T, Tensor, tf  # noqa: F401 — tf/T used by bodies
 from tilefoundry.ir.core.errors import VerifyError
 from tilefoundry.ir.core.module import Module
 from tilefoundry.ir.types.shard import Layout, Mesh, Topology
+from tilefoundry.utils.spec_ref import spec_ref_render
 
 
 @module(entry="composed")
@@ -176,6 +177,15 @@ def test_the_runner_on_an_authored_module_takes_the_weights_too():
     with pytest.raises(TypeError, match=r"takes 1 activation") as excinfo:
         loaded.scale(ones, weight)
     assert "load(resource)" not in str(excinfo.value)
+
+    with pytest.raises(KeyError) as excinfo:
+        _Weighted.load(DictResource({}))
+    refused = str(excinfo.value)
+    assert "missing declared weight 'w'" in refused
+    assert "prepare produces it" in refused
+    assert spec_ref_render(
+        "[runtime §1.7](docs/spec/runtime.md#17-missing-prepared-weight)"
+    ) in refused
 
 
 def test_one_shared_child_binds_once_per_owner():

--- a/tests/integration/installed/smoke_spec.py
+++ b/tests/integration/installed/smoke_spec.py
@@ -81,7 +81,6 @@ def test_spec_rejects_a_section_that_does_not_exist(tf) -> None:
         ("core-ir", "target-inheritance", 'with `target="cuda"`'),
         ("core-ir", "default-step", "MUST have no default step"),
         ("cli", "check", "A FAIL with `--inputs random`"),
-        ("runtime", "1.7", "The refusal MUST name that weight"),
     ),
 )
 def test_spec_answers_askable_rules(

--- a/tests/integration/installed/smoke_spec.py
+++ b/tests/integration/installed/smoke_spec.py
@@ -80,9 +80,11 @@ def test_spec_rejects_a_section_that_does_not_exist(tf) -> None:
         ("target", "topology-levels", "Only `cta` MAY have a launch-provided"),
         ("core-ir", "target-inheritance", 'with `target="cuda"`'),
         ("core-ir", "default-step", "MUST have no default step"),
+        ("cli", "check", "A FAIL with `--inputs random`"),
+        ("runtime", "1.7", "The refusal MUST name that weight"),
     ),
 )
-def test_spec_answers_the_target_and_default_step_rules(
+def test_spec_answers_askable_rules(
     tf, topic, section, expected
 ) -> None:
     done = tf("spec", topic, section)

--- a/tests/integration/installed/smoke_tutorial.py
+++ b/tests/integration/installed/smoke_tutorial.py
@@ -39,6 +39,8 @@ def test_migrate_splices_the_shipped_model_source_verbatim(tf, shipped) -> None:
     done = tf("tutorial", "migrate")
     assert done.returncode == 0, done.stderr
     assert "w_router: ConstTensor" in done.stdout
+    assert "Prepare real weights first" in done.stdout
+    assert "../spec/runtime.md#112-weight-converter-and-prepare--forward" in done.stdout
 
     authored = (Path(shipped["models"]) / "qwen3_5_35b_a3b" / "model.py").read_text(
         encoding="utf-8"

--- a/tests/models/minicpm3_4b/model.py
+++ b/tests/models/minicpm3_4b/model.py
@@ -67,8 +67,7 @@ cache across heads on the way in.
    k_rope_broadcast)``, nope first, restoring each head's 64/32 layout.
 7. **Attend** the cache and the token itself, online-softmax merged, then
    ``@ Wo``. ``scaling = qk_head_dim ** -0.5`` (96, not 64 or 32) arrives as the
-   ``scale`` tensor, read off ``layer.self_attn.scaling`` by the test rather than
-   recomputed here.
+   ``scale`` tensor, computed here from ``_QK_HEAD_DIM``.
 
 ``mla_attention`` fuses the preceding ``input_layernorm`` and ``mlp`` the
 post-attention one, so each fused kernel lines up with one HF
@@ -482,7 +481,7 @@ class MiniCPM3_4B:
         cos_cache, sin_cache = _generation_rope(device)
         pos_ids = torch.tensor([step], device=device, dtype=torch.int32)
         scale = torch.full(
-            (1, 1, 1, 1), config.head_dim ** -0.5, device=device, dtype=config.dtype
+            (1, 1, 1, 1), _QK_HEAD_DIM ** -0.5, device=device, dtype=config.dtype
         )
         residual_scale = torch.full(
             (1, 1, 1),

--- a/tests/models/minicpm3_4b/test_decoder_layer.py
+++ b/tests/models/minicpm3_4b/test_decoder_layer.py
@@ -19,7 +19,7 @@ import torch
 
 from tests.models.decode_oracle import agrees_to_one_rounding
 from tests.models.minicpm3_4b import reference
-from tests.models.minicpm3_4b.model import MiniCPM3_4B, config
+from tests.models.minicpm3_4b.model import _QK_HEAD_DIM, MiniCPM3_4B, config
 
 HIDDEN = reference.CONFIG.hidden_size
 
@@ -46,6 +46,7 @@ def test_generation_inputs_match_the_drawn_position() -> None:
     assert cos.shape == sin.shape == (config.max_position_embeddings, reference.CONFIG.head_dim)
     assert torch.equal(pos_ids, torch.tensor([step], device=DEV, dtype=torch.int32))
     assert scale.shape == (1, 1, 1, 1)
+    torch.testing.assert_close(scale, torch.full_like(scale, _QK_HEAD_DIM ** -0.5))
     assert residual_scale.shape == (1, 1, 1)
     assert caches is sentinel
 


### PR DESCRIPTION
## Why
- The published MiniCPM3 reference used the rotary width rather than the assembled QK width.
- FAIL reports did not state their input and reference limits.
- A missing prepared weight did not point to the existing preparation workflow.

## What
- Correct the MiniCPM3 scale and assert its value.
- Add generic FAIL guidance to text and top-level JSON reports without changing a run record's JSON shape.
- Link missing prepared weights and the migration tutorial to the existing preparation specification.

## Contract
- `check` reports its two FAIL limitations in text and JSON; `runs[*]` remains unchanged.
- `Module.load` names the declared missing weight, `prepare`, and `spec runtime §1.1.2`.

## Verification
- `pytest tests/cli/test_cli_check.py -q -n 4` - 16 passed (`test_results/m1-cli-regression.*`).
- `pytest tests/dsl/test_module_decorator.py::test_the_runner_on_an_authored_module_takes_the_weights_too -q -n 4` - 1 passed (`test_results/m2-existing-prepare.*`).
- `pytest tests/integration/installed/smoke_check.py::test_check_reports_the_same_verdict_as_json -q -n 4` - 1 passed (`test_results/ci-install-smoke-json-shape.*`).
- `pytest tests/models/minicpm3_4b/test_decoder_layer.py -q -n 4` - 1 passed (`test_results/m0-green.*`).
- `pytest tests/integration/installed/smoke_tutorial.py::test_migrate_splices_the_shipped_model_source_verbatim -q -n 4` - 1 passed (`test_results/m3-impl.*`).

## Risk
- The full suite was not run; this change was verified with affected workflows only.