### PR TITLE
fix(release): use hosted publish runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
 
   publish:
     needs: build-and-verify
-    runs-on: [self-hosted, tilefoundry]
+    runs-on: ubuntu-latest
     environment:
       name: ${{ github.event_name == 'workflow_dispatch' && 'testpypi' || 'pypi' }}
       url: ${{ github.event_name == 'workflow_dispatch' && 'https://test.pypi.org/project/tilefoundry/' || 'https://pypi.org/project/tilefoundry/' }}


### PR DESCRIPTION
## Why

The first TestPyPI rehearsal built and verified its artifacts successfully, then failed before OIDC or upload because `pypa/gh-action-pypi-publish` requires Docker and the self-hosted `tilefoundry` runner has none.

## What

- Run only the `publish` job on GitHub-hosted `ubuntu-latest`.
- Keep `build-and-verify` on the self-hosted runner and pass the same `distributions` artifact across jobs.

## Contract

Manual dispatch remains TestPyPI-only; a pushed `v*` tag remains the sole PyPI route. The publish job still requires its environment approval and retains job-scoped OIDC permissions.

## Verification

- The failed rehearsal reached 68 passing installed smoke tests, uploaded JUnit/stdout and distributions artifacts, and failed before upload with `docker: command not found`.
- Checked the revised YAML runner, permissions, environment, artifact dependency, and event routes.
- `pre-commit run --all-files` (9 hooks) and `ruff check .` pass.

## Risk

The publish job now consumes a short-lived GitHub-hosted Ubuntu VM and downloads the existing 2 MB artifact. The TestPyPI `0.0.1` release remains absent; after this PR merges, it can be safely retried with the same version.