### PR TITLE
docs(spec): clarify contracts and design invariants

### DIFF
--- a/docs/SPEC-RULES.md
+++ b/docs/SPEC-RULES.md
@@ -2,9 +2,11 @@
 
 ## Principles
 
-The spec is the single source of truth for TileFoundry public contracts. If a
-different implementation of the same public construct would need to know a fact,
-that fact belongs in `docs/spec/*.md`, not in code comments or plan files.
+- The spec records decisions every implementation must preserve: public semantics,
+  cross-module boundaries, and internal design invariants required for correctness,
+  extensibility, or operability.
+- It does not repeat self-describing declarations or incidental details that may
+  change without a design decision.
 
 Runtime ops use one public entry per op/family. Target runtime headers may split
 the implementation into internal helpers, traits, or impl classes, but generated

--- a/docs/spec/analysis.md
+++ b/docs/spec/analysis.md
@@ -60,7 +60,7 @@ class TileUnit:
 
 ```python
 class TileGraph:
-    """Polyhedral model of one HIR Function body, plus its schedule.
+    """Provide the polyhedral model of one HIR Function body.
 
     Attributes:
         domain: attribute; Union of every statement's iteration domain, one named tuple per statement.
@@ -71,9 +71,6 @@ class TileGraph:
         params: attribute; isl parameter name to the ShapeDim it stands for.
         buffer_dtypes: attribute; Buffer tuple name to the DType its elements carry.
         parallel_dims: attribute; Statement name to one flag per own domain dimension, set when that dimension carries no dependence.
-        tree: attribute; isl schedule tree over this model, or None before one is built.
-        ring: attribute; Buffer name to its decided ring depth; empty until atom selection decides it.
-        decisions: attribute; Recorded per-statement decisions, or None until atom selection records them.
     """
 
     domain: "isl.union_set"
@@ -82,11 +79,8 @@ class TileGraph:
     writes: "isl.union_map"
     units: tuple[TileUnit, ...]
     params: dict
-    buffer_dtypes: dict = {}
-    parallel_dims: dict = {}
-    tree: "isl.schedule | None" = None
-    ring: dict = {}
-    decisions: dict | None = None
+    buffer_dtypes: dict = field(default_factory=dict)
+    parallel_dims: dict = field(default_factory=dict)
 ```
 
 - constraints:
@@ -112,12 +106,10 @@ class TileGraph:
   - `parallel_dims` MUST carry exactly one flag per own domain dimension of
     every statement, and MUST be measured from `domain` + `deps` ([§1.7](#17-parallel-dimensions)) rather
     than reported by a scheduler.
-  - `tree`, `ring` and `decisions` MUST be empty (`None` / `{}`) as returned by
-    `extract`, and MUST be filled only by the schedule stages that decide them
+  - Schedule trees, ring depths, and decisions MUST remain schedule-owned state
+    outside `TileGraph`; schedule program views pair those values with the
+    immutable analysis graph without mutating it
     ([schedule §4](./schedule.md#4-kernel-schedule-construction)).
-  - `ring` and `decisions` MUST be plain fields. Neither MAY be carried as an
-    isl mark payload: isl marks are process-global state and MUST NOT hold a
-    Python object.
 
 ### 1.3 `extract`
 
@@ -338,18 +330,10 @@ requested analysis and renders the results together
 
 ### 2.1 Metadata records
 
+`TrafficBytes` is the shared cost-context record defined by
+[visitor-registry §7](./visitor-registry.md#7-instance-4--cost).
+
 ```python
-class TrafficBytes:
-    """Read and write byte counts for one memory hierarchy level.
-
-    Attributes:
-        read: attribute; Bytes read at this level.
-        write: attribute; Bytes written at this level.
-    """
-
-    read: int = 0
-    write: int = 0
-
 class ComputeCostMetadata(IRMetadata):
     """One Call's logical work, as the authored program states it.
 
@@ -616,6 +600,45 @@ class MemoryHierarchyFacts:
     capacity MUST be recorded as an advisory and MUST NOT fail the call, because
     a working set larger than a cache still runs.
 
+### 2.4 Throughput and parallel-capacity facts
+
+```python
+class ThroughputFacts:
+    """Carry the rates used by roofline analysis.
+
+    Attributes:
+        peak_flops_per_second: attribute; Published compute rates by dtype.
+        memory_bandwidth_bytes_per_second: attribute; Published memory bandwidth.
+        bandwidth_level: attribute; Memory level whose traffic the bandwidth measures.
+    """
+
+    peak_flops_per_second: tuple[tuple[DType, int], ...]
+    memory_bandwidth_bytes_per_second: int | None
+    bandwidth_level: str
+
+    def peak_for(self, dtype: DType) -> int | None: ...
+
+
+class ParallelCapacityFacts:
+    """Carry the parallel capacity assumed by timeline analysis.
+
+    Attributes:
+        topology: attribute; Topology level being scheduled.
+        parallel_units: attribute; Instances admitted concurrently.
+    """
+
+    topology: str
+    parallel_units: int
+```
+
+- constraints:
+  - `ThroughputFacts.peak_for` MUST return `None` for a dtype with no published
+    rate; analysis MUST NOT substitute an assumed rate.
+  - `bandwidth_level` MUST select the traffic level divided by the published
+    bandwidth rather than summing traffic across levels.
+  - `parallel_units` is compiler policy over hardware facts and MUST be a
+    capacity used to form waves, not a program rewrite.
+
 ## 3. Composed analysis
 
 `tilefoundry.analysis.api.analyze` is the dependency-composed measurement
@@ -624,7 +647,15 @@ what that root transitively needs, runs each member once, and reports what ran.
 
 ```python
 class AnalysisResult:
-    """What one composed Analyze call computed."""
+    """Record what one composed Analyze call computed.
+
+    Attributes:
+        module: attribute; Source Module.
+        function: attribute; Function that received records.
+        analysis: attribute; Requested root analysis.
+        executed: attribute; Analyses executed in dependency order.
+        metadata_types: attribute; Metadata classes actually written.
+    """
 
     module: "Module"
     function: "Function"
@@ -706,12 +737,19 @@ def analyze(
 
 ```python
 class AnalysisAlgorithm:
-    """One registered analysis: its identity, needs, and owned Metadata."""
+    """Describe one registered analysis.
+
+    Attributes:
+        selector: attribute; Public analysis selector.
+        run: attribute; Analysis implementation.
+        requires: attribute; Dependency selectors.
+        produces: attribute; Owned metadata classes.
+    """
 
     selector: str
     run: AnalysisCallable
-    requires: tuple[str, ...]
-    produces: tuple[type[IRMetadata], ...]
+    requires: tuple[str, ...] = ()
+    produces: tuple[type[IRMetadata], ...] = field(default=())
 
 
 def register_analysis(

--- a/docs/spec/architecture.md
+++ b/docs/spec/architecture.md
@@ -38,6 +38,7 @@ graph TD
     subgraph aux["auxiliary"]
         inspection["<b>inspection</b>"]
         evaluator["<b>evaluator</b>"]
+        cli["<b>cli</b>"]
         codeorg["<b>code-organization</b>"]
     end
 
@@ -66,6 +67,9 @@ graph TD
     inspection -. side-channel reader .-> hir
     inspection -. side-channel reader .-> tir
     evaluator -. reference oracle .-> hir
+    cli -. user entry surface .-> parser
+    cli -. reports .-> analysis
+    cli -. reports .-> schedule
 ```
 
 A TileFoundry compilation flows left to right along the **pipeline**:
@@ -98,7 +102,7 @@ The type system is what each `Expr` carries. It is split into a
 **core** layer ([types](./types.md)) and a **shard / layout** sublayer
 ([shard](./shard.md)).
 
-- core types: `IRType` (abstract base) / `TensorType` / `TupleType` /
+- core types: `Type` (union alias) / `TensorType` / `TupleType` /
   `UnitType` / `DType` / `dim.*`.
 - shard / layout sublayer: `IntTuple` / `Layout` / `ComposedLayout` /
   `Topology` / `Mesh` family / `ShardAttr` / `ShardLayout`.
@@ -216,7 +220,7 @@ This table is the authoritative spec-to-box map. Each row lists the
 |---|---|
 | **[architecture](./architecture.md)** (this doc) | The map: pipeline + support-network picture, IR-region overview, spec-ownership table |
 | **[core-ir](./core-ir.md)** | core_ir shared node algebra: `Module` / `Expr` / `Op` / `Call` / `Var` / `Constant` / `Tuple`. No types, no `Stmt` |
-| **[types](./types.md)** | Core type system: `IRType` abstract base / `TensorType` / `TupleType` / `UnitType` / `DType` / `dim.*` + TensorType invariants |
+| **[types](./types.md)** | Core type system: `Type` union / `TensorType` / `TupleType` / `UnitType` / `DType` / `dim.*` + TensorType invariants |
 | **[shard](./shard.md)** | Shard / layout sublayer: `IntTuple` / `Layout` / `ComposedLayout` / `Mesh` family / `ShardAttr` / `ShardLayout` + shard-binding invariants |
 | **[hir](./hir.md)** | HIR dataflow IR: `Function` (`Expr` subclass), op subdirectories (math / tensor / nn / shape / sharding), `GridRegionExpr`, hir-side Mesh-scope rule |
 | **[tir](./tir.md)** | TIR stmt IR: `Stmt` base (tir-only), `PrimFunction`, `Sequential(Stmt)`, control-flow Stmts, effect / tile Ops in `Evaluate(op, args)` form, user `@intrinsic` Stmt generation |
@@ -232,6 +236,7 @@ This table is the authoritative spec-to-box map. Each row lists the
 | **[target](./target.md)** | Target capability descriptors, architecture/device facts, Facts projection, and admitted program topology levels |
 | **[codegen](./codegen.md)** | Emit / link pipeline and products (`LinkableFunction` / `LinkableModule` / `LinkedModule`), emitter registry, dispatch + shape-scalar ABI, program-shape / dynamic-CTA source contract, ShardLayout emission |
 | **[runtime](./runtime.md)** | `RuntimeModule` / launcher ABI, C++ runtime surface, `runtime.h` umbrella header, runtime op free-function contract |
+| **[cli](./cli.md)** | Command-line grammar and behavior for models, spec, tutorial, check, analyze, schedule, and inspect |
 | **[code-organization](./code-organization.md)** | Implementation guide (not architectural): Python source tree layout |
 
 **Cross-spec sync.** Downstream specs link back to the relevant § of

--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -22,25 +22,6 @@ help to standard error and exit with status 2.
 
 ## Commands
 
-```text
-tilefoundry models [NAME] [--source]
-
-tilefoundry spec [TOPIC [SECTION]]
-
-tilefoundry check TARGET (--inputs random | --inputs real --ckpt DIR | --input=PATH ...)
-    [--expected=PATH ...] --out OUTPUT --fn F [bounds] [--fn F [bounds]] ...
-    [--out OUTPUT ...] [--dim NAME=V[,V...] ...] [--json]
-
-tilefoundry analyze model.py[:Module[.child_module...][.function]]
-    [--roofline] [--footprint] [--timeline] [--dim NAME=EXTENT ...]
-
-tilefoundry schedule model.py[:Module[.child_module...][.function]] --topology LEVEL [--json]
-    [--dim NAME=EXTENT ...] [--solver-timeout SECONDS] [--solver-workers COUNT]
-    [--first-plan]
-
-tilefoundry inspect [capabilities [SOURCE]]
-```
-
 `SOURCE` is a Python file followed optionally by
 `:Module[.child_module...][.function]`. Without a selector, the source must
 define exactly one top-level HIR Module or Function. A selector chooses the
@@ -146,8 +127,6 @@ bounds the caller stated.
     covered. Choosing a neighbouring implementation instead would answer about a
     program nobody selected, and the failure is only actionable if the reader can
     see where the coverage stops.
-  - The functions and their bounds in `--help` MUST be generated from the
-    predicates themselves, so a predicate cannot exist without being listed.
   - Text and `--json` MUST carry the same facts.
 
 ## Tutorial
@@ -223,9 +202,11 @@ that runs before it can be read is a reference that decides what it describes.
     or execute model source. It MUST NOT reformat, regenerate, or copy a shipped
     file: the installed directory is the reference, and a rendered copy is a
     different artifact wearing its name.
-  - A shipped model source directory with `hf_alias.py` MUST carry the executable
-    `run.py` and its `generation.py` decode source, whose shapes MUST come only from
-    that directory's `config.json`.
+  - Catalog membership and `--source` describe a model and its shipped authored
+    files; neither claims that the model has a runnable decode path. The package
+    data manifest alone defines those files. Repository-only helpers such as
+    `hf_alias.py` MUST NOT create an implicit requirement to ship `run.py` or
+    `generation.py`.
   - A `NAME` the catalog does not have MUST be refused naming the models it does.
   - The forest and the counts MUST be generated from the models themselves rather
     than maintained beside them, because a hand-kept inventory of trees and numbers

--- a/docs/spec/code-organization.md
+++ b/docs/spec/code-organization.md
@@ -18,11 +18,12 @@ truth for the directory's structure and invariants.
 | Directory | Owning spec | Contents |
 |---|---|---|
 | `ir/core/` | [core-ir](./core-ir.md) | Shared node algebra: `Module` / `Expr` / `Var` / `Constant` / `Tuple` / `Op` / `Call` / `Stmt` (base class) / `OpSchema` / `ParamDef` / `@register_op` / `@register_alias` / `op_registry` / `errors`. |
-| `ir/types/` | [types](./types.md) | Type-system root: `TensorType` / `TupleType` / `UnitType` / `CallableType` / `DType` / `StorageKind` / `resolve_storage` / `dim.*` (with their typeinfer). |
+| `ir/types/` | [types](./types.md) | Type-system root: `Type` / `TensorType` / `TupleType` / `UnitType` / `CallableType` / `DType` / `StorageKind` / `resolve_storage` / `dim.*` (with their typeinfer). |
 | `ir/types/shard/` | [shard](./shard.md) | Shard / layout sublayer: `Topology` / `Mesh` / `Layout` / `ComposedLayout` / `ShardLayout` / `ShardAttr` (`Split` / `Broadcast` / `Dynamic` / `Partial`). The physical nesting reflects the spec's "sublayer" relationship. |
-| `ir/visitor.py` | [visitor-mutator](./visitor-mutator.md) | `ExprVisitor` / `ExprMutator` / `StmtVisitor` / `StmtMutator` / `StmtExprMutator`. |
+| `ir/constraints/` | [schedule](./schedule.md) | Authored scheduling constraints: the shared base plus layout, mesh, and storage constraint records. |
+| `ir/visitor.py` | [visitor-mutator](./visitor-mutator.md) | `ExprVisitor` / `ExprMutator` / `StmtVisitor` / `StmtMutator` / `StmtExprMutator`, plus the canonical `PrimFunction` walk and rewrite entries. |
 | `ir/hir/` | [hir](./hir.md) | HIR Op layer; one subdirectory per category (`math/` / `tensor/` / `nn/` / `shape/` / `sharding/`). One real Op per `.py` ([§2](#2-file-naming-and-content-rules) rule 1); surface-alias schemas have no per-name file and live in each category's `aliases.py` ([§2](#2-file-naming-and-content-rules) rule 5). |
-| `ir/tir/` | [tir](./tir.md) | TIR layer: `stmt.py` re-exports the `Stmt` base from `ir/core/stmt.py`; `stmts.py` hosts the TIR `Stmt` subclasses (`LetStmt` / `Evaluate` / `Sequential` / `MeshScope` / …); `prim_function.py`; effect Ops and TIR-owned Expr Ops by category (`memory/` / `nn/` / …); `launch.py` owns `Launch` and its authored launch-attribute descriptors; `arith.py` / `reduce.py` for tag-dispatched `Binary` / `Unary` / `Reduce`; `intrinsic.py` for the `@intrinsic` decorator. Target-specific nodes nest under `ir/tir/<target>/<category>/` (e.g. `ir/tir/cuda/nn/mma.py`) per [§2](#2-file-naming-and-content-rules) Rule 1c. |
+| `ir/tir/` | [tir](./tir.md) | TIR layer: `stmt.py` re-exports the `Stmt` base from `ir/core/stmt.py`; `stmts.py` hosts the general TIR `Stmt` subclasses (`LetStmt` / `Evaluate` / `Sequential` / `MeshScope` / …), while specialized statement families such as `DispatchCall` may live in their own file; `prim_function.py`; effect Ops and TIR-owned Expr Ops by category (`memory/` / `nn/` / …); `launch.py` owns `Launch` and its authored launch-attribute descriptors; `arith.py` / `reduce.py` for tag-dispatched `Binary` / `Unary` / `Reduce`; `intrinsic.py` for the `@intrinsic` decorator. Target-specific nodes nest under `ir/tir/<target>/<category>/` (e.g. `ir/tir/cuda/nn/mma.py`) per [§2](#2-file-naming-and-content-rules) Rule 1c. |
 | `parser/` | [parser](./parser.md) | DSL → IR parsing: `base.py` (shared visitor base + dispatch), `hir_parser.py` (`@func` body), `tir_parser.py` (`@prim_func` body), layout sugar / range-slice / dispatch modules. **Not under `ir/`** — the parser is a producer of IR, not an IR sublayer. |
 | `analysis/` | [analysis](./analysis.md) | Fact layer over typed HIR: `poly.py` (the polyhedral model — `extract` / `TileGraph` and the facts measured over a time relation), and one module per analysis family. The compact public surface lives in `analysis/__init__.py`; per-target atom catalogues and Facts projections live with their owning Target. |
 | `schedule/` | [schedule](./schedule.md) | The public Schedule boundary in `schedule/__init__.py` -- the `schedule()` operation, immutable options, result, and plan base. One directory per algorithm family: `pipeline/` for asynchronous overlap within a cooperating unit, `partition/` for spatial division across a device. Each owns its private program view, projected Facts, closed problem, solve, and typed plan export; concrete Target packages register which families serve which exact levels. |
@@ -42,10 +43,13 @@ truth for the directory's structure and invariants.
 | `analysis/memory.py` | [analysis](./analysis.md) | The `memory` family: value lifetimes, per-level peaks, and the capacity comparisons against a target's hierarchy — failing on an over-full addressable level and advising on an over-full cache. |
 | `analysis/roofline.py` | [analysis](./analysis.md) | The `roofline` family: the recorded work divided by the target's published rates, per Call and aggregated per Function. Adds no count of its own. |
 | `analysis/timeline.py` | [analysis](./analysis.md) | The `timeline` family: execution-unit fusion, wave decomposition against a parallel capacity, and the placement the scheduling model solves for. |
+| `visitor_registry/` | [visitor-registry](./visitor-registry.md) | Shared registry instances and derived visitors: access-relation construction, contexts, ISL helpers, relation building, shard propagation, type inference, verification, code generation, and cost evaluation. |
 | `schedule/api.py` | [schedule](./schedule.md) | The public `schedule()` operation and `ScheduleResult`: resolve the Target and the requested level from the Module, dispatch once on the exact pair, and verify the returned Plan. Generic -- it names no concrete target. |
 | `schedule/plan.py` | [schedule](./schedule.md) | `SchedulePlan`, the extensible semantic base every algorithm's result derives from, and `PlanVerificationError`. It fixes three operations and no shape: there is no shared schema, version, deserializer, or renderer registry. |
 | `schedule/registry.py` | [schedule](./schedule.md) | The Schedule instance of the shared exact-key `AlgorithmRegistry`, keyed on `(concrete Target type, topology name)`, and the registration decorator. |
 | `schedule/errors.py` | [schedule](./schedule.md) | `ScheduleError`, the one diagnostic the schedule layer raises for a request it cannot serve or a solve that failed. Distinct from `PlanVerificationError`, which says a plan was produced and does not hold together. |
+| `schedule/kernel_schedule.py` | [schedule](./schedule.md) | ISL schedule-tree construction, band discovery, tiling, and kernel-schedule validation. |
+| `schedule/render.py` | [schedule](./schedule.md) | Scaffold emission from a graph, its independently built schedule tree, and selected ring depths. |
 | `target/<backend>/schedule.py` | [target](./target.md) | One backend's scheduling algorithms, registered for the exact levels it schedules as an import side effect. This is where that backend's private problem construction, solve, and Plan export are composed. |
 | `schedule/partition/` | [schedule](./schedule.md) | The spatial partition family: program extraction, `PartitionFacts`, the closed candidate problem, the CP-SAT solve, and the `PartitionSchedulePlan` export. Every hardware number enters through the Facts, so no module below the family entry holds a Target, and nothing in it rewrites the program it decided about. |
 | `visitor_registry/op_cost.py` | [analysis](./analysis.md) | Each operation's per-instance flops and bytes, registered into the shared cost-evaluator registry. Owned here rather than by any target package, because the work an operation asks for follows from its own semantics and operand types on every backend. |
@@ -56,9 +60,12 @@ truth for the directory's structure and invariants.
 | `codegen/` | [codegen](./codegen.md) | Code generation: the emitter registry, the linkable / linked products and the linker, and per-target emitters under `<target>/` (mirroring `ir/tir/` file layout — `tir/<category>/<name>.py` emitter, [§2](#2-file-naming-and-content-rules) rule 2). **Not under `ir/`** — codegen is a consumer of IR; `templates/` holds boilerplate only (kernel shells / host stubs). |
 | `runtime/` | [runtime](./runtime.md) | Runtime support (per-target headers, function templates, launch helpers). |
 | `inspection/` | [inspection](./inspection.md) | IR visualisation: DOT, Python printer, web viewer. |
-| `dsl/` | [parser](./parser.md) (authoring namespace) | User-facing import surface: `tf/` (HIR namespace) / `T/` (TIR namespace) / `_stub_gen.py` / `__main__.py`. The `tf/__init__.pyi` and `T/__init__.pyi` stubs are produced by `python -m tilefoundry.dsl regen` and are gitignored. |
-| `compile.py` | [architecture](./architecture.md) | `tilefoundry.lower` / `build` / `compile` top-level public verbs. |
-| `script.py` | [parser](./parser.md) | `@func` / `@prim_func` / `@module` decorator entry points. |
+| `dump/` | [inspection](./inspection.md) | Dump flags, dynamically scoped dump contexts, and file/null dump sinks used by inspection and test integration. |
+| `dsl/` | [parser](./parser.md) (authoring namespace) | User-facing import surface: `tf/` (HIR namespace) / `T/` (TIR namespace, including `_platforms.py`) / `_namespace.py` / `_stub_gen.py` / `storage.py` / `__main__.py`. The `tf/__init__.pyi` and `T/__init__.pyi` stubs are produced by `python -m tilefoundry.dsl regen` and are gitignored. |
+| `compile.py` | [architecture](./architecture.md) | `tilefoundry.lower` / `build` / `compile` / `jit` top-level public verbs. |
+| `module.py` | [parser](./parser.md) | The `@module` decorator entry point and module-level topology authoring constants. |
+| `script.py` | [parser](./parser.md) | `@func` / `@prim_func` / `@intrinsic` decorator entry points. |
+| `__init__.py` | [inspection](./inspection.md) | The top-level `view` convenience entry and re-exports of public compiler surfaces. |
 | `utils/` | [code-organization](./code-organization.md) | Shared leaf machinery: a module here MUST import nothing from `ir/`, `parser/`, `passes/`, `codegen/`, `runtime/` or `cli/`, and MUST name no layer. It is depended on and depends on nothing, which is what lets a consumer outside the package — a pre-commit hook under an interpreter with nothing installed — load one of these modules by path and get the same implementation the package uses. A helper that needs to know a layer belongs in that layer; this is not a home for anything that did not fit. |
 
 **Stage boundary.** The pipeline picture in
@@ -102,6 +109,11 @@ layout reflects that boundary directly.
   than carried past it as a runtime-owned metadata type. The two launch
   contracts are distinct even though both are consumed across the codegen
   boundary.
+
+`ir/constraints/`, `visitor_registry/`, and `dump/` are cross-cutting packages;
+their stable responsibilities are owned by [schedule](./schedule.md),
+[visitor-registry](./visitor-registry.md), and [inspection](./inspection.md),
+respectively. Their internal file layout is not a per-Op contract.
 
 ## 2. File naming and content rules
 
@@ -153,126 +165,58 @@ each get their own file. Codegen consumes TIR only.
   `@register_verify_stmt(Op)`. The verify rule keys on the Op class
   even though the invocation is an `Evaluate(op, args)` Stmt — see
   [visitor-registry §5](./visitor-registry.md#5-instance-2--verify).
-- **TIR-owned Expr Op file**
-  (`ir/tir/memory/{alloc_tensor,ptr_of,memory_span,tensor_view}.py`,
-  …): Op class + `@register_typeinfer(Op)` +
-  `@register_cost_evaluator(Op)` (if any). Call-position constraints
-  (e.g. `AllocTensor` may only appear as `LetStmt.value`) are
-  checked by the **enclosing Stmt's** `@register_verify_stmt`; there
-  is no separate Op-level verify decorator for these.
-- **`<category>/aliases.py` file** (Rule 1a): a list of
-  `@register_alias(...)` declarations whose builders construct the
-  target Op instance. Alias files hold no IR class and participate
-  in neither typeinfer nor verify.
+- **TIR-owned Expr Op file** (`ir/tir/memory/{alloc_tensor,ptr_of,memory_span,tensor_view}.py`,
+  …): Op class + `@register_typeinfer(Op)` + `@register_cost_evaluator(Op)`
+  (if any). Call-position constraints are checked by the enclosing Stmt's
+  `@register_verify_stmt`.
+- **`<category>/aliases.py` file** (Rule 1a): `@register_alias(...)`
+  declarations whose builders construct the target Op instance.
 
 **Rule 4 — what a target codegen file contains:** the
-`@register_codegen_<target>` for that (op / stmt) pair, and nothing
-else.
+`@register_codegen_<target>` for that (op / stmt) pair, and nothing else.
 
-**Rule 5 — `<category>/__init__.py` re-export rules:**
-
-- Real Op submodules are re-exported via `from .<file> import <Cls>`
-  (maintained by hand; new Ops add their import here).
-- `aliases.py` is imported only for its `@register_alias`
-  side-effects; nothing is re-exported from it (aliases have no
-  class to expose).
-- User imports go through the `tilefoundry.dsl.tf` /
-  `tilefoundry.dsl.T` namespaces' `__getattr__`, not through the
-  per-category `__init__.py`
-  ([parser §2](./parser.md#2-dsl-namespace-surface)).
+**Rule 5 — `<category>/__init__.py` re-export rules:** real Op submodules are
+re-exported; aliases are imported only for registration side effects; user imports
+go through [parser §2](./parser.md#2-dsl-namespace-surface).
 
 **Rule 6 — one pass = one file.** A pass class lives in
-`passes/transforms/<pass_name>.py` (snake_case file name = pass
-class CamelCase in snake form: `HirToTirPass` → `hir_to_tir.py`).
-Internal visitors / mutators stay in the same file.
+`passes/transforms/<pass_name>.py`; internal visitors / mutators stay in that file.
 
-**Rule 7 — what template files contain.**
-`codegen/<target>/templates/*.j2` carry boilerplate assembly only
-(kernel shells, host stubs, fixed-shape per-target wrappers).
-Stmt-level and Op-level emitters are not template-driven; they live
-in `codegen/<target>/tir/.../*.py` as Python walkers (see
-[codegen](./codegen.md)).
+**Rule 7 — what template files contain.** `codegen/<target>/templates/*.j2`
+carry boilerplate assembly only; emitters live in Python walkers.
 
 ## 3. Multi-agent parallelism guarantee
 
-The lock granularity is a single `(node, target)` pair. The naming
-rules in [§2](#2-file-naming-and-content-rules) imply that two agents working on different
-`(node, target)` pairs touch disjoint files; cross-cutting changes
-(`shard/` fields, kernel templates, pass framework) confine
-themselves to the owning directory. Representative scenarios:
-
-| Scenario | Files affected |
-|---|---|
-| Agent A adds `Conv2D`, Agent B adds `RMSNorm` | `ir/hir/nn/conv2d.py` + `ir/hir/nn/rms_norm.py` — no conflict |
-| Agent A edits `MatMul.typeinfer`, Agent B adds `tir.cuda.nn.Mma` CUDA codegen | `ir/hir/nn/matmul.py` + `codegen/cuda/tir/nn/mma.py` — no conflict |
-| Agent A adds a new target `cpu` | a fresh `codegen/cpu/` subtree — no conflict |
-
-Anything that fits the "one Op = one file" / "one (node, target) =
-one file" / "one pass = one file" rules above shares the same
-property by construction.
+The lock granularity is a single `(node, target)` pair. The naming rules in
+[§2](#2-file-naming-and-content-rules) imply that two agents working on different
+`(node, target)` pairs touch disjoint files; cross-cutting changes confine
+themselves to the owning directory.
 
 ## 4. DSL package layout
 
-The author-facing surface is delivered as a namespace package:
-
-```
-src/tilefoundry/dsl/
-  __init__.py           # exports `tf` and `T` sub-namespaces
-  __main__.py           # `python -m tilefoundry.dsl regen` CLI
-  _stub_gen.py          # `.pyi` generator (run by regen)
-  py.typed              # PEP 561 marker
-  tf/
-    __init__.py         # module-level __getattr__ → OpSchema lookup
-    __init__.pyi        # AUTO-GENERATED, gitignored
-  T/
-    __init__.py         # same pattern for TIR
-    __init__.pyi        # AUTO-GENERATED, gitignored
-```
-
-The two sub-packages (`tf` and `T`) follow the same pattern:
-`__getattr__(name)` looks `name` up in the OpSchema registry for the
-corresponding dialect and returns either the Op class (for real-Op
-schemas) or the alias builder fn (for surface-alias schemas).
-Unknown names raise `AttributeError`.
+The author-facing surface is delivered as a namespace package. The two
+sub-packages (`tf` and `T`) use the OpSchema registry for their corresponding
+dialect and return an Op class or alias builder; unknown names raise `AttributeError`.
 
 ### 4.1 Built-in op-class location convention
 
-For `@register_op` to auto-derive `dialect` + `category`, an Op
-class MUST live under:
-
-```
-src/tilefoundry/ir/<hir|tir>/<category>/<file>.py
-```
-
-with `cls.__module__` matching `tilefoundry.ir.<hir|tir>.<category>.*`.
-The 4th segment of the dotted path is the category. Outside that
-path, the decorator requires explicit `dialect=` and `category=`
-kwargs.
-
-`cls.__name__.lower()` is the default canonical Op name. When the
-canonical name diverges from the class lowercase (e.g. `RMSNorm` →
-`rms_norm`), pass `name="..."` explicitly.
+For `@register_op` to auto-derive `dialect` + `category`, an Op class MUST live
+under `src/tilefoundry/ir/<hir|tir>/<category>/<file>.py`, with its module name
+matching that path. Outside it the decorator requires explicit values.
 
 ### 4.2 `.pyi` stub regeneration
 
-The `.pyi` stubs reflect the registered schemas only. After adding
-a new `@register_op` / `@register_alias`, regenerate stubs via:
-
-```
-python -m tilefoundry.dsl regen
-```
-
-The CLI imports `tilefoundry.ir` (forcing every built-in schema to
-register) and writes `tf/__init__.pyi` / `T/__init__.pyi`. Stubs
-are gitignored — IDEs that need them locally SHOULD run `regen` on
-package install.
+The `.pyi` stubs reflect registered schemas only. After adding a new
+`@register_op` / `@register_alias`, regenerate them with
+`python -m tilefoundry.dsl regen`.
 
 ## 5. DSL import surface
 
 The author-facing exports route through `tilefoundry.dsl`:
 
 ```python
-# canonical authoring imports
+# example
+# Canonical authoring imports.
 from tilefoundry import func, prim_func
 from tilefoundry.dsl import tf, T, Tensor
 ```

--- a/docs/spec/codegen.md
+++ b/docs/spec/codegen.md
@@ -47,12 +47,18 @@ metadata the link step needs.
 ### 2.1 Emitter registry
 
 ```python
-def get_emitter(target: str) -> Emitter: ...    # resolve the emitter registered for a target
-# Emitter: Callable[[tuple[PrimFunction, ...]], LinkableModule]
+def get_emitter(target: str | Target) -> Callable: ...
+def emit_cuda_module(cuda_fns: tuple[PrimFunction, ...]) -> LinkableModule: ...
+def emit_host_module(entry: PrimFunction, module) -> LinkableModule: ...
 ```
 
 - constraints:
-  - each target registers one emitter, resolved by target name.
+  - Each target registers one callable emitter, resolved by target object or
+    target name.
+  - Emitters do not share one callable shape. The CUDA emitter consumes the
+    grouped CUDA functions; the CPU emitter consumes the host entry plus the
+    module whose device functions it launches. Callers MUST invoke the resolved
+    emitter according to its target-owned contract.
 
 An emitter MUST consume only TIR and MUST return a `LinkableModule` for its
 target. The emitter file layout mirrors the IR file layout
@@ -62,7 +68,7 @@ by [code-organization](./code-organization.md).
 ### 2.2 Per-Op handler registry
 
 ```python
-def handler(call: Call, ctx: CodegenContext) -> None: ...   # Call (wrapped Op inside Evaluate) + CodegenContext
+def handler(call: Call, ctx: CodegenContext) -> None: ...
 ```
 
 - constraints:
@@ -80,15 +86,32 @@ prohibited.
 
 ```python
 class CodegenContext:
-    def emit(self, line: str) -> None: ...               # append a target source line
-    def expr(self, node: Expr) -> str: ...               # render an Expr as a target expression string
-    def dtype_to_cpp(self, dtype_name: str) -> str: ...  # backend dtype mapping
-    def name_for(self, var) -> str: ...                  # allocate / return the target-side identifier for an SSA var
+    """Mutable CUDA source builder passed to registered handlers."""
+
+    def reset_barrier_ids(self) -> None: ...
+    def alloc_barrier_id(self) -> int: ...
+    def dtype_to_cpp(self, dtype_name: str) -> str: ...
+    def register_kernel_param(self, var) -> None: ...
+    def is_kernel_param(self, var) -> bool: ...
+    def emit(self, line: str) -> None: ...
+    def blank(self) -> None: ...
+    def indent(self) -> None: ...
+    def dedent(self) -> None: ...
+    def name_for(self, var) -> str: ...
+    def source(self) -> str: ...
+    def capture(self, fn) -> str: ...
+    def emit_node(self, node) -> None: ...
 ```
 
 - constraints:
-  - the per-walk state object passed to handlers; the single source of truth for
-    target-side type strings, so handlers do not read the IR for them directly.
+  - This is the concrete CUDA context; it has a zero-argument constructor and
+    keeps its output, indentation, symbol table, and counters private.
+  - `emit_node` dispatches `Evaluate(op, args)` by the wrapped Op class; all
+    other nodes dispatch by their own class.
+  - `source` returns accumulated source text, and `capture` temporarily isolates
+    only the output buffer while preserving indentation and symbol bindings.
+  - The context is the single source of truth for target-side type strings, so
+    handlers do not read the IR for them directly.
 
 A handler MUST NOT reach into the IR for type strings on its own; the context is
 the single source of truth. Other helpers MAY be added per target.
@@ -109,7 +132,7 @@ codegen-static participant geometry) as compile-time template parameters. The
 runtime template dispatches on those layouts at compile time; codegen does not
 select a tier, compute a per-tier parameter, or carry the selection on the TIR
 op. This is the codegen side of the runtime-owned dispatch principle, whose
-contract lives in [runtime.md §3](runtime.md#3-runtime-ops). The target-side
+contract lives in [runtime.md §3](./runtime.md#3-runtime-ops). The target-side
 emission that produces these calls is owned by [target](./target.md).
 
 ## 4. Codegen products
@@ -121,13 +144,19 @@ One lowered function's pre-link source.
 
 ```python
 class LinkableFunction:
-    name: str      # the function / kernel symbol
-    source: str    # that function's emitted text
+    """One lowered function's pre-link source.
+
+    Attributes:
+        name: attribute; function or kernel symbol.
+        source: attribute; emitted function text.
+    """
+
+    name: str
+    source: str
 ```
 
 - constraints:
-  - MUST be the function / kernel symbol.
-  - MUST be that function's emitted text.
+  - No additional constraints.
 
 ### 4.2 `LinkableModule`
 
@@ -135,17 +164,24 @@ One target's pre-link translation unit.
 
 ```python
 class LinkableModule:
-    target: str                              # the function target name (cuda / cpu)
-    language: str                            # the source language (cu / cpp)
-    source: str                              # the assembled translation-unit text
-    functions: tuple[LinkableFunction, ...]  # the module's constituent LinkableFunctions
+    """One target's pre-link translation unit.
+
+    Attributes:
+        target: attribute; function target name.
+        language: attribute; source language.
+        source: attribute; assembled translation-unit text.
+        functions: attribute; constituent linkable functions in emission order.
+    """
+
+    target: str
+    language: str
+    source: str
+    functions: tuple[LinkableFunction, ...] = field(default_factory=tuple)
 ```
 
 - constraints:
-  - MUST be the function target name (`cuda` / `cpu`).
   - MUST be the source language: `cu` for a CUDA translation unit, `cpp` for a
     host translation unit.
-  - MUST be the assembled translation-unit text the link step compiles.
   - MUST list the module's constituent `LinkableFunction`s, in emission order.
 
 A `LinkableModule` is a build artifact, not a runtime object and not a
@@ -158,16 +194,22 @@ needs.
 
 ```python
 class LinkedModule:
-    library_path: Path                  # the produced shared library
-    source: str                         # the assembled host + device source
-    entry: EntryABI                     # the host-visible ABI of the module entry
+    """Linked library plus host-visible ABI metadata.
+
+    Attributes:
+        library_path: attribute; produced shared-library path.
+        source: attribute; assembled host and device source.
+        entry: attribute; host-visible ABI of the module entry.
+    """
+
+    library_path: Path
+    source: str
+    entry: EntryABI
 ```
 
 - constraints:
-  - MUST point at the produced shared library.
   - MUST carry the assembled host + device source — the diagnostic source the
     runtime exposes as `RuntimeModule.source` ([runtime](./runtime.md)).
-  - MUST be the host-visible ABI of the module entry.
 
 The `entry` `EntryABI` is a host-visible ABI metadata type owned by
 [runtime](./runtime.md); codegen references it on `LinkedModule` and MUST NOT

--- a/docs/spec/core-ir.md
+++ b/docs/spec/core-ir.md
@@ -37,21 +37,38 @@ Exprs.
 
 ```python
 class Module:
-    name: str                                               # the module name
-    functions: tuple[hir.Function | tir.PrimFunction, ...]  # the heterogeneous hir.Function | tir.PrimFunction container
-    entry: str                                              # name of the public entry function (a name present in functions)
-    modules: tuple["Module", ...]                           # child modules, each named by the attribute it is attached under
-    target: Target | None                                   # the hardware this execution domain runs on; None inherits from the owner
-    topologies: tuple[Topology, ...] | None                 # the complete ordered parallel-resource hierarchy; None inherits, () declares none
-    metadata: dict[str, object]                             # target / option metadata, never semantic mesh bindings
-    methods: Mapping[str, object]                           # plain Python orchestration methods (e.g. forward), bound like instance methods
+    """Contain one execution domain and its owned module tree.
 
-    @property
-    def weights(self) -> Mapping[str, TensorType]: ...     # derived — see below; there is no `states` field
+    Attributes:
+        name: attribute; Module name within its owner.
+        functions: attribute; Heterogeneous HIR and TIR function container.
+        entry: attribute; Optional public entry-function name.
+        modules: attribute; Child modules named by their attachment attributes.
+        target: attribute; Declared hardware target, or None to inherit.
+        topologies: attribute; Declared hierarchy, None to inherit, or an empty tuple.
+        metadata: attribute; Target and compiler-option metadata.
+        methods: attribute; Plain Python orchestration methods.
+    """
 
-    def resolve_target(self) -> Target: ...                # effective Target; fails when no owner declares one
-    def effective_topologies(self) -> tuple[Topology, ...]: ...   # effective hierarchy, inherited included
-    def resolve_topology(self, name: str) -> Topology: ...  # one effective level by exact name
+    name: str
+    functions: tuple[hir.Function | tir.PrimFunction, ...]
+    entry: str | None = None
+    modules: tuple["Module", ...] = field(default_factory=tuple)
+    target: Target | None = None
+    topologies: tuple[Topology, ...] | None = None
+    metadata: dict[str, object] = field(default_factory=dict)
+    methods: Mapping[str, object] = field(default_factory=dict)
+
+    def weights(self) -> Mapping[str, TensorType]: ...
+    def resolve_target(self) -> Target: ...
+    def effective_topologies(self) -> tuple[Topology, ...]: ...
+    def resolve_topology(self, name: str) -> Topology: ...
+    def owns(self, function: object, *, derived: bool = False) -> bool: ...
+    def load(self, resource) -> "LoadedModule": ...
+    def forward(self, *args): ...
+    def prepare(
+        self, raw, out_dir: str, *, device: str = "cpu"
+    ) -> None: ...
 ```
 
 - constraints:
@@ -61,6 +78,10 @@ class Module:
     declares the `Target` and the ordered `Topology` hierarchy.
   - a `Module` owns its child subtree. Placing a child that already belongs to
     another owner MUST NOT change what the first owner's subtree resolves.
+  - `owns(function)` MUST use identity and accept the Module's direct functions
+    and their specialization variants. With `derived=True`, it MUST also follow
+    a derived function's recorded specialization origin; equal copies and
+    same-name functions from another Module MUST remain unowned.
 
 - `parse_module` (see [parser §1](./parser.md#1-dsl-syntax)) returns a `Module`.
 - A bare `@func` / `@prim_func` becomes an implicit single-function
@@ -76,20 +97,21 @@ class Module:
 *declares*, not what it resolves to; resolution is lexical over the owner
 chain and is not copied onto each Module or Function.
 
-- `topologies = None` declares nothing and inherits the owner's hierarchy;
+- constraints:
+  - `topologies = None` declares nothing and inherits the owner's hierarchy;
   `topologies = ()` declares an explicitly topology-free domain; an explicit
   tuple replaces the inherited hierarchy whole rather than extending it. A
   declared tuple MUST NOT repeat a level name.
-- `resolve_topology(name)` returns the single effective level with that exact
+  - `resolve_topology(name)` returns the single effective level with that exact
   name and MUST fail, naming the levels that are available, when there is
   none.
-- `metadata` carries target / compiler-option configuration, never
+  - `metadata` carries target / compiler-option configuration, never
   semantic topology / mesh information.
-- Each entry of `modules` is named by the attribute it is attached under —
+  - Each entry of `modules` is named by the attribute it is attached under —
   torch / HuggingFace checkpoint-naming semantics: assigning a child to
   `self.self_attn` in a class body names that child `self_attn` in the tree,
   independent of the child's own `name`.
-- `mod.cloned()` returns an independent copy: its functions, their bodies, its
+  - `mod.cloned()` returns an independent copy: its functions, their bodies, its
   children, and every `Call` targeting one of them are copies, with internal
   `Call.target`s redirected to the copy. The immutable context around the node —
   its owner, `target` and `topologies` — MUST stay shared, since those are not
@@ -99,20 +121,20 @@ chain and is not copied onto each Module or Function.
   holding one Function would report one measurement under two names. This is
   what lets one definition become N distinct instances (N decoder layers, each
   renamed by index) and one prototype serve any number of independent builds.
-- `methods` collects plain Python functions (orchestration methods, e.g.
+  - `methods` collects plain Python functions (orchestration methods, e.g.
   `forward` / `init_caches`; full collection rule in
   [parser §2.7](./parser.md#27-module-authoring-surface)). A function name,
   a child module name, and a method name MUST be disjoint at one `Module`'s
   own level — all three resolve through the same attribute surface ([§1.1](#11-function-access)
   below), so a name used by more than one would be ambiguous.
-- `weights` is a derived property, not a stored field: each access unions
+  - `weights` is a derived property, not a stored field: each access unions
   every function's `ConstTensor` params (`Var.is_const`), in (function
   order, param order); the same name in two functions MUST carry an
   identical `TensorType`, or the access raises. There is no `states` field
   or persistent-state concept in the IR — a tensor that must survive across
   steps (e.g. a KV cache) is an ordinary `Tensor` param the caller passes in
   and receives back explicitly ([runtime §1.1.2](./runtime.md#112-weight-converter-and-prepare--forward)).
-- Constructing a `Module` **seals** its functions: each base function and
+  - Constructing a `Module` **seals** its functions: each base function and
   its specialization variants are finalized. Variants may be added to a
   base only during authoring, before the base enters a `Module`; once
   sealed, adding a variant is an error
@@ -168,22 +190,21 @@ A `Module` mirrors the model it describes: a caller reaches a kernel, a child
 component, or an orchestration step through the same attribute surface.
 
 Each `name` maps to at most one entry among `Module.functions`,
-`Module.modules`, and `Module.methods` — and a function name, a child module
-name, and a method name MUST be mutually disjoint at one `Module`'s own level
-(checked at construction), since all three resolve through the attribute
-surface below. Within `functions` alone, shape-specialization variants of a
-function live inside that entry's `Function.variants`
-([hir.md §1.1](./hir.md#11-function)), never as separate same-name
-entries — so name resolution is always single-valued.
+`Module.modules`, and `Module.methods`. Within `functions`,
+shape-specialization variants live inside that entry's `Function.variants`
+([hir.md §1.1](./hir.md#11-function)), never as separate same-name entries.
 
-- `mod.lookup(name)` returns the function named `name`; it raises unless
+- constraints:
+  - A function name, child-module name, and method name MUST be mutually
+  disjoint at one Module's own level.
+  - `mod.lookup(name)` returns the function named `name`; it raises unless
   exactly one function matches. This is the canonical name-resolution
   contract (e.g. for a `SymbolRef` callee) and always returns the `Function`
   / `PrimFunction` node itself.
-- `mod.function_named(name)` returns the entries named `name`. In a verified
+  - `mod.function_named(name)` returns the entries named `name`. In a verified
   module this is length 0 or 1 (variants are not separate entries).
-- `mod.entry_function()` returns the function named by `entry`.
-- Python attribute access `mod.<name>` resolves, in order, a function, a
+  - `mod.entry_function()` returns the function named by `entry`.
+  - Python attribute access `mod.<name>` resolves, in order, a function, a
   child module, or a method named `<name>`, and MUST raise `AttributeError`
   when none match or when more than one same-kind entry shares the name. A
   **function** name resolves to a callable that runs it — not to the
@@ -206,30 +227,44 @@ domain it belongs to: a `Function` carries neither the Target its numbers are
 measured against nor the topology hierarchy they divide over, so a bare function
 is not a thing a cost can be stated about.
 
-`select(module, path)` resolves a dotted `path` relative to `module` and returns a
-`Module`. Each segment MUST name a child module, except that the last MAY instead
-name one of the reached module's own functions — which returns that module
-re-entried at it, carrying the Target and topology hierarchy it resolved through
-its owners. An empty `path` is `module` itself. An empty *segment* MUST be
-refused: dropping it would make two different paths name one node.
-
-`function_selectors(module)` returns every HIR function in `module`'s tree paired
-with the path that names it, in source order, parents before children. The paths
-are the ones `select` resolves, so a name is qualified by the children it was
-reached through — two child modules may each define a `moe`, and an unqualified
-name would make them one entry. A `PrimFunction` is not one of these: it is an
-implementation of a function rather than a function of the model.
+- constraints:
+  - `select(module, path)` MUST resolve a dotted `path` relative to `module`
+    and return a `Module`. Each segment MUST name a child module, except that
+    the last MAY instead name one of the reached module's own functions and
+    return that module re-entried at it. An empty path is the input module; an
+    empty segment MUST be refused.
+  - `function_selectors(module)` MUST return every HIR function in the module
+    tree paired with its resolving path, in source order and parents before
+    children. It MUST NOT return `PrimFunction` entries.
 
 ## 2. `Expr`
 
 ```python
 class IRMetadata:
+    """Describe one immutable expression annotation."""
+
     def format_comment(self) -> str | None: ...
 
 class BindingMetadata(IRMetadata):
+    """Describe an authored SSA binding name.
+
+    Attributes:
+        name: attribute; Authored binding name.
+    """
+
     name: str
 
 class SourceSpanMetadata(IRMetadata):
+    """Describe an authored source range.
+
+    Attributes:
+        file: attribute; Source file.
+        line: attribute; Starting line.
+        column: attribute; Starting column.
+        end_line: attribute; Optional ending line.
+        end_column: attribute; Optional ending column.
+    """
+
     file: str
     line: int
     column: int
@@ -248,6 +283,13 @@ class SourceSpanMetadata(IRMetadata):
 
 ```python
 class Expr:
+    """Provide the immutable base for every typed expression.
+
+    Attributes:
+        type: attribute; Expression type.
+        metadata: attribute; Typed expression annotations.
+    """
+
     type: Type
     metadata: tuple[IRMetadata, ...] = ()
 ```
@@ -303,9 +345,15 @@ and TIR owns `SymbolRef` and other TIR-specific `Expr` constructs
 
 ```python
 class Call(Expr):
-    target: Op              # the Op being called
-    args: tuple[Expr, ...]  # the input Exprs
-    # type: computed by typeinfer(target, args); one of TensorType / TupleType / UnitType
+    """Represent an Op invocation.
+
+    Attributes:
+        target: attribute; Op being called.
+        args: attribute; Input expressions in parameter order.
+    """
+
+    target: Op
+    args: tuple[Expr, ...]
 ```
 
 - constraints:
@@ -321,15 +369,35 @@ class Call(Expr):
 
 ```python
 class Var(Expr):
-    name: str     # a named value (HIR params, TIR bindings)
-    type: IRType  # declaration-side type
+    """Represent a named value.
+
+    Attributes:
+        name: attribute; Value name.
+        type: attribute; Declaration-side type.
+        is_const: attribute; Whether this is an external constant parameter.
+    """
+
+    name: str
+    type: Type
     is_const: bool = False
 
 class Constant(Expr):
-    value: object  # a literal; a scalar is a rank-0 TensorType
+    """Represent a literal value.
+
+    Attributes:
+        value: attribute; Literal payload.
+    """
+
+    value: object
 
 class Tuple(Expr):
-    elements: tuple[Expr, ...]  # value-level multi-output aggregate; type is TupleType
+    """Represent a value-level aggregate.
+
+    Attributes:
+        elements: attribute; Aggregate elements in field order.
+    """
+
+    elements: tuple[Expr, ...]
 ```
 
 - constraints:
@@ -337,10 +405,6 @@ class Tuple(Expr):
   - `Var.is_const` MUST be preserved for HIR function parameters and MUST mark
     an external constant tensor parameter without embedding a tensor payload or
     changing its `TensorType`.
-
-`Tuple` is the value-level aggregate node; it pairs with `TupleType`
-([types §4](./types.md#4-dim--symbolic-shape-dimensions)) but is not the same — `Tuple` is an `Expr`
-in the IR graph, `TupleType` is the type carried by `Expr.type`.
 
 ### 2.3 `Op`
 
@@ -351,10 +415,25 @@ in the IR graph, `TupleType` is the type carried by `Expr.type`.
 registered with `@register_op`.
 
 ```python
-class Op:                                     # @register_op registers a class
-    @classmethod
-    def params(cls) -> list[ParamDef]: ...    # reflectively scans class-level ParamDef attributes and returns them ordered
-    def __init__(self, **attrs): ...          # instantiates with attribute values (a no-attribute Op is a singleton)
+class ParameterInfo:
+    """Describe the public reflection view of one Op parameter.
+
+    Attributes:
+        name: attribute; Declared parameter name.
+        kind: attribute; Whether the parameter is an input or attribute.
+        type: attribute; Declared Python annotation.
+    """
+
+    name: str
+    kind: Literal["input", "attribute"]
+    type: object
+
+
+class Op:
+    """Describe an operation signature and its attribute values."""
+
+    def params(cls) -> list[ParameterInfo]: ...
+    def __init__(self, **attrs): ...
 ```
 
 - constraints:
@@ -366,11 +445,21 @@ class Op:                                     # @register_op registers a class
 
 ```python
 class ParamDef:
-    kind: Literal["input", "attribute"]  # "input" (flows into Call.args) or "attribute" (carried on the Op instance)
-    annotation: type | None              # the Python type of the parameter
-    pattern: Pattern | None              # input-kind only — the Pattern matched against arg.type
-    default: object                      # attribute-kind only — omitted-call default
-    optional: bool                       # attribute-kind only — nullability
+    """Declare one Op input or attribute.
+
+    Attributes:
+        kind: attribute; Whether the parameter is an input or attribute.
+        annotation: attribute; Python value-family annotation.
+        pattern: attribute; Optional input-type predicate.
+        optional: attribute; Whether None is accepted.
+        default: attribute; Call-site default or the required-value sentinel.
+    """
+
+    kind: Literal["input", "attribute"]
+    annotation: type = field(default=object)
+    pattern: Pattern | None = None
+    optional: bool = False
+    default: Any = MISSING
 ```
 
 - constraints:
@@ -379,6 +468,7 @@ class ParamDef:
 Example:
 
 ```python
+# example
 @register_op
 class Binary(Op):
     lhs  = ParamDef(kind="input", pattern=Tensor)
@@ -420,16 +510,8 @@ def builder() -> Op:
   - alias schemas have no IR class (`OpSchema.op_class is None`) and prepend to the
     schema bucket so they win first-match resolution.
 
-```python
-@register_alias(dialect="tf", category="math", name="add",
-                params=[Binary.lhs, Binary.rhs])
-def _add() -> Op:
-    return Binary(kind=BinaryKind.ADD)
-```
-
 Properties:
 
-- `OpSchema.op_class is None` — alias schemas have no IR class.
 - `params` reuses the **static `ParamDef` references** of the target
   Op. The alias never re-declares ParamDef structures.
 - `builder` takes attribute kwargs only; input args still flow into
@@ -441,9 +523,13 @@ Properties:
   ``op_class``-keyed legacy lookup transparently sees the real class
   registered for the same name (or `None` when there is none).
 
-HIR `math` uses aliases for kinded sugar names (`add` / `sub` /
-... / `cmp_eq` / ... / `neg` / ...); the IR core has just `Binary`
-/ `Unary` (see [hir math ops](./hir.md#irhirmath)).
+```python
+# example
+@register_alias(dialect="tf", category="math", name="add",
+                params=[Binary.lhs, Binary.rhs])
+def _add() -> Op:
+    return Binary(kind=BinaryKind.ADD)
+```
 
 #### Input position and form
 
@@ -466,7 +552,9 @@ and specialization dispatch.
 
 ```python
 class Pattern:
-    def match(self, subject) -> bool: ...    # base predicate returning bool; subclasses override it
+    """Carry a reusable dispatch predicate."""
+
+    def match(self, subject) -> bool: ...
 ```
 
 - constraints:
@@ -491,29 +579,92 @@ Two consumer surfaces:
 
 ```python
 class DimVarRangePat(Pattern):
-    dim_var: str  # name of the DimVar the range applies to
-    lo: int       # the half-open interval [lo, hi) lower bound
-    hi: int       # the half-open interval [lo, hi) upper bound
+    """Match one sub-range of a named dimension.
+
+    Attributes:
+        dim_var: attribute; Name of the dimension.
+        lo: attribute; Inclusive lower bound.
+        hi: attribute; Exclusive upper bound.
+    """
+
+    dim_var: str = ""
+    lo: int = 0
+    hi: int = 0
 ```
 
 - constraints:
-  - the per-variant sub-range for a named `DimVar`; `match(v)` is `lo <= v < hi`
-    and ignores `dim_var`.
+  - This is the per-variant sub-range for a named `DimVar`; `match(v)` is
+    `lo <= v < hi` and ignores `dim_var`.
+  - `dim_var` MUST be a non-empty `str` — the name of the `DimVar` the
+    range applies to. The lowering resolves it to a runtime
+    `ShapeOf(param, axis)` by walking the enclosing function signature.
+  - `lo` and `hi` MUST be plain `int`s (`bool` is rejected).
+  - The interval is half-open `[lo, hi)` (`lo` inclusive, `hi`
+    exclusive); construction MUST satisfy `lo < hi`. A single-point
+    range is `[k, k+1)`.
+  - `match(value)` returns `True` for an `int` value `v` iff
+    `lo <= v < hi`. The `dim_var` field does not participate in
+    `match`.
+  - The pattern references a `DimVar` by name only. The envelope of
+    the named dim lives on the `DimVar(name, lo, hi)` itself (see
+    [types.md §4](./types.md#4-dim--symbolic-shape-dimensions)); the
+    `DimVarRangePat` carries the per-variant sub-range. Envelope
+    containment (`pattern ⊆ DimVar envelope`) is checked in
+    signature context — by the `@tilefoundry.func` validator and the
+    HIR→TIR lowering — not by `DimVarRangePat.__post_init__`.
 
-- `dim_var` MUST be a non-empty `str` — the name of the `DimVar` the
-  range applies to. The lowering resolves it to a runtime
-  `ShapeOf(param, axis)` by walking the enclosing function signature.
-- `lo` and `hi` MUST be plain `int`s (`bool` is rejected).
-- The interval is half-open `[lo, hi)` (`lo` inclusive, `hi`
-  exclusive); construction MUST satisfy `lo < hi`. A single-point
-  range is `[k, k+1)`.
-- `match(value)` returns `True` for an `int` value `v` iff
-  `lo <= v < hi`. The `dim_var` field does not participate in
-  `match`.
-- The pattern references a `DimVar` by name only. The envelope of
-  the named dim lives on the `DimVar(name, lo, hi)` itself (see
-  [types.md §4](./types.md#4-dim--symbolic-shape-dimensions)); the
-  `DimVarRangePat` carries the per-variant sub-range. Envelope
-  containment (`pattern ⊆ DimVar envelope`) is checked in
-  signature context — by the `@tilefoundry.func` validator and the
-  HIR→TIR lowering — not by `DimVarRangePat.__post_init__`.
+## 4. Shared operation kinds
+
+```python
+class BinaryKind(enum.Enum):
+    """Enumerate pointwise binary operation kinds shared by HIR and TIR."""
+
+    ADD = "add"
+    SUB = "sub"
+    MUL = "mul"
+    DIV = "div"
+    FLOOR_DIV = "floor_div"
+    MOD = "mod"
+    MIN = "min"
+    MAX = "max"
+    EQ = "eq"
+    NE = "ne"
+    LT = "lt"
+    LE = "le"
+    GT = "gt"
+    GE = "ge"
+    AND = "and"
+    OR = "or"
+
+
+class UnaryKind(enum.Enum):
+    """Enumerate pointwise unary operation kinds shared by HIR and TIR."""
+
+    NEG = "neg"
+    ABS = "abs"
+    RSQRT = "rsqrt"
+    CAST = "cast"
+    NOT = "not"
+    RELU = "relu"
+    SQUARE = "square"
+    EXP = "exp"
+    LOG = "log"
+    CEIL = "ceil"
+    ROUND = "round"
+    EXP2 = "exp2"
+    LOG2 = "log2"
+
+
+class ReduceKind(enum.Enum):
+    """Enumerate reduction operation kinds shared by HIR and TIR."""
+
+    MEAN = "mean"
+    SUM = "sum"
+    ABS_MAX = "abs_max"
+    MAX = "max"
+```
+
+- constraints:
+  - These enums MUST be the single shared kind vocabulary carried by HIR and
+    TIR generic operations; lowering MUST preserve a kind without remapping it.
+  - The member names and string values above are the complete built-in sets.

--- a/docs/spec/evaluator.md
+++ b/docs/spec/evaluator.md
@@ -29,6 +29,7 @@ def evaluate(
     fn_or_call: "Function | Call",
     *inputs: "torch.Tensor",
     backend: str = "torch",
+    device: str | None = None,
 ) -> "torch.Tensor | tuple[torch.Tensor, ...]":
     ...
 ```
@@ -37,6 +38,8 @@ def evaluate(
 order, walks the body, and returns the logical tensor for a single
 output or a tuple for a `TupleType` result. `backend` selects the
 tensor engine; `"torch"` is the defined backend.
+`device` selects the torch device; when omitted it chooses CUDA when available
+and otherwise CPU.
 
 ## 1. `Value`
 
@@ -46,7 +49,8 @@ single-output node produces a `TensorValue`; a multi-output node (a
 produces a `TupleValue`.
 
 ```python
-class Value: ...    # base of every evaluated value
+class Value:
+    """Provide the base of every evaluated value."""
 ```
 
 - constraints: none — abstract base; concrete values are `TensorValue` / `TupleValue`
@@ -54,9 +58,16 @@ class Value: ...    # base of every evaluated value
 ### `TensorValue`
 
 ```python
-class TensorValue:
-    data: torch.Tensor    # the logical tensor value
-    type: TensorType      # the HIR type of this value (carries layout)
+class TensorValue(Value):
+    """Pair a logical tensor value with its HIR type.
+
+    Attributes:
+        data: attribute; Logical tensor value.
+        type: attribute; HIR tensor type, including layout.
+    """
+
+    data: torch.Tensor
+    type: TensorType
 ```
 
 - constraints:
@@ -69,8 +80,14 @@ class TensorValue:
 ### `TupleValue`
 
 ```python
-class TupleValue:
-    elements: tuple[Value, ...]    # the per-field `Value`s
+class TupleValue(Value):
+    """Aggregate evaluated values.
+
+    Attributes:
+        elements: attribute; Values in field order.
+    """
+
+    elements: tuple[Value, ...]
 ```
 
 - constraints:
@@ -102,19 +119,32 @@ spec's module-level instances).
 ```python
 eval_registry: AnalysisRegistry[type[Op]]
 
-def register_eval(op_cls: type[Op]): ...   # decorator
+def register_eval(op_cls: type[Op]):
+    """Return the evaluator registration decorator for an Op class."""
+    ...
 ```
 
 A handler receives an `EvalContext` and returns a `Value`:
 
 ```python
 class EvalContext:
-    args: tuple[Value, ...]    # already-evaluated operands in `Call.args` order (TensorValue / TupleValue)
-    op: Op                     # the op instance; attributes read as fields (e.g. `ctx.op.kind`, `ctx.op.index`)
-    result_type: Type          # the `Call`'s result type
-    device: torch.device       # backend device; a handler materialising a new tensor (e.g. `Zeros`) creates it there
+    """Carry one registered evaluator invocation.
 
-def handler(ctx: EvalContext) -> Value: ...    # a registered per-op value handler
+    Attributes:
+        op: attribute; Operation instance.
+        args: attribute; Evaluated operands in Call-argument order.
+        result_type: attribute; Call result type.
+        device: attribute; Backend device name.
+    """
+
+    op: Any
+    args: tuple[Any, ...]
+    result_type: Any
+    device: str = "cpu"
+
+def handler(ctx: EvalContext) -> Value:
+    """Evaluate one registered Op invocation."""
+    ...
 ```
 
 A `Call` whose op class has no registered handler raises an error that
@@ -128,8 +158,11 @@ Evaluation is an `ExprVisitor[Value]`
 a shared sub-DAG ([hir §1.1](./hir.md#11-function)) is evaluated once:
 
 ```python
-class Evaluator(ExprVisitor[Value]):             # memoized on id(expr): a shared sub-DAG is evaluated once
-    def visit(self, expr: Expr) -> Value: ...    # dispatch by expr kind: Var / Constant / Tuple / Call(Op) / Call(Function) / GridRegionExpr
+class Evaluator(ExprVisitor):
+    """Evaluate expressions with identity-based memoization."""
+
+    def visit(self, expr: Expr) -> Value: ...
+    def visit_GridRegionExpr(self, region: GridRegionExpr) -> Value: ...
 ```
 
 - A `Var` resolves to its binding in the current environment; a
@@ -148,9 +181,8 @@ class Evaluator(ExprVisitor[Value]):             # memoized on id(expr): a share
 A `GridRegionExpr` ([hir §1.2](./hir.md#12-gridregionexpr)) is a loop over its iteration
 domain whose carry chain starts from `init_args`:
 
-```python
-def eval_grid(region: GridRegionExpr) -> Value: ...    # loop over the iteration domain; carry chain starts from init_args
-```
+`Evaluator.visit_GridRegionExpr(region)` implements the loop; there is no
+separate `eval_grid` function.
 
 - The first iteration binds each `carried_args` phi to the matching
   `init_args` value; each later iteration binds it to the previous

--- a/docs/spec/hir.md
+++ b/docs/spec/hir.md
@@ -36,16 +36,22 @@ class Function(Expr):
     """HIR's function container; its value type is the function signature.
 
     Attributes:
-        name: the function name; call sites resolve through Module's symbol table.
-        params: each Var carries a type annotation.
-        body: a single Expr — typically a Call DAG; None for a dispatch prototype.
-        return_type: TensorType for single output, TupleType for multi.
+        name: attribute; the function name; call sites resolve through Module's symbol table.
+        params: attribute; each Var carries a type annotation.
+        body: attribute; a single Expr — typically a Call DAG; None for a dispatch prototype.
+        return_type: attribute; TensorType for single output, TupleType for multi.
+        specializations: attribute; Dispatch patterns carried by a variant.
+        variants: attribute; Shape-specialized implementations carried by a prototype.
+        converters: attribute; Weight names paired with offline converter functions.
     """
 
     name: str
     params: tuple[Var, ...]
     body: Expr | None
-    return_type: IRType
+    return_type: Type
+    specializations: tuple[Pattern, ...] = field(default_factory=tuple)
+    variants: tuple["Function", ...] = field(default_factory=tuple)
+    converters: tuple[tuple[str, "Function"], ...] = field(default_factory=tuple)
 ```
 - constraints:
   - an `Expr` subclass whose value type is the function signature; always returns
@@ -122,12 +128,8 @@ explicit `Reshard` or allreduce may complete that state.
 
 When the body cannot express a propagated sharding (e.g. a reshape
 whose layout factorization straddles a new axis), typeinfer fails at that
-op, not at the boundary. Reconstructing IR for every call is unnecessary
-when nothing would change: elaborating with argument types that already
-equal the callee's current parameter types returns the same `Function`
-instance (dedup) rather than a clone — an optimization, not a semantic;
-callers MUST NOT rely on getting a distinct instance. A dispatch-prototype
-callee (`variants != ()`, `body is None`) is not elaborated: the call's
+op, not at the boundary. A dispatch-prototype callee
+(`variants != ()`, `body is None`) is not elaborated: the call's
 result is the declared `return_type` and the `None` body is never inspected
 (variant selection is **Shape dispatch and specializations** below).
 
@@ -186,12 +188,9 @@ single **base** `Function` through its `variants` field; there is no
 separate specialized-function type. The field is the IR-side carrier for
 the parser surface ([parser.md](./parser.md)).
 
-```python
-class Function(Expr):
-    ...
-    specializations: tuple[Pattern, ...] = ()
-    variants: tuple["Function", ...] = ()
-```
+The `specializations`, `variants`, and `converters` tuples are canonical
+`Function` fields. `converters` records `(weight_name, converter)` pairs in
+registration order and is sealed recursively with the base and its variants.
 
 *Structure.* A `Function` is exactly one of three shapes:
 
@@ -264,14 +263,14 @@ class GridRegionExpr(Expr):
     """Loop-phi-shaped structured SSA folding a tile-style loop into one Expr value.
 
     Attributes:
-        induction_var: loop induction Var, ranging over range(start, extent, step).
-        carried_args: loop-phi carry chain (equal lengths).
-        init_args: loop-phi carry chain (equal lengths).
-        body: the loop body Expr.
-        yield_values: loop-phi carry chain (equal lengths).
-        extent: iteration-domain stop (half-open).
-        step: induction-var stride.
-        start: iteration-domain start (default 0).
+        induction_var: attribute; loop induction Var, ranging over range(start, extent, step).
+        carried_args: attribute; loop-phi carry chain (equal lengths).
+        init_args: attribute; loop-phi carry chain (equal lengths).
+        body: attribute; the loop body Expr.
+        yield_values: attribute; loop-phi carry chain (equal lengths).
+        extent: attribute; iteration-domain stop (half-open).
+        step: attribute; induction-var stride.
+        start: attribute; iteration-domain start (default 0).
     """
 
     induction_var: Var
@@ -495,11 +494,186 @@ class Unary(Op):
     `logical_not` are not proven to commute with any `reduction` and reject a
     `Partial` operand unconditionally.
 
+##### Clamp
+
+```python
+class Clamp(Op):
+    """Clamp every element to a closed interval; produces a Tensor.
+
+    Attributes:
+        x: input; Source tensor.
+        min_val: attribute; Lower bound.
+        max_val: attribute; Upper bound.
+    """
+
+    x: Tensor
+    min_val: float
+    max_val: float
+```
+
+- constraints:
+  - The result MUST preserve `x`'s shape, dtype, layout, and storage.
+  - Clamp is monotone non-decreasing, so it MAY preserve a `Partial(max)` or
+    `Partial(min)` state and MUST reject `Partial(sum)`.
+
+##### Softplus
+
+```python
+class Softplus(Op):
+    """Apply pointwise softplus; produces a Tensor.
+
+    Attributes:
+        x: input; Source tensor.
+    """
+
+    x: Tensor
+```
+
+- constraints:
+  - The result MUST preserve `x`'s type.
+  - Softplus is monotone non-decreasing, so it MAY preserve a `Partial(max)`
+    or `Partial(min)` state and MUST reject `Partial(sum)`.
+
 #### `ir/hir/tensor/`
 
 Tensor structural operations; consensus ops (`Transpose` / `Slice` / `Concat`
 / `Stack` / `ShapeOf` / `Rank`) follow torch / numpy
 ([torch tensor manipulation ops](https://pytorch.org/docs/stable/torch.html#indexing-slicing-joining-mutating-ops)).
+
+##### ArgMax
+
+```python
+class ArgMax(Op):
+    """Produce indices of maximum values along an axis.
+
+    Attributes:
+        x: input; Source tensor.
+        axis: attribute; Reduction axis.
+    """
+
+    x: Tensor
+    axis: int = -1
+```
+
+- constraints:
+  - `x` MUST have rank at least one and `axis` MUST resolve within that rank.
+  - The result MUST remove `axis`, use dtype `i64`, and preserve `x`'s layout
+    and storage.
+  - `x` MUST NOT carry a `Partial` state because a winning index cannot be
+    recovered from an unpaired per-device partial reduction.
+
+##### FullLike
+
+```python
+class FullLike(Op):
+    """Produce a tensor like an input filled with a scalar constant.
+
+    Attributes:
+        x: input; Type and shape template.
+        value: attribute; Fill value.
+    """
+
+    x: Tensor
+    value: float
+```
+
+- constraints:
+  - The result MUST have exactly `x`'s type and every element MUST equal
+    `value` converted to that dtype.
+
+##### Quant
+
+```python
+class Quant(Op):
+    """Produce per-token-group quantized values and scales.
+
+    Attributes:
+        x: input; Source tensor.
+        scheme: attribute; Quantization scheme.
+        group: attribute; Last-axis group size.
+        target_dtype: attribute; Quantized element dtype.
+    """
+
+    x: Tensor
+    scheme: str = "per_token_group"
+    group: int = 128
+    target_dtype: DType = DType.fp8e4m3
+```
+
+- constraints:
+  - `x` MUST have rank at least one and MUST NOT carry a `Partial` state.
+  - For a static last extent, `group` MUST divide that extent.
+  - The result MUST be `(x_q, x_scale)`: `x_q` preserves `x.shape` with
+    `target_dtype`; `x_scale` has dtype `f32` and, for a static last extent,
+    replaces it by `x.shape[-1] // group`. For a symbolic last extent,
+    `x_scale` retains the original last extent. Both fields preserve layout
+    and storage.
+
+##### RepeatInterleave
+
+```python
+class RepeatInterleave(Op):
+    """Repeat elements along one axis; produces a Tensor.
+
+    Attributes:
+        x: input; Source tensor.
+        repeats: attribute; Repetitions per source element.
+        axis: attribute; Axis to expand.
+    """
+
+    x: Tensor
+    repeats: int
+    axis: int
+```
+
+- constraints:
+  - `axis` MUST resolve within the rank and its result extent MUST be the input
+    extent multiplied by `repeats`; all other extents and storage are preserved.
+  - The result layout is unsharded. A genuinely sharded input MUST be refused;
+    an unsharded or fully broadcast input is accepted.
+
+##### Split
+
+```python
+class Split(Op):
+    """Split a tensor into equal parts; produces a Tuple.
+
+    Attributes:
+        x: input; Source tensor.
+        axis: attribute; Split axis.
+        num_splits: attribute; Number of outputs.
+    """
+
+    x: Tensor
+    axis: int
+    num_splits: int
+```
+
+- constraints:
+  - A static selected extent MUST be divisible by `num_splits`; every output
+    field has that extent divided by `num_splits` and otherwise preserves the
+    input type.
+  - A symbolic selected extent is retained in each output until a tighter
+    symbolic quotient is available.
+
+##### TupleGetItem
+
+```python
+class TupleGetItem(Op):
+    """Extract one field from a tuple-typed expression.
+
+    Attributes:
+        tuple_value: input; Tuple-typed expression.
+        index: attribute; Static field index.
+    """
+
+    tuple_value: Expr
+    index: int
+```
+
+- constraints:
+  - `tuple_value.type` MUST be `TupleType` and `index` MUST be in range.
+  - The result type MUST be exactly the selected field type.
 
 ##### Reshape
 ```python
@@ -908,6 +1082,65 @@ class RoPE(Op):
   - A non-`sum` Partial, multiple value-carrying Partials, or a Partial on a
     secondary cache/index input MUST be rejected with a `Reshard` remedy.
 
+##### CUDA matrix multiply-accumulate family
+
+```python
+class Mma(Op):
+    """Provide the marker base for HIR CUDA matrix operations."""
+
+
+class Mma_SM80_16x8x16(Mma):
+    """Produce an SM80 16-by-8 accumulator fragment.
+
+    Attributes:
+        a: input; Left 16-by-16 fragment.
+        b: input; Right 16-by-8 fragment.
+        dtype_a: attribute; Left operand dtype.
+        dtype_b: attribute; Right operand dtype.
+        dtype_acc: attribute; Accumulator dtype.
+        a_layout: attribute; Left matrix orientation.
+        b_layout: attribute; Right matrix orientation.
+    """
+
+    a: Tensor
+    b: Tensor
+    dtype_a: DType
+    dtype_b: DType
+    dtype_acc: DType
+    a_layout: str = "T"
+    b_layout: str = "N"
+
+
+class Wgmma_SM90_64x128x16(Mma):
+    """Produce an SM90 64-by-128 accumulator fragment.
+
+    Attributes:
+        a: input; Left fragment.
+        b: input; Right fragment.
+        dtype_a: attribute; Left operand dtype.
+        dtype_b: attribute; Right operand dtype.
+        dtype_acc: attribute; Accumulator dtype.
+        a_layout: attribute; Left matrix orientation.
+        b_layout: attribute; Right matrix orientation.
+    """
+
+    a: Tensor
+    b: Tensor
+    dtype_a: DType
+    dtype_b: DType
+    dtype_acc: DType
+    a_layout: str = "T"
+    b_layout: str = "N"
+```
+
+- constraints:
+  - `Mma` is a marker base used for family dispatch and has no independent
+    callable parameter surface.
+  - Both concrete operations MUST return a value-form tensor in `dtype_acc`,
+    preserving `a`'s layout and resolving storage from both operands.
+  - `Mma_SM80_16x8x16` returns shape `(16, 8)` and is warp-level;
+    `Wgmma_SM90_64x128x16` returns shape `(64, 128)` and is four-warp-level.
+
 #### `ir/hir/shape/`
 
 Shape-level Ops on whole shape values (per-axis dim Ops are
@@ -936,9 +1169,11 @@ class ShapeCompose(Op):
 
     Attributes:
         dims: input; per-axis dimensions.
+        is_variadic: attribute; Whether the input parameter consumes all args.
     """
 
     dims: Tensor
+    is_variadic: ClassVar[bool] = True
 ```
 - constraints:
   - The result is a shape value assembled in input order.
@@ -1016,3 +1251,136 @@ class Local(Op):
   - `dtype` and `storage` are preserved.
   - The shard wrapper is stripped, leaving the base `Layout`.
   - Static split sizes divide by mesh extent; symbolic sizes pass through.
+
+## 2. Function specialization API
+
+```python
+class SpecializationError(ValueError):
+    """Report that a function cannot be specialized as requested."""
+
+
+PROVENANCE = "_specialized_from"
+BOUND_DIMS = "_specialized_dims"
+
+
+def origin_of(function: object) -> Function | None:
+    """Return the source function of a derived specialization.
+
+    Args:
+        function: Candidate derived function.
+
+    Returns:
+        Its recorded origin, or None.
+    """
+    ...
+
+
+def bound_dims_of(function: object) -> tuple[tuple[str, int], ...] | None:
+    """Return the sorted dimensions bound on a derived specialization.
+
+    Args:
+        function: Candidate derived function.
+
+    Returns:
+        Recorded bindings, or None.
+    """
+    ...
+
+
+def variant_for(fn: Function, dims: Mapping[str, int]) -> Function:
+    """Select the unique implementation covering concrete dimensions.
+
+    Args:
+        fn: Function or dispatch prototype.
+        dims: Concrete extents by dimension name.
+
+    Returns:
+        The selected implementation.
+    """
+    ...
+
+
+def specialize_function(
+    fn: Function,
+    dims: Mapping[str, int],
+    *,
+    ctx: TypeInferContext | None = None,
+) -> Function:
+    """Bind stated dimensions and rebuild the selected implementation.
+
+    Args:
+        fn: Function or dispatch prototype.
+        dims: Dimensions to bind.
+        ctx: Optional shared type-inference context.
+
+    Returns:
+        The selected and partially or fully specialized function.
+    """
+    ...
+
+
+def specialize_concretely(fn: Function, dims: Mapping[str, int]) -> Function:
+    """Specialize a function with no residual symbolic dimensions.
+
+    Args:
+        fn: Function or dispatch prototype.
+        dims: Complete concrete dimension bindings.
+
+    Returns:
+        A concrete function.
+    """
+    ...
+
+
+def residual_dims(fn: Function) -> tuple[str, ...]:
+    """Return every dimension still stated as a range.
+
+    Args:
+        fn: Function to inspect recursively.
+
+    Returns:
+        Residual dimension names.
+    """
+    ...
+
+
+def dim_vars_reached(fn: Function) -> dict[str, object]:
+    """Return residual dimension declarations by name.
+
+    Args:
+        fn: Function to inspect recursively.
+
+    Returns:
+        Residual dimension declarations.
+    """
+    ...
+
+
+def is_concrete(fn: Function) -> bool:
+    """Return whether no required extent remains symbolic.
+
+    Args:
+        fn: Function to inspect.
+
+    Returns:
+        Whether the function is concrete.
+    """
+    ...
+```
+
+- constraints:
+  - `variant_for` MUST return an ordinary function unchanged and otherwise
+    MUST select exactly one matching variant. Missing or ambiguous coverage and
+    an unstated dimension used by a pattern MUST raise `SpecializationError`.
+  - `specialize_function` MUST reject an empty binding, an unknown dimension,
+    or a selected implementation with no body. It MUST record the chosen
+    implementation and sorted bindings on a rebuilt function so `origin_of`
+    and `bound_dims_of` can recover them.
+  - `specialize_concretely` MUST require a non-empty string-to-integer mapping
+    and MUST reject any residual dimension after specialization.
+  - Provenance and bound-dimension records MUST NOT participate in structural
+    equality or hashing; ownership checks use the recorded origin rather than
+    a function name.
+  - `residual_dims` and `dim_vars_reached` MUST inspect the whole function
+    graph, including signatures, bodies, Op attributes, loop bounds, variants,
+    and called functions. `is_concrete` additionally checks the return type.

--- a/docs/spec/inspection.md
+++ b/docs/spec/inspection.md
@@ -5,23 +5,44 @@
 Developer-facing inspection facilities for TileFoundry IR: DOT graph,
 Python DSL printer (round-trippable), interactive HTML viewer, and dump
 integration.
-Implementation: `src/tilefoundry/inspection/`.
 
 ## 1. HIR DOT
 
-`hir_function_to_dot(fn: hir.Function) -> str` produces a Graphviz DOT
-digraph from an SSA HIR function.  Each `Var`, `Call`, and `Constant`
-node is rendered with its type, shape, dtype, and `ShardLayout`
-distribution annotations (mesh axes, attrs).  Shared subexpressions are
-deduplicated by object identity.
+```python
+def hir_function_to_dot(fn: hir.Function) -> str:
+    """Render an SSA HIR function as Graphviz DOT.
+
+    Args:
+        fn: Function to render.
+
+    Returns:
+        Graphviz DOT text.
+    """
+    ...
+
+
+def module_entry_to_dot(module: Module) -> str:
+    """Render a Module's entry function as Graphviz DOT.
+
+    Args:
+        module: Module whose entry is rendered.
+
+    Returns:
+        Graphviz DOT text.
+    """
+    ...
+```
+
+- constraints:
+  - Each `Var`, `Call`, and `Constant` node MUST show its type, shape, dtype,
+    and sharding annotations. Shared expressions MUST be deduplicated by
+    object identity.
 
 ```python
+# example
 from tilefoundry.inspection import hir_function_to_dot
 print(hir_function_to_dot(fn))
 ```
-
-`module_entry_to_dot(mod: Module) -> str` renders the entry function of
-a module.
 
 ## 2. Python DSL Printer
 
@@ -32,18 +53,77 @@ IR.
 
 ### 2.1 Function printer
 
-`hir_function_to_python(fn: hir.Function) -> str` — standalone
-`@func` DSL output.  Produces imports, `@func` signature with full
-`Tensor[...]` type annotations, and SSA body with op calls.
+```python
+class PythonPrintOptions:
+    """Control optional non-canonical printer annotations.
+
+    Attributes:
+        show_types: attribute; Whether to append inferred types.
+        comment_metadata_types: attribute; Metadata classes rendered as comments.
+    """
+
+    show_types: bool = False
+    comment_metadata_types: tuple[type[IRMetadata], ...] = ()
+
+
+def hir_function_to_python(
+    fn: hir.Function, *, options: PythonPrintOptions | None = None
+) -> str:
+    """Render a HIR function as Python DSL source.
+
+    Args:
+        fn: Function to render.
+        options: Optional inspection annotations.
+
+    Returns:
+        Python DSL source.
+    """
+    ...
+```
+
+- constraints:
+  - The output MUST include imports, a bare `@func` signature with complete
+    `Tensor[...]` annotations, and the SSA body.
 
 ### 2.2 Module printer
 
-`as_script(module: hir.Module)` and
-`module_to_python(fn: hir.Function, module_name: str = "M") -> str` — wrap one
-or more HIR Functions in `@module(entry="<fn>") class Name:`. Module input
-emits all HIR Functions, preserving shared `Mesh` / `Topology` definitions at
-module level (before the class); sugar annotations are preserved. Mixed
-HIR/TIR Modules are rejected by the Python HIR printer.
+```python
+def as_script(
+    fn: hir.Function | Module,
+    *,
+    module: str | None = None,
+    options: PythonPrintOptions | None = None,
+) -> str:
+    """Render a HIR function or Module as Python DSL source.
+
+    Args:
+        fn: Function or Module to render.
+        module: Optional wrapper class name for a Function.
+        options: Optional inspection annotations.
+
+    Returns:
+        Python DSL source.
+    """
+    ...
+
+
+def module_to_python(fn: hir.Function, module_name: str = "M") -> str:
+    """Render a function through the module-wrapper compatibility alias.
+
+    Args:
+        fn: Function to render.
+        module_name: Wrapper class name.
+
+    Returns:
+        Python DSL source.
+    """
+    ...
+```
+
+- constraints:
+  - Module input MUST emit every HIR Function and preserve shared `Mesh` and
+    `Topology` definitions before the class. Mixed HIR/TIR Modules MUST be
+    rejected.
 
 The printer MUST emit a Module's whole tree: each nested Module prints as a
 `@module` class inside its owner's body, so a re-parse rebuilds the same
@@ -106,12 +186,12 @@ definitions are emitted in the module prelude / standalone header.
 ### 2.6 Specialization printing
 
 A dispatch prototype ([hir.md §1.1](./hir.md#11-function))
-prints as its base `@tilefoundry.func` with a `pass` body, followed by each
+prints as its base `@func` with a `pass` body, followed by each
 variant as an `@<name>.specialize(pattern)` block in declared order:
 
 ```python
 # example
-@tilefoundry.func
+@func
 def f(x: Tensor[(S,), "f32"]) -> Tensor[(S,), "f32"]:
     pass
 
@@ -133,7 +213,8 @@ validation artifact.
 A rendering is one of two surfaces:
 
 **Canonical** — the rendering of a function with no `DimVar` parameter. It
-MUST round-trip: `print → parse → structural_equal` holds over
+MUST round-trip: printing, parsing, and the test-side structural comparison
+MUST agree over
 
 - Params: shape, dtype, storage, layout.attrs, layout.shape, layout.strides, mesh identity (topology name/size, layout shape, names)
 - Body: op class, args, keyword attrs, types
@@ -147,7 +228,7 @@ MUST round-trip: `print → parse → structural_equal` holds over
 therefore of any dispatch prototype and its `.specialize` variants ([§2.6](#26-specialization-printing)). A
 display-only rendering is human-readable and MUST NOT be used as a
 `parse_script` validation artifact: it is held to importing, not to
-`structural_equal`.
+the same structural comparison.
 
 A `DimVar` shape entry prints as its bare name, and a shape-valued op attribute
 holding one MUST print it the same way rather than as its repr. The rendering
@@ -293,21 +374,6 @@ graph; an id that was collapsed away returns 404.
 
 ### 3.5 File layout
 
-```
-src/tilefoundry/inspection/viewer/
-  __init__.py        # Viewer.serve()
-  builder.py         # HIR/Module → graphviz.Digraph; DetailIndex; format_detail
-  htmltable.py       # typed Table / Row / Cell / Span for DOT HTML labels
-  palette.py         # colour palette (also served at /api/palette)
-  server.py          # HTTP routes (no server-side dot)
-  assets.py          # vendored-JS manifest + ensure_assets()
-  static/
-    index.html       # first-party page (committed)
-    viewer.js        # first-party client (committed)
-    .gitignore       # allowlist: only index.html / viewer.js / .gitignore
-scripts/fetch_viewer_assets.py   # CLI to pre-populate the asset cache
-```
-
 Vendored browser JS lives only in the user cache, never in the repo.
 
 ## 4. Dump Integration
@@ -316,9 +382,108 @@ Vendored browser JS lives only in the user cache, never in the repo.
 provide per-test, per-pass IR dumping (see [passes §6](./passes.md#6-top-level-api)).
 
 ```python
+# example
 from tilefoundry.dump import DumpFlags, dump, current_scope
 dump("ir.py", src, DumpFlags.PASS_IR)
 ```
 
-Output rooted at `test_results/{worker_id}/{nodeid}/` (per-test
-subdirectory).  `pytest.mark.no_dump` opt-out available.
+```python
+class DumpFlags(IntFlag):
+    """Enumerate dump categories."""
+
+    NONE = 0
+    PASS_IR = 1
+    CODEGEN_SOURCE = 2
+    BUILD_LOG = 4
+    ALL = PASS_IR | CODEGEN_SOURCE | BUILD_LOG
+
+
+class DumpScope:
+    """Install or narrow a dynamically scoped dump destination."""
+
+    def __init__(
+        self,
+        subdir: str | None = None,
+        flags: DumpFlags | None = None,
+        *,
+        dumper: IDumpper | None = None,
+    ) -> None: ...
+```
+
+- constraints:
+  - `DumpScope(subdir, flags)` MUST nest beneath the active scope and intersect
+    its flags with the parent's. Without a parent it MUST remain a no-op.
+  - `DumpScope(dumper=..., flags=...)` MUST replace the active scope.
+  - Plain child threads MUST start without the parent's scope; asyncio tasks
+    MUST inherit a copy of the creating context.
+  - Test output MUST be rooted at `test_results/<file-stem>/<test-name>/`.
+    A non-master worker appends `__<worker-id>` to the test-name leaf rather
+    than adding a worker directory. `pytest.mark.no_dump` disables it.
+
+## 5. Compact TIR rendering
+
+```python
+def format_expr(expr) -> str:
+    """Render one supported TIR expression compactly.
+
+    Args:
+        expr: Expression to render.
+
+    Returns:
+        Compact text.
+    """
+    ...
+
+
+def format_pattern(pat: Pattern) -> str:
+    """Render one dispatch pattern compactly.
+
+    Args:
+        pat: Pattern to render.
+
+    Returns:
+        Compact text.
+    """
+    ...
+
+
+def format_symbol_call(call: Evaluate) -> str:
+    """Render one symbol invocation compactly.
+
+    Args:
+        call: Function-call statement.
+
+    Returns:
+        Compact text.
+    """
+    ...
+
+
+def format_abort(stmt: Abort) -> str:
+    """Render one abort statement compactly.
+
+    Args:
+        stmt: Abort statement.
+
+    Returns:
+        Compact text.
+    """
+    ...
+
+
+def format_dispatch_call(stmt: DispatchCall, indent: str = "") -> str:
+    """Render a dispatch statement compactly.
+
+    Args:
+        stmt: Dispatch statement.
+        indent: Prefix for each emitted line.
+
+    Returns:
+        Compact multiline text.
+    """
+    ...
+```
+
+- constraints:
+  - These functions are display-only and MUST NOT be treated as parser input.
+  - `format_dispatch_call` MUST preserve case order and render the fallback.

--- a/docs/spec/parser.md
+++ b/docs/spec/parser.md
@@ -179,6 +179,7 @@ dtype          ::= '"f32"' | '"f16"' | '"bf16"' | …  ; see types §3
 layout         ::= layout-sugar                      ; see §1.5
                 | 'ShardLayout(' … ')'              ; verbose, see shard §7
 storage        ::= '"host"' | '"gmem"' | '"smem"' | '"rmem"' | '"tmem"'
+                | 'host' | 'gmem' | 'smem' | 'rmem' | 'tmem'
 ```
 
 `Tensor[...]` and `ConstTensor[...]` resolve to the same ordinary `TensorType`;
@@ -203,6 +204,8 @@ Tensor[(), "bf16"]                                    # scalar
     descriptor before constructing `TensorType`.
   - An unknown dtype string MUST be rejected; it MUST NOT fall back to another
     descriptor.
+  - Bare storage names MUST resolve to the five constants exported by
+    `tilefoundry.dsl.storage`; they are equivalent to the quoted spellings.
 
 ### 1.5 Layout sugar
 
@@ -460,16 +463,29 @@ The two namespaces are real Python modules; resolution is module
 
 ```python
 # tilefoundry/ir/core/op_registry.py
-def _register_schema(schema: OpSchema) -> None: ...
+def _register_schema(schema: OpSchema, *, prepend: bool = False) -> None: ...
 def get_schemas(dialect: str, name: str) -> list[OpSchema]: ...
 def iter_schema_names(dialect: str) -> Iterable[str]: ...
 
 # tilefoundry/ir/core/op_schema.py — a frozen dataclass
 class OpSchema:
-    dialect: str            # "tf" or "T"
+    """Describe one registered callable schema.
+
+    Attributes:
+        name: attribute; Canonical callable name.
+        dialect: attribute; Surface dialect, `tf` or `T`.
+        category: attribute; Organizational group.
+        signature: attribute; Parameters in declaration order.
+        builder: attribute; Callable that constructs the IR operation.
+        op_class: attribute; Registered Op class, or None for an alias schema.
+    """
+
     name: str
-    op_cls: type[Op]
+    dialect: str
+    category: str
     signature: tuple[ParamDef, ...]
+    builder: Callable[..., Any]
+    op_class: type | None = None
 
 # tilefoundry/dsl/tf/__init__.py        (TIR symmetric in tilefoundry/dsl/T)
 def __getattr__(name: str) -> type[Op] | Callable: ...
@@ -485,7 +501,7 @@ classDiagram
         iter_schema_names(dialect)
         _register_schema(schema)
     }
-    class OpSchema { dialect; name; op_cls; signature }
+    class OpSchema { name; dialect; category; signature; builder; op_class }
     class tilefoundry_dsl_tf { __getattr__(name); __dir__() }
     class tilefoundry_dsl_T  { __getattr__(name); __dir__() }
     class Op { <<abstract>> }
@@ -503,8 +519,13 @@ for any name not found on the module's own namespace. Both
 namespaces implement it identically:
 
 ```python
-def __getattr__(name: str) -> type[Op] | Callable: ...   # resolve a dialect name to its Op class / alias builder
-def __dir__() -> list[str]: ...                          # list the dialect's registered schema names
+def __getattr__(name: str) -> type[Op] | Callable:
+    """Resolve a dialect name to its Op class or alias builder."""
+    ...
+
+def __dir__() -> list[str]:
+    """Return the dialect's registered schema names."""
+    ...
 ```
 
 `__getattr__` looks up `op_registry.get_schemas(_DIALECT, name)` and raises
@@ -580,7 +601,7 @@ completions for `tf.<name>(...)`.
   on the `tilefoundry.ir.<dialect>.<category>` directory layout. DSL
   source addresses Ops only through `(dialect, name)`.
 - **Single-schema identity**. For a single-schema name `n`,
-  `getattr(tilefoundry.dsl.tf, n) is get_schemas("tf", n)[0].op_cls`.
+  `getattr(tilefoundry.dsl.tf, n) is get_schemas("tf", n)[0].op_class`.
   No wrapper class is interposed.
 
 ### 2.6 Platform sub-namespaces
@@ -721,14 +742,14 @@ function-level entry points are independent calls; there is no
 
 ```python
 # tilefoundry/parser/hir_parser.py
-def parse_func        (fn, *, topologies=()) -> hir.Function: ...
+def parse_func(fn, *, topologies=(), specializations=(), extra_closure=None) -> hir.Function: ...
 def parse_func_source (src: str) -> core_ir.Module | hir.Function: ...
-def parse_module_source(src: str) -> core_ir.Module: ...
+def parse_module_source(src: str) -> core_ir.Module | hir.Function: ...
 def parse_script      (src: str) -> core_ir.Module | hir.Function: ...
 class _HirBodyVisitor(BaseExprVisitor): ...
 
 # tilefoundry/parser/tir_parser.py
-def parse_prim_func   (fn) -> tir.PrimFunction: ...
+def parse_prim_func(fn, *, target=None, extra_closure=None) -> tir.PrimFunction: ...
 class _TirBodyVisitor(BaseExprVisitor): ...
 
 # tilefoundry/parser/base.py
@@ -738,7 +759,7 @@ class BaseExprVisitor: ...
 # tilefoundry/parser/symtab.py
 class LexicalEnv:
     def push_frame(self) -> None: ...
-    def pop_frame (self) -> None: ...
+    def pop_frame (self) -> dict[str, Any]: ...
     def define    (self, name, value) -> None: ...
     def lookup    (self, name) -> object: ...
     def innermost_mesh(self) -> Mesh | None: ...
@@ -893,6 +914,26 @@ schema's `ParamDef.annotation`:
 - `annotation=ShardLayout` → `parse_shard_layout_sugar`
 - `annotation=Layout`      → `parse_layout_sugar`
 
+```python
+def parse_mesh_layout_sugar(
+    node: ast.AST, *, closure: dict[str, Any] | None = None
+) -> Layout:
+    """Parse mesh-layout tuple sugar.
+
+    Args:
+        node: Static tuple syntax.
+        closure: Optional static-name bindings.
+
+    Returns:
+        The parsed mesh layout.
+    """
+    ...
+```
+
+- constraints:
+  - `parse_mesh_layout_sugar` MUST resolve closure-bound integer extents and
+    MUST derive C-order strides when the tuple omits them.
+
 Sugar dispatch is annotation-driven, not name-driven: an attribute
 called `shape` will not be parsed as layout sugar unless its
 ParamDef declares a layout annotation. Ops without a registered
@@ -925,6 +966,42 @@ across dialects. An HIR-only Op (e.g. `rope`) raises *unknown TIR
 callable* in a TIR body, and a TIR-only Op (e.g. `copy`) raises
 *unknown HIR callable* in an HIR body. The trailing-underscore
 selector is gated to the TIR token only.
+
+### 4.7 Restricted static evaluation
+
+```python
+def eval_static(
+    node: ast.AST,
+    *,
+    closure: dict[str, Any],
+    lookup: Callable[[str], Any] | None = None,
+    allowed_nodes: tuple[type, ...] = ALL_NODES,
+    div: DivMode = "true",
+    attr_resolver: Callable[[Any, str], Any] | None = None,
+    on_closure_name: Callable[[Any, str], None] | None = None,
+) -> Any:
+    """Evaluate the parser's restricted static-AST subset.
+
+    Args:
+        node: AST node to evaluate.
+        closure: Python closure bindings.
+        lookup: Optional parser-lexical name resolver.
+        allowed_nodes: Admitted AST node classes.
+        div: Division policy.
+        attr_resolver: Optional attribute resolver.
+        on_closure_name: Optional closure-use callback.
+
+    Returns:
+        The statically evaluated value.
+    """
+    ...
+```
+
+- constraints:
+  - Lexical `lookup` MUST run before closure fallback.
+  - A node outside `allowed_nodes`, an unresolved name, or an unsupported
+    operator MUST raise `VerifyError`.
+  - `div="floor"` MUST affect `/`; `//` is always floor division.
 
 ## 5. HIR parser
 

--- a/docs/spec/passes.md
+++ b/docs/spec/passes.md
@@ -45,10 +45,14 @@ class Pass(ABC):
     Side-effect logging is allowed, but the input Module MUST NOT be
     mutated — Module is a frozen dataclass, so a mutator returns a new
     instance.
+
+    Attributes:
+        name: attribute; Stable dump and log name.
+        requires: attribute; Ordered dependency assertion.
     """
 
-    name: str                               # for dump / log
-    requires: tuple[str, ...] = ()          # ordered dependency assertion (no scheduling)
+    name: str = ""
+    requires: tuple[str, ...] = ()
 
     @abstractmethod
     def run(self, module: Module) -> Module: ...
@@ -71,7 +75,9 @@ HIR → TIR replacement (substitute `tir.PrimFunction` for
 `hir.Function`).
 
 ```python
-class ModulePass(Pass):                             # runs over the whole Module; may add / remove / reorder functions
+class ModulePass(Pass):
+    """Run over a complete Module."""
+
     @abstractmethod
     def run(self, module: Module) -> Module: ...
 ```
@@ -89,10 +95,12 @@ entries, and reassembles the `Module`.
 ```python
 from tilefoundry.ir.hir import Function as HirFunction
 
-class FunctionPass(Pass):                                                       # visits each hir.Function; framework supplies the default run
+class FunctionPass(Pass):
+    """Run independently over each HIR Function."""
+
     @abstractmethod
-    def run_function(self, fn: HirFunction, module: Module) -> HirFunction: ...  # visit one HIR function
-    def run(self, module: Module) -> Module: ...                                # default reassembles the Module from run_function results
+    def run_function(self, fn: HirFunction, module: Module) -> HirFunction: ...
+    def run(self, module: Module) -> Module: ...
 ```
 
 - constraints:
@@ -101,16 +109,17 @@ class FunctionPass(Pass):                                                       
 
 ### 3.3 `PrimFuncPass`
 
-Same shape as `FunctionPass`, but visits `tir.PrimFunction`. Mirrors
-nncase's `PrimFuncPass.cs`.
+Same shape as `FunctionPass`, but visits `tir.PrimFunction`.
 
 ```python
 from tilefoundry.ir.tir import PrimFunction
 
-class PrimFuncPass(Pass):                                                       # visits each tir.PrimFunction (mirrors FunctionPass)
+class PrimFuncPass(Pass):
+    """Run independently over each TIR PrimFunction."""
+
     @abstractmethod
     def run_prim_func(self, fn: PrimFunction, module: Module) -> PrimFunction: ...
-    def run(self, module: Module) -> Module: ...   # default mirrors FunctionPass
+    def run(self, module: Module) -> Module: ...
 ```
 
 - constraints:
@@ -144,10 +153,10 @@ class PassManager:
     """Ordered pass pipeline.
 
     Attributes:
-        passes: the registered passes, run in registration order.
+        passes: attribute; the registered passes, run in registration order.
     """
 
-    passes: list[Pass]
+    passes: list[Pass] = field(default_factory=list)
 
     def add(self, p: Pass) -> "PassManager": ...      # register a pass; returns self for chaining
     def run(self, module: Module) -> Module: ...      # run passes in registration order
@@ -168,10 +177,21 @@ Three public verbs operate on `Module` (no bare `HirFunction` /
 `PrimFunction`):
 
 ```python
-def lower(mod: Module, /, *, target: str, options: CompilerOptions | None = None) -> Module: ...
+class CompilerOptions:
+    """Carry deterministic compiler configuration.
+
+    Attributes:
+        target: attribute; Compilation target name.
+    """
+
+    target: str = "cuda"
+
+    def canonical_text(self) -> str: ...
+
+
+def lower(mod: Module, /, *, target: str = "cuda") -> Module: ...
 def build(mod: Module, /, *, target: str | None = None) -> RuntimeModule: ...
-def compile(mod: Module, /, *, target: str, options: CompilerOptions | None = None) -> RuntimeModule: ...
-def jit(fn_or_mod: Function | Module, /, *, target: str = "cuda", options: CompilerOptions | None = None) -> RuntimeModule: ...
+def compile(mod: Module, /, *, target: str = "cuda") -> RuntimeModule: ...
 ```
 
 `lower` runs the default pipeline (`HirToTirPass → BufferizePass →
@@ -185,10 +205,8 @@ keyword is omitted; an explicit `target` that disagrees with
 runs codegen → toolchain link → loader and returns a
 `RuntimeModule` ([runtime](./runtime.md)).
 
-`compile` is `build(lower(mod, ...))`. `jit` accepts a `Module` or
-an `hir.Function` (single-function convenience: it normalises into a
-single-function `Module` that declares no execution context) and caches
-on the canonical module text + target + options hash.
+`compile` is `build(lower(mod, ...))`. The `jit` convenience and cache contract
+are owned by [runtime §1.3](./runtime.md#13-jit-api).
 
 ### Dirty-scope retype / verify
 
@@ -372,43 +390,63 @@ FFI surface (see [target](./target.md)).
 
 ### 7.2 `BufferizePass`
 
-`PrimFuncPass` (or `ModulePass` when crossing `Evaluate(SymbolRef)`
-callee boundaries). Runs after `HirToTirPass`, before codegen. The input
+`PrimFuncPass`. Runs after `HirToTirPass`, before codegen. The input
 is already an explicit-buffer-param `PrimFunction`; this pass does
 **not** perform an MLIR-style value → buffer IR conversion.
 
-Responsibility: collect logical-buffer lifetime, assign each
-logical buffer a physical offset / size, and write the result back
-into the `tir.memory.*` descriptors. Policy: every logical buffer
-gets an independent physical allocation; no reuse, pool, or lifetime
-overlap. Buffer planning is not a codegen responsibility.
+Responsibility: collect logical-buffer lifetimes and run the placement-policy
+hook. The independent-allocation policy is already represented by one
+`AllocTensor` per logical buffer, so the pass returns the `PrimFunction`
+unchanged and does not write placement records into `tir.memory.*` descriptors.
 
 ```python
-class BufferizePass(PrimFuncPass):                  # assigns each logical buffer a physical offset / size after HirToTirPass
-    name = "bufferize"
-    requires = ("hir_to_tir",)
+class BufferizePass(PrimFuncPass):
+    """Collect lifetimes and validate independent allocation placement.
+
+    Attributes:
+        collector: attribute; lifetime collector, defaulted during initialization.
+        scheduler: attribute; placement scheduler, defaulted during initialization.
+        name: attribute; pass name.
+        requires: attribute; required predecessor passes.
+    """
+
+    collector: LifetimeCollector = None
+    scheduler: BufferScheduler = None
+    name: str = "bufferize"
+    requires: tuple[str, ...] = ("hir_to_tir",)
 ```
 
 - constraints:
   - every logical buffer gets an independent physical allocation; no reuse, pool,
     or lifetime overlap. Buffer planning is not a codegen responsibility.
+  - The scheduler's placement result is advisory under this policy;
+    `run_prim_func` MUST return the input function unchanged.
+
+### 7.3 `insert_default_host_entry`
+
+```python
+def insert_default_host_entry(module: Module) -> Module:
+    """Return a Module whose entry is host-callable.
+
+    Args:
+        module: Lowered Module to normalize.
+
+    Returns:
+        The unchanged or host-entry-normalized Module.
+    """
+    ...
+```
+
+- constraints:
+  - A CPU entry MUST pass through unchanged.
+  - A dispatch entry MUST be retargeted to CPU while its launched variants
+    remain device functions.
+  - With no CPU entry and exactly one CUDA device function, the transform MUST
+    synthesize a CPU entry that mirrors the parameters and launches that
+    function. It MUST reject ambiguous device-function sets, a non-entry CPU
+    function, or a launch-provided dynamic CTA extent.
 
 ## 8. Directory layout
 
-```
-src/tilefoundry/passes/
-├── __init__.py              # re-exports Pass / PassManager
-├── pass_base.py             # Pass / FunctionPass / PrimFuncPass / ModulePass
-├── pass_manager.py          # PassManager
-└── transforms/
-    ├── __init__.py
-    ├── hir_to_tir.py        # HirToTirPass
-    └── bufferize.py         # BufferizePass
-```
-
-`passes/analysis/` is reserved but currently unused — the analysis
-registries (`typeinfer` / `verify` / `cost_evaluator`) live in
-[visitor-registry](./visitor-registry.md) and do not move into
-`passes/`. Only a standalone analysis pass that needs to run
-independently and cache its result (such as an `AliasAnalysisPass`)
-lands under `passes/analysis/`.
+File layout is implementation-owned. Analysis registry ownership is defined by
+[visitor-registry](./visitor-registry.md).

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -172,21 +172,25 @@ exactly the one declared `ConstTensor`'s shape / dtype. A weight needing no
 transform has no converter. Two converters registered for the same weight
 name is an error.
 
-`load`, `forward`, and `prepare` are **methods on the ir `Module`** — the same
-authoring surface as its `RuntimeModule` twin, which also has a `forward`:
+`load`, `forward`, and `prepare` are methods on the IR `Module` owned by
+[core-ir §1](./core-ir.md#1-module). This section defines their runtime-facing
+behavior and the distinct loaded view:
 
 ```python
-class Module:      # tilefoundry.ir.core.module
-    def load(self, resource: RuntimeResource) -> "LoadedModule": ...
-    def forward(self, *args): ...                                              # __call__ = forward
-    def prepare(self, raw: RuntimeResource, out_dir: str, *, device="cpu") -> None: ...
+class LoadedModule:
+    """Bind one reading of an IR Module to loaded constants.
 
+    Attributes:
+        module: attribute; Source IR Module.
+        constants: attribute; Loaded constants by declared weight name.
+        modules: attribute; Recursively loaded children.
+    """
 
-class LoadedModule:  # tilefoundry.ir.core.module — one reading of a Module
     module: Module
     constants: Mapping[str, torch.Tensor]
     modules: tuple["LoadedModule", ...]
-    def forward(self, *acts): ...                                              # __call__ = forward
+
+    def forward(self, *acts): ...
 ```
 
 - constraints:
@@ -305,13 +309,21 @@ implementations are not bound by it.
 ### 1.3 `jit()` API
 
 ```python
-def jit(fn_or_mod: Function | Module, *, target: str = "cuda", options: CompilerOptions | None = None) -> RuntimeModule:
+def jit(
+    fn_or_mod: Function | Module,
+    /,
+    *,
+    target: str = "cuda",
+    options: CompilerOptions | None = None,
+    **kwargs,
+) -> RuntimeModule:
     """Compile *fn_or_mod* and return the callable runtime module.
 
     Args:
         fn_or_mod: a hir.Function or Module (normalized to a Module).
         target: the back-end target.
         options: optional CompilerOptions.
+        kwargs: rejected compatibility catch-all for unexpected keywords.
 
     Returns:
         The callable RuntimeModule.
@@ -335,8 +347,8 @@ entry point.  It accepts a `hir.Function` or `Module`, normalizes to a
 - Mesh layout is expressed in the DSL with lexical `with Mesh(...) as mesh` scopes.
 - `jit()` has no `cta_mesh` / `thread_mesh` parameters.
 
-**Pipeline**: `jit()` reuses the existing `lower()` → `build()` pipeline
-(`compile()`).  It auto-wraps a bare `Function` input into a single-function
+**Pipeline**: `jit()` reuses [passes §6](./passes.md#6-top-level-api)'s
+`lower()` → `build()` pipeline (`compile()`). It auto-wraps a bare `Function` input into a single-function
 `Module` that declares no execution context.
 
 **Cache**: in-process dict cache keyed by
@@ -375,10 +387,9 @@ The exported function accepts flattened input/output tensor arguments. HIR
 functions may be written as `Function(params) -> tensor`, but by the runtime
 boundary the TIR/codegen surface is explicit input/output parameters.
 
-Launch geometry (grid / block extents) is derived internally by
-`codegen/cuda/emit.py::_derive_launch_config` and embedded into the generated
-host entry (or supplied by an authored `launch(...)`); it is never carried as
-metadata past codegen.
+Launch geometry (grid / block extents) is embedded into the generated host entry
+or supplied by an authored `launch(...)`; it is never carried as metadata past
+codegen.
 
 ### 1.5 `RuntimeResource`
 
@@ -388,6 +399,16 @@ resolved by the same lookup order.
 
 ```python
 AliasValue = str | tuple[str, ...] | Absolute | Preprocessed
+
+class Absolute:
+    """Name a raw checkpoint key from the resource root.
+
+    Attributes:
+        name: attribute; Absolute raw key.
+    """
+
+    name: str
+
 
 class Preprocessed:
     name: str | Absolute
@@ -485,38 +506,79 @@ class SafetensorsResource:
 ### 1.6 `check`
 
 ```python
-class Predicate:                                # one comparison and its bound
-    name: ClassVar[str]                         # how it is named
-    bounds: ClassVar[tuple[str, ...]]           # the bound fields it takes
-    needs_reference: ClassVar[bool]             # false: it judges the candidate alone
-    discrete: ClassVar[bool]                    # true: meaningful on integers
+class Predicate:
+    """Carry one comparison and its bounds.
 
-PREDICATES: Mapping[str, type[Predicate]]       # allclose rel_l2 cosine equal
-                                                # ulp max_abs max_rel nan_inf
+    Attributes:
+        name: attribute; Registry and report name.
+        bounds: attribute; Bound fields in surface order.
+        needs_reference: attribute; Whether the comparison consumes a reference.
+        discrete: attribute; Whether it is meaningful on integer outputs.
+        guidance: attribute; One-line CLI guidance.
+    """
+
+    name: ClassVar[str] = ""
+    bounds: ClassVar[tuple[str, ...]] = ()
+    needs_reference: ClassVar[bool] = True
+    discrete: ClassVar[bool] = True
+    guidance: ClassVar[str] = ""
+
+PREDICATES: Mapping[str, type[Predicate]]
 
 class PredicateResult:
+    """Record one predicate measurement.
+
+    Attributes:
+        predicate: attribute; Predicate that ran.
+        values: attribute; Named measurements.
+        passed: attribute; Whether its bound held.
+        note: attribute; Optional interpretation note.
+    """
+
     predicate: Predicate
-    values: Mapping[str, float]                 # what it measured
+    values: Mapping[str, float]
     passed: bool
-    note: str | None                            # when the measure changed meaning
+    note: str | None = None
 
 class OutputCheck:
-    path: str                                   # "output", "output[0]", ...
+    """Record predicate results for one output.
+
+    Attributes:
+        path: attribute; Structural output path.
+        shape: attribute; Runtime output shape.
+        dtype: attribute; Runtime output dtype.
+        ref_norm: attribute; Reference norm when a reference exists.
+        results: attribute; Predicate results.
+        passed: attribute; Derived read-only verdict over the results.
+    """
+
+    path: str
     shape: tuple[int, ...]
     dtype: str
-    ref_norm: float | None                      # None without a reference
+    ref_norm: float | None
     results: tuple[PredicateResult, ...]
-    passed: bool
+
+    def passed(self) -> bool: ...
 
 class Report:
+    """Record all checked outputs.
+
+    Attributes:
+        outputs: attribute; Output checks in structural order.
+        passed: attribute; Derived read-only verdict over the outputs.
+    """
+
     outputs: tuple[OutputCheck, ...]
-    passed: bool
+
+    def passed(self) -> bool: ...
 
 def check(candidate: Callable, reference: Callable | None, inputs: tuple, *,
           expect: Mapping[str, Sequence[Predicate]]) -> Report: ...
 ```
 
 - constraints:
+  - `PREDICATES` MUST contain the built-in `allclose`, `rel_l2`, `cosine`,
+    `equal`, `ulp`, `max_abs`, `max_rel`, and `nan_inf` predicates by name.
   - `check` runs `candidate(*inputs)`, and `reference(*inputs)` when there is a
     reference, and measures each output against the predicates *expect* states
     for it. Neither *reference* nor *expect* has a default.
@@ -537,8 +599,9 @@ def check(candidate: Callable, reference: Callable | None, inputs: tuple, *,
     distance against a zero reference, a direction between two zero vectors — the
     result MUST state what was measured instead through its `note`, rather than
     return a number whose scale is an artefact of a clamp.
-  - `passed` is `all` of its parts, at both levels, so a verdict cannot disagree
-    with the measurements printed beside it.
+  - `OutputCheck.passed` and `Report.passed` are read-only properties derived
+    as `all` of their parts; neither is accepted as a constructor field, so a
+    verdict cannot disagree with the measurements printed beside it.
   - it is not specific to `RuntimeModule`: *candidate* / *reference* may be a
     `RuntimeModule` bound method, a raw torch callable, or an evaluator
     closure — anything callable on *inputs*.
@@ -572,7 +635,7 @@ enum class TopologyScope {
 };
 ```
 
-- constraints: none — a fixed enumeration of program topology levels
+- constraints: none
 
 ### 2.2 Topology Metadata
 
@@ -647,7 +710,7 @@ struct ShardLayout {
 };
 ```
 
-- constraints: none — a plain layout / attrs / mesh aggregate
+- constraints: none
 
 ### 2.5 `tilefoundry::shard` — Shard Attributes
 
@@ -660,7 +723,7 @@ namespace tilefoundry::shard {
 }
 ```
 
-- constraints: none — compile-time shard-attribute tags
+- constraints: none
 
 Shorthand: `S<Axis>` = Split, `B` = Broadcast, `P<Reduction>` = Partial.
 
@@ -738,7 +801,7 @@ void copy(ST const& src, ShardTensor<T, GL, SL>& dst);
 ```
 
 - constraints:
-  - Copies the full tensor between a shard tensor and a plain tensor.
+  - No additional constraints.
 
 ### 2.10 `local()`
 
@@ -868,7 +931,6 @@ void copy(SrcTensor const& src, DstTensor& dst);
 ```
 
 - constraints:
-  - copies data from `src` to `dst`
   - `size(src) == size(dst)`
   - source and destination dtypes are compatible
 
@@ -884,8 +946,7 @@ template <class Tensor, class Value>
 void fill(Tensor& tensor, Value val);
 ```
 
-- constraints:
-  - fills `tensor` with scalar `val`
+- constraints: none
 
 ### 3.3 `tilefoundry::shard_partition`
 

--- a/docs/spec/schedule.md
+++ b/docs/spec/schedule.md
@@ -7,8 +7,12 @@ algorithm decides is its own vocabulary: two algorithms placing different
 hardware over different levels do not decide the same things, and a shared result
 schema would either describe neither or force both to pretend.
 
-The public surface ([§1](#1-the-public-schedule-operation)–[§2](#2-public-structures)) is the `schedule` package. The construction stages an
-algorithm composes its solve from ([§4](#4-kernel-schedule-construction)) are imported from their own modules; they
+The top-level `schedule` package exports the operation in [§1](#1-the-public-schedule-operation),
+its request/result/base-plan types, and the public errors in [§6](#6-public-errors).
+Algorithm-specific plan structures in [§2](#2-public-structures) are public from their owning
+submodules and are not necessarily re-exported at package top level. The
+construction stages an algorithm composes its solve from
+([§4](#4-kernel-schedule-construction)) are imported from their own modules; they
 read [analysis](./analysis.md) facts, and the dependency is one-way — nothing in
 the analysis layer imports the schedule layer.
 
@@ -211,6 +215,8 @@ class TargetSpecRef:
     architecture_digest: str
     device_id: str
     device_digest: str
+
+    def of(cls, target: object) -> TargetSpecRef: ...
 ```
 
 - constraints:
@@ -219,10 +225,69 @@ class TargetSpecRef:
     differently.
   - A Target constructed directly rather than installed from documents MUST state
     an empty digest rather than a fabricated one.
+  - `TargetSpecRef` is public from `tilefoundry.schedule.plan`, not re-exported
+    from `tilefoundry.schedule`. `of` derives IDs and digests from the supplied
+    target as a classmethod, falling back to architecture/device names and
+    empty digests.
 
 ### 2.4 `PipelineSchedulePlan`
 
 ```python
+class ScheduledStatement:
+    """One selected instruction and execution interval.
+
+    Attributes:
+        id: attribute; stable statement identity.
+        instruction: attribute; selected instruction name.
+        tile: attribute; selected tile extents.
+        resources: attribute; selected resource counts.
+        start: attribute; inclusive start of the execution interval.
+        end: attribute; exclusive end of the execution interval.
+        footprint_bytes: attribute; ring-adjusted buffer footprint.
+        fits_capacity: attribute; whether the footprint fits tile capacity.
+    """
+
+    id: str
+    instruction: str
+    tile: tuple[int, ...]
+    resources: tuple[tuple[str, int], ...]
+    start: int
+    end: int
+    footprint_bytes: int
+    fits_capacity: bool
+
+class ScheduledBuffer:
+    """One storage object and its ring allocation.
+
+    Attributes:
+        id: attribute; stable buffer identity.
+        storage: attribute; selected storage name.
+        ring_depth: attribute; dependency-safe positive ring depth.
+        producer_ids: attribute; producing statement identities.
+        consumer_ids: attribute; consuming statement identities.
+    """
+
+    id: str
+    storage: str
+    ring_depth: int
+    producer_ids: tuple[str, ...]
+    consumer_ids: tuple[str, ...]
+
+class KernelHole:
+    """One statement reference with serialized boundary relations.
+
+    Attributes:
+        statement_id: attribute; referenced statement identity.
+        inputs: attribute; input buffer identities.
+        outputs: attribute; output buffer identities.
+        relations: attribute; serialized ISL boundary relations.
+    """
+
+    statement_id: str
+    inputs: tuple[str, ...]
+    outputs: tuple[str, ...]
+    relations: tuple[str, ...]
+
 class PipelineSchedulePlan(SchedulePlan):
     """Export one closed pipeline schedule."""
 
@@ -407,42 +472,61 @@ constraint base and source-location fields.
 
 ```python
 class LayoutConstraint(ScheduleConstraint):
-    """Fix a physical Layout pattern and ShardAttr bindings."""
+    """Fix a physical layout pattern and shard bindings.
 
-    layout: Layout
-    bindings: tuple[tuple[str, ShardAttr], ...]
+    Attributes:
+        layout: attribute; required physical layout pattern.
+        bindings: attribute; named shard-attribute bindings.
+    """
+
+    layout: Layout = Layout(shape=())
+    bindings: tuple[tuple[str, ShardAttr], ...] = ()
 
 class MeshConstraint(ScheduleConstraint):
-    """Filter an eventual ShardLayout by one Mesh value."""
+    """Filter an eventual shard layout by one mesh.
 
-    mesh: Mesh
+    Attributes:
+        mesh: attribute; required mesh value.
+    """
+
+    mesh: Mesh | None = None
 
 class StorageConstraint(ScheduleConstraint):
-    """Filter a value by one current StorageKind."""
+    """Filter a value by one storage kind.
 
-    storage: StorageKind
+    Attributes:
+        storage: attribute; required storage kind.
+    """
+
+    storage: StorageKind | None = None
 ```
 
-`LayoutConstraint.layout` is constraint-owned and may contain the private
-wildcard sentinel. Its `bindings` reuse `Split`, `Broadcast`, and `Partial`
-from [shard](./shard.md). A wildcard is never stored as `Layout(None)` and
-never enters a `TensorType.layout`. Metadata is not part of expression
-equality, hashing, or the printed `repr`.
-
-These values are hard filters for later scheduling stages. They carry no
-preferences, candidate rows, costs, solver state, or CTA capability
-decisions, and they do not register a scheduling algorithm for a `CudaTarget`.
+- constraints:
+  - `LayoutConstraint.layout` is constraint-owned and MAY contain the private
+    wildcard sentinel. Its `bindings` reuse `Split`, `Broadcast`, and `Partial`
+    from [shard](./shard.md).
+  - A wildcard MUST NOT be stored as `Layout(None)` and MUST NOT enter a
+    `TensorType.layout`.
+  - Constraint metadata MUST NOT participate in expression equality, hashing,
+    or the printed `repr`.
+  - These values are hard filters for later scheduling stages. They carry no
+    preferences, candidate rows, costs, solver state, or CTA capability
+    decisions, and they do not register a scheduling algorithm for a
+    `CudaTarget`.
 
 ## 4. Kernel schedule construction
 
-An algorithm composes its solve from these stages over one
-`TileGraph` ([analysis §1.2](./analysis.md#12-tilegraph)). Each takes the graph
-and returns it enriched; none of them re-derives a fact the analysis layer
-already states.
+An algorithm composes its solve from these stages over one immutable
+`TileGraph` ([analysis §1.2](./analysis.md#12-tilegraph)). Scheduling state is
+held separately; no stage mutates or enriches the analysis graph, and none
+re-derives a fact the analysis layer already states.
 
 ```text
-extract(root)  ──▶  build_schedule_tree  ──▶  emit_scaffold
-  (analysis)          tg.tree                 Skeleton / Swimlane / HoleContract
+extract(root) ──▶ graph ──▶ build_schedule_tree(graph) ──▶ tree
+                       graph + tree + solved ring ──▶ emit_scaffold
+                                                        │
+                                                        ▼
+                                         Skeleton / Swimlane / HoleContract
 ```
 
 Each stage lives in its own module of the `schedule` package and is imported
@@ -451,13 +535,13 @@ operation and its results only.
 
 | Stage | Signature | Error |
 |---|---|---|
-| tree construction | `build_schedule_tree(tg: TileGraph) -> TileGraph` | `KernelScheduleError` |
-| scaffold emission | `emit_scaffold(tg: TileGraph) -> tuple[Skeleton, Swimlane, list[HoleContract]]` | `EmitScaffoldError` |
+| tree construction | `build_schedule_tree(tg: TileGraph) -> isl.schedule` | `KernelScheduleError` |
+| scaffold emission | `emit_scaffold(graph: TileGraph, tree: isl.schedule, ring: dict[str, int]) -> tuple[Skeleton, Swimlane, list[HoleContract]]` | `EmitScaffoldError` |
 
 ### 4.1 Tree construction
 
 ```python
-def build_schedule_tree(tg: TileGraph) -> TileGraph: ...
+def build_schedule_tree(tg: TileGraph) -> "isl.schedule": ...
 
 def schedule_bands(tree: "isl.schedule") -> tuple["isl.schedule_node_band", ...]: ...
 
@@ -484,9 +568,9 @@ class KernelScheduleError(RuntimeError):
   - Each band's `coincident` members MUST be written from
     `tg.parallel_dims` ([analysis §1.7](./analysis.md#17-parallel-dimensions)) —
     the flags are read, never recomputed.
-  - `build_schedule_tree` MUST return `tg` with `tree` filled in and every other
-    field unchanged. An empty `tg.units`, or a unit with no matching piece of
-    `tg.domain`, MUST raise `KernelScheduleError`.
+  - `build_schedule_tree` MUST return a new ISL schedule and MUST NOT mutate
+    `tg`. An empty `tg.units`, or a unit with no matching piece of `tg.domain`,
+    MUST raise `KernelScheduleError`.
   - `schedule_bands` MUST return every band of the tree in top-down order, which
     for a constructed tree is `tg.units` order, and MUST raise when the tree
     carries no band.
@@ -554,7 +638,11 @@ class HoleContract:
     output: BufferAccess
     coords: tuple[str, ...]
 
-def emit_scaffold(tg: TileGraph) -> tuple[Skeleton, Swimlane, list[HoleContract]]: ...
+def emit_scaffold(
+    graph: TileGraph,
+    tree: "isl.schedule",
+    ring: dict[str, int],
+) -> tuple[Skeleton, Swimlane, list[HoleContract]]: ...
 
 class EmitScaffoldError(RuntimeError):
     """A construct emit_scaffold does not render, or a TileGraph precondition that did not hold."""
@@ -562,18 +650,18 @@ class EmitScaffoldError(RuntimeError):
 
 - constraints:
   - Every structure MUST be immutable.
-  - The skeleton MUST be isl code generation over `tg.tree`, with each naked
-    statement call replaced by its hole call. `tg.tree is None` MUST raise
-    `EmitScaffoldError`.
+  - The skeleton MUST be ISL code generation over `tree`, with each naked
+    statement call replaced by its hole call. `graph`, `tree`, and `ring` are
+    separate inputs; the function MUST NOT read scheduling state from or write
+    scheduling state to the `TileGraph`.
   - A hole call MUST name its inputs, its output, and its raw schedule
     coordinates, each behind its own marker, so the three groups are
     distinguishable without re-deriving them.
   - A read-modify-write self-read on the output buffer MUST appear among the
     inputs rather than be silently dropped.
-  - A buffer whose decided ring depth is above `1` MUST be referenced through
-    that ring, indexed by the innermost coordinate modulo the depth. Before atom
-    selection has run `tg.ring` is empty, and every reference MUST then be the
-    bare buffer name.
+  - A buffer whose `ring` depth is above `1` MUST be referenced through that
+    ring, indexed by the innermost coordinate modulo the depth. An empty `ring`
+    mapping makes every reference the bare buffer name.
   - Exactly one `HoleContract` MUST be produced per statement, not per call site
     in the generated text, and its `coords` MUST come from the first occurrence.
   - A statement whose name has no matching `TileUnit`, or that writes more than
@@ -699,3 +787,75 @@ class PartitionFacts:
   - Compiler policy MUST stay in `ScheduleOptions`, not in these facts: what the
     hardware is does not depend on how aggressively the compiler was asked to
     schedule it.
+
+### 5.3 `PipelineFacts`
+
+```python
+class PipelineFactsQuery:
+    """Facts requested for one pipeline projection.
+
+    Attributes:
+        topology: attribute; topology level the pipeline is scheduled over.
+        statements: attribute; stable statement IDs paired with their ops.
+    """
+
+    topology: str
+    statements: tuple[tuple[str, object], ...]
+
+class PipelineInstructionFacts:
+    """Instruction choices for one statement.
+
+    Attributes:
+        statement_id: attribute; stable statement identity.
+        candidates: attribute; supported atom choices for that statement.
+    """
+
+    statement_id: str
+    candidates: tuple[AtomFact, ...]
+
+class PipelineFacts:
+    """All concrete information required to close a pipeline problem.
+
+    Attributes:
+        topology: attribute; level the pipeline is scheduled over.
+        tile_capacity_scope: attribute; level that owns the bounded tile store.
+        tile_capacity_bytes: attribute; capacity of that tile store in bytes.
+        max_threads_per_warp: attribute; target warp-width limit.
+        instructions: attribute; instruction choices by statement identity.
+    """
+
+    topology: str
+    tile_capacity_scope: str
+    tile_capacity_bytes: int
+    max_threads_per_warp: int
+    instructions: tuple[PipelineInstructionFacts, ...]
+```
+
+- constraints:
+  - Every structure MUST be immutable.
+  - `PipelineFactsQuery.statements` MUST preserve program statement order and
+    MUST use the stable IDs later used by the plan.
+  - `topology` and `tile_capacity_scope` MUST remain distinct: the level whose
+    threads are scheduled need not own the capacity that bounds their shared
+    tile.
+  - `instructions` MUST contain one entry per requested statement. Each atom is
+    carried through `AtomFact` and remains opaque to the common scheduler.
+  - Like `PartitionFacts`, this aggregate is projected once with
+    `Target.as_facts`; the closed problem MUST NOT retain a `Target` callback.
+
+## 6. Public errors
+
+```python
+class ScheduleError(ValueError):
+    """A scheduling request that cannot be served, or a solve that failed."""
+
+class PlanVerificationError(ValueError):
+    """A plan that refers to missing state or contradicts itself."""
+```
+
+- constraints:
+  - Both errors are public from `tilefoundry.schedule`.
+  - Request validation, algorithm resolution, and solve failures MUST surface as
+    `ScheduleError`.
+  - `SchedulePlan.verify` failures MUST surface as `PlanVerificationError`, so a
+    caller can distinguish an unserviceable request from a malformed result.

--- a/docs/spec/semantic-analysis.md
+++ b/docs/spec/semantic-analysis.md
@@ -14,18 +14,20 @@ this file links to it rather than redefining it.
 Type inference is registered per Op through
 `@register_typeinfer(<OpClass>)` and enforces its constraints via `ctx.error(...)`
 ([visitor-registry §4](./visitor-registry.md#4-instance-1--typeinfer)). A handler receives the op and a
-typeinfer context, derives the output `IRType`, and reports violations through
+typeinfer context, derives the output `Type`, and reports violations through
 `ctx.error`. A `hir.Function` call composes these per-op rules under
 elaboration ([hir §1.1](./hir.md#11-function)): the callee body is
 reconstructed and each of its nodes re-derives through the same per-op
 rules under the call's actual argument types, so a relation-derived rule
 never needs its own function-boundary case.
 
-A function boundary MUST NOT complete or reject a legal `Partial`. A function
-return MAY carry a `Partial(reduction)` in a `TensorType`, and a tuple return
-MAY carry it in any nested tensor field. Call elaboration MUST preserve the
-`ShardLayout` mesh-axis position and reduction on the actual value; completion
-remains the responsibility of an explicit `Reshard` or allreduce.
+- constraints:
+  - A function boundary MUST NOT complete or reject a legal `Partial`.
+  - A function return MAY carry a `Partial(reduction)` in a `TensorType`, and a
+    tuple return MAY carry it in any nested tensor field.
+  - Call elaboration MUST preserve the `ShardLayout` mesh-axis position and
+    reduction on the actual value; completion remains the responsibility of an
+    explicit `Reshard` or allreduce.
 
 ### 1.1 Relation-derived type behavior
 
@@ -54,12 +56,8 @@ defined in [§3.2](#32-relation-driven-shard-propagation).
 
 ### 1.2 Domain construction and output shape derivation
 
-The relation describes one shared iteration domain; a symbolic size is an isl
-parameter of that domain, and the relation's rank is fixed and read from the
-input types. Output shape is not carried by the relation — it is typeinfer-side
-data, derived from the op's shape rule or, where implemented, by composing the
-output access map over the domain. Output access-map arity is validated by the
-relation service ([visitor-registry §4.1](./visitor-registry.md#41-forward-relation-service--type_relation)).
+Output access-map arity is validated by the relation service
+([visitor-registry §4.1](./visitor-registry.md#41-forward-relation-service--type_relation)).
 
 ## 2. Access relation analysis
 
@@ -91,89 +89,94 @@ relation ([§1.1](#11-relation-derived-type-behavior)), the
 output `ShardAttr`s are determined from the input shards and the
 relation's access maps by a single rule, shared across ops.
 
-**Mesh-axis value state.** `ShardLayout.attrs` is indexed by mesh axis. A
-`Partial(reduction)` is a value state at that exact index, not an unordered
-collection of reductions and not a layout position. Every propagation decision
-MUST retain that index and its reduction independently of every other mesh
-axis.
+```python
+def partial_reductions_by_axis(layout: object) -> tuple[str | None, ...]: ...
 
-**Reduction effect.** A reduction dim (a domain dim absent from the
-output access map) carries one of two effects, declared by the
-op/relation:
+def derive_output_shard_layout(
+    input_types: tuple,
+    relation,
+    output_shape: tuple,
+    *,
+    partial_reduction_dims: frozenset[int] = frozenset(),
+    complete_reduction_dims: frozenset[int] = frozenset(),
+    fresh_strides: bool = False,
+): ...
+```
 
-- `partial` — the per-shard result is a partial that still needs a
-  cross-shard reduction (e.g. a contraction dim split across the mesh);
-- `complete` — the reduction is already complete within each shard
-  (e.g. an explicit reduce over a sharded axis).
-
-**Propagation.** Per input mesh axis, by its attr:
-
-1. `Split(k)` — map layout axis `k` to the input's logical tensor axis,
-   then to a domain dim via the input access map.
-2. If that domain dim appears in the output access map, the output
-   carries `Split` on the **output layout axis** the domain dim maps to.
-3. If that domain dim is a reduction dim, the output mesh axis becomes
-   `Partial(reduction)` when the effect is `partial`, or `Broadcast`
-   when the effect is `complete`. The resulting `Partial` carries no
-   layout axis — it is a value state on that mesh axis.
-4. `Partial(reduction)` input — propagates on the **same mesh axis**, gated by
-   commutation: the op MUST propagate `Partial(reduction)` unchanged only
-   when its own math is proven to commute with `reduction` —
-   `op(reduction(x0..xn)) == reduction(op(x0)..op(xn))`. This service reads
-   only the relation's affine structure and MUST NOT make that mathematical
-   judgment itself; each op's typeinfer rule owns it. On each mesh axis, two
-   Partial inputs MUST be compatible with that op's rule. States on different
-   mesh axes MUST NOT be compared as an unordered set; the op evaluates each
-   axis independently. `Partial` resolves to `Broadcast` only via an explicit
-   reduction / allreduce over that axis. There is no layout-axis mapping for a
-   `Partial`.
-5. A `Broadcast` (size-1) input axis contributes no `Split`.
-6. Two inputs binding the same domain dim to incompatible mesh axes is
-   an error.
-
-A `Partial` MUST NOT be silently eliminated, nor silently carried through a
-non-commuting ordinary op; only an explicit `Reshard` / allreduce from
-`Partial` to `Broadcast` completes it.
-
-An ordinary multi-input op MUST inspect every tensor input for a `Partial`.
-When its result type cannot represent a secondary input's axis-preserving
-state, typeinfer MUST reject that input and name the `Reshard` remedy rather
-than silently dropping the state.
-
-A fully-`Broadcast` input `ShardLayout` (every attr `Broadcast`) is
-**replicated**: it carries no real sharding, so it contributes no
-`Split` / `Partial` and does not pin a mesh — it MAY combine with an
-input sharded on a different mesh. When no input carries real sharding
-the output carries none.
-
-An input `Split` that accesses a non-projection domain dim, or an
-output-surviving dim reachable only through a non-projection output
-access, MUST **fail closed** rather than guess a mapping. The rule
-reads only the access maps' affine structure (which domain dim each
-axis uses), never the domain bounds, so it is size-agnostic and
-identical for static and dynamic shapes.
-
-**Owner axis.** `Split(axis)` indexes an **output layout axis**,
-not the logical tensor axis. A reduction-induced `Partial` attaches to no
-layout axis — it is a value state on the mesh axis that was reduced.
+- constraints:
+  - `derive_output_shard_layout` reads only input types, forward-relation maps,
+    the requested output shape, and the explicit reduction/stride controls. It
+    MUST NOT read relation bounds or an already-derived output type.
+  - `partial_reductions_by_axis` returns one entry per mesh axis: the carried
+    reduction name for `Partial`, `None` for any other attr, and an empty tuple
+    for a non-sharded layout.
+  - With no real input sharding it returns `None`. Inputs with real sharding on
+    different meshes MUST fail.
+  - `partial_reduction_dims` turns a reduced split into `Partial("sum")`;
+    `complete_reduction_dims` turns it into `Broadcast`. The sets MUST NOT
+    overlap.
+  - `fresh_strides=True` requests fresh canonical strides; otherwise a
+    compatible propagated physical layout is preserved when possible.
+  - `ShardLayout.attrs` is indexed by mesh axis. A `Partial(reduction)` is a
+    value state at that exact index, not an unordered collection of reductions
+    and not a layout position. Every propagation decision MUST retain that
+    index and its reduction independently of every other mesh axis.
+  - A reduction dim (a domain dim absent from the output access map) carries
+    one of two effects declared by the op/relation: `partial` means the
+    per-shard result still needs a cross-shard reduction; `complete` means the
+    reduction is already complete within each shard.
+  - Propagation applies per input mesh axis:
+    1. `Split(k)` maps layout axis `k` to the input's logical tensor axis and
+       then to a domain dim through the input access map.
+    2. If that domain dim appears in the output access map, the output carries
+       `Split` on the output layout axis to which the domain dim maps.
+    3. If that domain dim is reduced, the output mesh axis becomes
+       `Partial(reduction)` for a `partial` effect or `Broadcast` for a
+       `complete` effect. The resulting `Partial` is a value state on that mesh
+       axis and carries no layout axis.
+    4. A `Partial(reduction)` input propagates on the same mesh axis only when
+       the op's math is proven to commute with `reduction`:
+       `op(reduction(x0..xn)) == reduction(op(x0)..op(xn))`. This service MUST
+       NOT make that mathematical judgment; each op's typeinfer rule owns it.
+       On each mesh axis, two Partial inputs MUST be compatible with that op's
+       rule. States on different mesh axes MUST NOT be compared as an unordered
+       set. Only an explicit reduction/allreduce resolves `Partial` to
+       `Broadcast`.
+    5. A `Broadcast` input axis contributes no `Split`.
+    6. Two inputs binding the same domain dim to incompatible mesh axes is an
+       error.
+  - A `Partial` MUST NOT be silently eliminated or carried through a
+    non-commuting ordinary op; only an explicit `Reshard`/allreduce from
+    `Partial` to `Broadcast` completes it.
+  - An ordinary multi-input op MUST inspect every tensor input for a `Partial`.
+    When its result type cannot represent a secondary input's axis-preserving
+    state, typeinfer MUST reject that input and name the `Reshard` remedy.
+  - A fully-`Broadcast` input `ShardLayout` is replicated: it carries no real
+    sharding, contributes no `Split`/`Partial`, and does not pin a mesh. When no
+    input carries real sharding, the output carries none.
+  - An input `Split` that accesses a non-projection domain dim, or an
+    output-surviving dim reachable only through a non-projection output access,
+    MUST fail closed. The rule reads only the maps' affine structure, never the
+    domain bounds.
+  - `Split(axis)` indexes an output layout axis, not a logical tensor axis. A
+    reduction-induced `Partial` attaches to no layout axis; it remains a value
+    state on the mesh axis that was reduced.
 
 ### 3.3 Output storage and mesh/layout compatibility
 
-A symmetric multi-input op (`Binary`, `MatMul`, `Concat`, `Stack`,
-`Mma`) resolves its output `storage` by **anchoring** on the concrete
-residency among its operands ([types §2](./types.md#2-tensortype)). The rule does not
-appeal to any ordering of storage kinds and is independent of operand order:
-
-- An **unmaterialized** operand (`storage=umat`) does not constrain the
-  output — it abstains.
-- One concrete operand storage (alongside any unmaterialized operands) is
-  the **anchor**; the output takes that storage.
-- Several concrete operands that agree on a storage → the output takes that
-  storage.
-- Several concrete operands that disagree on storage → typeinfer MUST
-  `ctx.error`, unless the op defines its own destination/mixed-storage
-  resolution. There is no operand-order tie-break.
-- All operands unmaterialized → the output is unmaterialized (`umat`).
+- constraints:
+  - A symmetric multi-input op (`Binary`, `MatMul`, `Concat`, `Stack`, `Mma`)
+    resolves output storage by anchoring on the concrete residency among its
+    operands ([types §2](./types.md#2-tensortype)); the rule is independent of
+    operand order.
+  - An unmaterialized operand (`storage=umat`) abstains and does not constrain
+    the output.
+  - One concrete operand storage is the anchor; the output takes that storage.
+  - Several concrete operands that agree on a storage produce that storage.
+  - Several concrete operands that disagree on storage cause typeinfer to
+    `ctx.error`, unless the op defines its own destination/mixed-storage
+    resolution. There is no operand-order tie-break.
+  - If all operands are unmaterialized, the output is unmaterialized (`umat`).
 
 This resolution uses no memory-level lattice; output residency is a function
 of the concrete anchor(s) alone. (The `rmem < smem < gmem` hierarchy is
@@ -187,6 +190,5 @@ operand layout / mesh compatibility it requires and its result layout;
 there is no uniform cross-op rule imposed from outside typeinfer.
 `Reshard` is the explicit op that changes a value's layout / mesh.
 
-Per-op typeinfer owns layout compatibility and result layout. For example,
-`Gather` owns whether an indexed access is a pure slice or a layout-preserving
+For example, `Gather` owns whether an indexed access is a pure slice or a layout-preserving
 data-dependent gather.

--- a/docs/spec/shard.md
+++ b/docs/spec/shard.md
@@ -63,10 +63,6 @@ IntTuple = int | tuple[IntTuple, ...]    # entry: an `int`, a symbolic/dynamic d
   - admits both a unique flat `int`-tuple view and a unique nested-structure view;
     the `shape` / `strides` of `Layout` and `ShardLayout` are `IntTuple`.
 
-Flatten-equivalence: every `IntTuple` admits both a unique flat
-`int`-tuple view and a unique nested-structure view. The `shape` and
-`strides` of `Layout` and `ShardLayout` are `IntTuple`.
-
 A `shape` / `stride` entry is not restricted to a static `int`: it may be a
 symbolic / dynamic dim (a `DimVar` or dim `Expr` — a `ShapeDim`), or `None`
 for a launch-provided (dynamic-CTA) extent (`Layout(shape=(None,),
@@ -82,10 +78,20 @@ and `T.sync` participation ([tir §1.5](./tir.md#15-sync)) — require static `i
 the `Layout` hierarchy:
 
 ```python
-class LayoutBase: ...                    # abstract base
-class Layout(LayoutBase): ...            # concrete `LayoutBase` member
-class ComposedLayout(LayoutBase): ...    # concrete `LayoutBase` member
-class ShardLayout(LayoutBase): ...       # concrete `LayoutBase` member
+class LayoutBase:
+    """Provide the abstract base for legal tensor layouts."""
+
+
+class Layout(LayoutBase):
+    """Provide a primitive coordinate-to-offset layout."""
+
+
+class ComposedLayout(LayoutBase):
+    """Provide a composition of two layout mappings."""
+
+
+class ShardLayout(LayoutBase):
+    """Bind a layout domain to a device mesh."""
 ```
 
 - constraints:
@@ -114,8 +120,15 @@ Mirrors `pycute.layout.Layout`:
 
 ```python
 class Layout(LayoutBase):
-    shape: IntTuple                 # layout-domain shape (entries `ShapeDim | None`)
-    stride: IntTuple | None = None  # step rule from domain to physical index; whole tuple `None` = un-materialized
+    """Describe a primitive coordinate-to-offset mapping.
+
+    Attributes:
+        shape: attribute; Layout-domain shape.
+        strides: attribute; Per-domain-axis step rule, or None when unmaterialized.
+    """
+
+    shape: IntTuple
+    strides: IntTuple | None = None
 ```
 
 - constraints:
@@ -129,16 +142,16 @@ Field meanings:
   unsharded** layout shape — i.e., the shape *before* mesh
   dividing. The per-thread local layout shape is derived from
   `layout.shape` ÷ mesh extents per `Split` (see [§7](#7-shardlayout)).
-- `stride` — the step rule from layout domain to physical index. When
+- `strides` — the step rule from layout domain to physical index. When
   not explicitly given, it defaults to `prefix_product(shape)` in the
   pycute style. When a `Layout` sits inside `ShardLayout.layout`,
-  `stride[k]` is the **storage-physical** step on the engine attached
+  `strides[k]` is the **storage-physical** step on the engine attached
   to that `ShardTensor` (see [§7](#7-shardlayout)).
 
 Semantics:
 
 ```python
-idx = crd2idx(coord, shape, stride)
+idx = crd2idx(coord, shape, strides)
 ```
 
 The primitive `Layout` has **no** `offset` field. `offset` belongs to
@@ -152,9 +165,17 @@ Mirrors CuTeDSL `make_composed_layout(inner, offset, outer)`:
 
 ```python
 class ComposedLayout(LayoutBase):
-    inner: LayoutBase | None   # applied last (output-side layout); `None` is identity
-    offset: int                # intermediate scalar offset (a property of the composition)
-    outer: LayoutBase | None   # applied first (input / domain-side layout); `None` is identity
+    """Describe a composition of two layout mappings.
+
+    Attributes:
+        inner: attribute; Output-side layout applied last, or identity.
+        offset: attribute; Intermediate scalar offset.
+        outer: attribute; Domain-side layout applied first, or identity.
+    """
+
+    inner: LayoutBase | None
+    offset: int
+    outer: LayoutBase | None
 ```
 
 - constraints:
@@ -174,13 +195,6 @@ Field meanings:
 - `inner` — applied **last** (the output-side layout); `None` applies
   the identity mapping
 
-Minimum semantics:
-
-```python
-idx = apply(inner, offset + apply(outer, coord))
-assert apply(None, value) == value
-```
-
 A `ComposedLayout` normally inherits its domain shape and axis numbering
 from `outer`. When `outer=None`, the identity mapping contributes no explicit
 domain, so the composition inherits them from `inner`. Therefore, when an
@@ -192,22 +206,46 @@ references the composition's stable `shape` / `domain_rank` contract.
 ## 5. `Mesh`
 
 ```python
-class Topology:                            # device-domain description
+class Topology:
+    """Describe one parallel-resource level.
+
+    Attributes:
+        name: attribute; Stable topology-level name.
+        size: attribute; Static, symbolic, or launch-provided extent.
+    """
+
     name: str
-    num_devices: int | None                # `None` only for a launch-provided (dynamic) `cta` extent
+    size: ShapeDim | None
 
-class Mesh:                                # the parallel device domain
-    topology: Topology                     # primary (first) Topology
-    topologies: tuple[Topology, ...]       # full Topology sequence; normalized non-empty, `topologies[0] is topology`
-    layout: Layout | ComposedLayout        # a plain `Layout` (un-sliced) or a `ComposedLayout` (a constant `m[...]` slice)
-    names: tuple[str, ...] | None = None
+class Mesh:
+    """Describe a parallel device domain.
 
-    def topology_domain(self) -> int | None: ...  # product of `topologies[i].num_devices`; `None` if any is dynamic
+    Attributes:
+        topology: attribute; Primary topology level.
+        layout: attribute; Mesh layout or constant sliced layout.
+        names: attribute; Human-readable layout-axis names.
+        topologies: attribute; Full normalized topology sequence.
+    """
 
-class MeshAxis:                            # single-axis object via `mesh.x` / `mesh.axes[i]`
+    topology: Topology
+    layout: Layout | ComposedLayout
+    names: tuple[str, ...] = ()
+    topologies: tuple[Topology, ...] = ()
+
+    def topology_domain(self) -> int | None: ...
+
+class MeshAxis:
+    """Describe one named or indexed mesh axis.
+
+    Attributes:
+        mesh: attribute; Owning mesh.
+        index: attribute; Layout-axis index.
+        size: attribute; Static or symbolic layout-axis extent.
+    """
+
     mesh: Mesh
     index: int
-    size: int
+    size: ShapeDim
 ```
 
 - constraints:
@@ -217,7 +255,7 @@ class MeshAxis:                            # single-axis object via `mesh.x` / `
 Field meanings:
 
 - `topology` — the primary (first) device-domain description (`name` +
-  `num_devices`)
+  `size`)
 - `layout` — the mesh's own shape / strides (a `Layout`); a constant slice
   (`m[...]`) replaces it with a `ComposedLayout` recording the sub-box
   ([tir §1.5](./tir.md#15-sync))
@@ -247,15 +285,66 @@ full sequence is `topologies`, and `topology` is always its first entry.
 ## 6. `ShardAttr`
 
 ```python
-class Split:                          # binds the current mesh axis to the layout's `axis`-th layout domain axis
+class ShardAttr:
+    """Provide the base for per-mesh-axis sharding attributes."""
+
+
+class Split(ShardAttr):
+    """Bind a mesh axis to a layout-domain axis.
+
+    Attributes:
+        axis: attribute; Layout-domain axis index.
+    """
+
     axis: int
 
-class Broadcast: ...                  # the value is replicated across this mesh axis
+class Broadcast(ShardAttr):
+    """Mark the value replicated across this mesh axis."""
 
-class Dynamic: ...                    # the distribution policy is not yet resolved
+class Dynamic(ShardAttr):
+    """Mark the distribution policy unresolved on this mesh axis."""
 
-class Partial:                        # an un-reduced partial value (`sum` / `max` / `min`)
+class Partial(ShardAttr):
+    """Mark an unreduced partial value.
+
+    Attributes:
+        reduction: attribute; Reduction required to obtain the full value.
+    """
+
     reduction: str = "sum"
+
+
+def S(axis: int) -> Split:
+    """Build a split attribute.
+
+    Args:
+        axis: Layout-domain axis index.
+
+    Returns:
+        The split attribute.
+    """
+    ...
+
+
+def P(reduction: str = "sum") -> Partial:
+    """Build a partial attribute.
+
+    Args:
+        reduction: Required reduction.
+
+    Returns:
+        The partial attribute.
+    """
+    ...
+
+
+def B() -> Broadcast:
+    """Build a broadcast attribute.
+
+    Returns:
+        The broadcast attribute.
+    """
+    ...
 ```
 
 - constraints:
@@ -272,14 +361,12 @@ Field meanings:
 - `Split(axis)` — the current mesh axis is bound to the underlying
   layout's `axis`-th layout domain axis (i.e., `layout.shape[axis]`).
   `axis` MUST satisfy `0 <= axis < rank(flatten(domain(layout)))`.
-  Across a single `ShardLayout.attrs`, an underlying-layout axis MAY
-  be bound by at most one mesh axis: two `Split` attrs sharing the
-  same `axis` are illegal. Since `layout.shape` is the **global
-  unsharded shape** ([§7](#7-shardlayout)), the binding constraint is
-  `mesh.shape[mesh_axis_position] | layout.shape[axis]`
-  (mesh extent must divide the global layout extent). The per-thread
-  local extent on this layout dim is then
-  `layout.shape[axis] // mesh.shape[mesh_axis_position]`.
+  Multiple mesh axes MAY bind the same layout axis. Each static mesh extent
+  must divide the remaining extent in mesh-axis order, and the local extent is
+  `layout.shape[axis] // product(mesh extents bound to axis)`. The canonical
+  constructor normally factorizes such bindings into distinct layout
+  positions, but `shard_layout_local_shape` also accepts and composes the
+  unfactorized form.
 - `Broadcast` — the current mesh axis does not participate in
   splitting; the value is replicated across this mesh axis.
 - `Dynamic` — the distribution policy of the current mesh axis is not
@@ -300,6 +387,7 @@ Surface syntax sugar:
 
 - `S(i)` ≡ `Split(axis=i)`
 - `P()` / `P("sum")` ≡ `Partial(reduction="sum")`
+- `B()` ≡ `Broadcast()`
 - omitted mesh axes are `Broadcast`
 
 ---
@@ -312,9 +400,17 @@ axes to mesh axes.
 
 ```python
 class ShardLayout(LayoutBase):
-    layout: LayoutBase                                        # the underlying layout-family member being bound
-    attrs: tuple[Split | Broadcast | Dynamic | Partial, ...]  # per-mesh-axis attributes, ordered by mesh axis
-    mesh: Mesh                                                # the device-domain `Mesh`
+    """Bind a layout domain to a device mesh.
+
+    Attributes:
+        layout: attribute; Underlying layout-family member.
+        attrs: attribute; Shard attributes in mesh-axis order.
+        mesh: attribute; Device-domain mesh.
+    """
+
+    layout: LayoutBase
+    attrs: tuple[ShardAttr, ...]
+    mesh: Mesh
 ```
 
 - constraints:
@@ -434,6 +530,7 @@ For `reshard(a:gmem, ..., storage='rmem')` (high → low, per-instance
 default):
 
 ```
+# example
 layout = Layout(shape=(2, 4, 3, 32, 4), strides=(0, 0, 4, 0, 1))
 attrs  = (Split(0), Split(1), Broadcast, Split(3), Broadcast)
 mesh   = Mesh(layout=Layout(shape=(2, 4, 32), ...))
@@ -468,3 +565,169 @@ logical shape → layout domain in
 [semantic-analysis §3.1](./semantic-analysis.md#31-logical-shape-to-layout-domain), and
 relation-driven propagation in
 [semantic-analysis §3.2](./semantic-analysis.md#32-relation-driven-shard-propagation).
+
+---
+
+## 9. Layout construction and mesh-scope projection
+
+```python
+class NotProjectable(ValueError):
+    """Report that a layout cannot serve as a mesh execution scope."""
+
+
+def prefix_product(shape: tuple[int, ...]) -> tuple[int, ...]:
+    """Return exclusive prefix-product strides.
+
+    Args:
+        shape: Static flat shape.
+
+    Returns:
+        Column-major natural strides.
+    """
+    ...
+
+
+def c_order_strides(shape: tuple, *, mul=None) -> tuple:
+    """Return row-major contiguous strides.
+
+    Args:
+        shape: Flat shape.
+        mul: Optional multiplication operation for symbolic entries.
+
+    Returns:
+        C-order strides.
+    """
+    ...
+
+
+def try_c_order_strides(shape: tuple) -> tuple[int, ...] | None:
+    """Return static C-order strides when possible.
+
+    Args:
+        shape: Candidate flat shape.
+
+    Returns:
+        Static strides, or None for a symbolic or dynamic shape.
+    """
+    ...
+
+
+def canonical_shard_layout(
+    logical_shape: tuple, mesh: Mesh, attrs: tuple[ShardAttr, ...]
+) -> ShardLayout:
+    """Build the canonical factorized sharding layout.
+
+    Args:
+        logical_shape: Logical tensor shape.
+        mesh: Device mesh.
+        attrs: Shard attributes naming logical axes.
+
+    Returns:
+        The canonical sharding layout.
+    """
+    ...
+
+
+def shard_layout_local_shape(sl: ShardLayout) -> tuple[int, ...]:
+    """Project a global sharding layout to its local shape.
+
+    Args:
+        sl: Sharding layout to project.
+
+    Returns:
+        The per-shard static shape.
+    """
+    ...
+
+
+def is_inverse_projectable(layout: Layout) -> bool:
+    """Return whether a layout admits the supported inverse projection.
+
+    Args:
+        layout: Primitive layout to inspect.
+
+    Returns:
+        Whether it is injective and compact-ordered.
+    """
+    ...
+
+
+def left_inverse(layout: Layout | ComposedLayout):
+    """Build the supported CuTe left inverse.
+
+    Args:
+        layout: Layout to invert.
+
+    Returns:
+        Its left-inverse layout.
+    """
+    ...
+
+
+def right_inverse(layout: Layout | ComposedLayout):
+    """Build the supported CuTe right inverse.
+
+    Args:
+        layout: Layout to invert.
+
+    Returns:
+        Its right-inverse layout.
+    """
+    ...
+
+
+def image(scope: ComposedLayout, coord: int) -> int:
+    """Map a domain coordinate into a mesh execution scope.
+
+    Args:
+        scope: Admissible composed mesh scope.
+        coord: Flat domain coordinate.
+
+    Returns:
+        Runtime thread index.
+    """
+    ...
+
+
+def project(scope: ComposedLayout, t: int) -> tuple[int, ...] | None:
+    """Project a runtime thread into a mesh execution scope.
+
+    Args:
+        scope: Admissible composed mesh scope.
+        t: Runtime thread index.
+
+    Returns:
+        The multidimensional coordinate, or None when outside the scope.
+    """
+    ...
+
+
+def contains(scope: ComposedLayout, t: int) -> bool:
+    """Return whether a runtime thread participates in a mesh scope.
+
+    Args:
+        scope: Admissible composed mesh scope.
+        t: Runtime thread index.
+
+    Returns:
+        Whether the thread participates.
+    """
+    ...
+```
+
+- constraints:
+  - `canonical_shard_layout` MUST factor each logical axis split by one or more
+    static mesh axes in mesh-axis order, remap each `Split` to its factor, and
+    append a non-unit residual factor. It MUST reject indivisible or
+    unrepresentable dynamic multi-axis splits.
+  - `shard_layout_local_shape` MUST multiply the divisors of multiple `Split`
+    attributes that name the same layout axis and MUST reject a remaining
+    non-static local extent.
+  - `try_c_order_strides` MUST return `None` unless every shape entry is a
+    non-boolean integer.
+  - Mesh-scope projection MUST accept only an identity inner mapping and an
+    inverse-projectable primitive outer layout; other layouts MUST raise
+    `NotProjectable` rather than guess a projection.
+  - `project` MUST return `None` for an index outside the scope or outside the
+    outer layout's round-tripping image; `contains` MUST report the same test as
+    a boolean.

--- a/docs/spec/target.md
+++ b/docs/spec/target.md
@@ -125,6 +125,7 @@ class H200SXM:
     hbm_capacity_bytes: int
     hbm_bandwidth_bytes_per_second: int
     l2_capacity_bytes: int | None
+    _dense_flops: tuple[tuple[DType, int], ...]
 
     def peak_for(self, dtype: DType) -> int: ...
 ```
@@ -167,6 +168,8 @@ class CudaTarget(Target):
         self,
         device: Device | str,
         architecture: Architecture | str | None = None,
+        *,
+        arch: str | None = None,
     ) -> None: ...
 
     def topology_limit(self, name: str) -> int | None: ...
@@ -178,6 +181,8 @@ class CudaTarget(Target):
   - `device` and `architecture` MUST each accept an installed document ID or a
     concrete value. An ID MUST resolve immediately to the typed value, and the
     resolved ID and content digest MUST be retained ([§1](#1-target)0.2).
+  - `arch`, when provided, MUST equal the resolved architecture's `name`; it is
+    a consistency check and MUST NOT select or override an architecture.
   - `device` MUST be required. The constructor MUST NOT select hardware for a
     caller who named none: a target nobody stated would answer about a machine
     nobody has.
@@ -336,6 +341,7 @@ class AppleM2Pro:
     cache_line_bytes: int
     unified_memory_capacity_bytes: int
     unified_memory_bandwidth_bytes_per_second: int
+    _unit_flops: tuple[tuple[str, tuple[tuple[DType, int], ...]], ...]
 
     def throughput_for(self, unit: str, dtype: DType) -> int: ...
 ```

--- a/docs/spec/tir.md
+++ b/docs/spec/tir.md
@@ -5,7 +5,7 @@ into TIR; the lowering pass `HirToTirPass` ([passes](./passes.md))
 also produces TIR. TIR has no value return; effect-form Ops carry
 the work, structural Stmts carry control flow.
 
-- **Container**: `tir.PrimFunction(name, params, body, output_count)`.
+- **Container**: `tir.PrimFunction(name, params, body, output_count, target)`.
   `body` is a `Sequential`; the function returns no value.
 - **Stmt tree**: function bodies are nested Stmts only. Exprs appear
   inside Stmt fields (e.g. `LetStmt.value`, `For.start`).
@@ -25,15 +25,17 @@ the work, structural Stmts carry control flow.
 
 ```python
 class Stmt:
-    loc: str | None = None    # optional debug location; not load-bearing for semantics
+    """Provide the abstract base for every TIR statement.
+
+    Attributes:
+        loc: attribute; Optional non-semantic debug location.
+    """
+
+    loc: str | None = None
 ```
 
 - constraints:
   - the abstract base of every TIR Stmt subclass; HIR has no `Stmt`.
-
-`Stmt` is the abstract base of every TIR Stmt subclass. HIR has no
-`Stmt`. `loc` is a debug surface; it is not load-bearing for
-semantics.
 
 ```mermaid
 flowchart TB
@@ -53,36 +55,83 @@ flowchart TB
 
 ```python
 class Sequential(Stmt):
-    body: tuple[Stmt, ...]            # a Stmt sequence (__iter__ / __len__ / __getitem__ provided)
+    """Contain a statement sequence.
+
+    Attributes:
+        body: attribute; Statements in execution order.
+    """
+
+    body: tuple[Stmt, ...]
 
 class LetStmt(Stmt):
-    var: Var                          # binds var to value; let chains nest body
+    """Bind a variable to an expression before a nested body.
+
+    Attributes:
+        var: attribute; Bound variable.
+        value: attribute; Bound expression.
+        body: attribute; Nested statements.
+    """
+
+    var: Var
     value: Expr
     body: Sequential
 
 class For(Stmt):
-    induction_var: Var                # counted loop
+    """Represent a counted loop.
+
+    Attributes:
+        induction_var: attribute; Loop variable.
+        start: attribute; Initial value.
+        stop: attribute; Exclusive bound.
+        step: attribute; Increment.
+        body: attribute; Loop body.
+    """
+
+    induction_var: Var
     start: Expr
     stop: Expr
     step: Expr
     body: Sequential
 
-class While(Stmt):                    # control flow
+class While(Stmt):
+    """Represent a conditional loop.
+
+    Attributes:
+        cond: attribute; Loop condition.
+        body: attribute; Loop body.
+    """
+
     cond: Expr
     body: Sequential
 
-class If(Stmt):                       # control flow
+class If(Stmt):
+    """Represent conditional control flow.
+
+    Attributes:
+        cond: attribute; Branch condition.
+        then_body: attribute; Taken body.
+        else_body: attribute; Untaken body.
+    """
+
     cond: Expr
     then_body: Sequential
     else_body: Sequential
 
 class MeshScope(Stmt):
-    mesh: Mesh                        # scopes a mesh binding over body
+    """Scope a mesh binding over a body.
+
+    Attributes:
+        mesh: attribute; Compile-time mesh.
+        binding: attribute; Lexical mesh binding.
+        body: attribute; Scoped statements.
+    """
+
+    mesh: Mesh
     binding: Var
     body: Sequential
 
 class Return(Stmt):
-    ...                               # @prim_func has no value return
+    """Terminate a value-less primitive function."""
 ```
 
 - constraints:
@@ -95,18 +144,26 @@ class Return(Stmt):
 
 ```python
 class PrimFunction(Stmt):
-    name: str                         # the function name
-    params: tuple[Var, ...]           # parameter Vars (the trailing output_count are outputs)
-    body: Sequential                  # the function body
-    output_count: int = 1             # number of trailing output params
+    """Contain one effect-only TIR function.
+
+    Attributes:
+        name: attribute; Function name.
+        params: attribute; Parameters, with trailing outputs.
+        body: attribute; Function body.
+        output_count: attribute; Number of trailing output parameters.
+        target: attribute; Compilation target for this function.
+    """
+
+    name: str
+    params: tuple[Var, ...]
+    body: Sequential
+    output_count: int = 1
+    target: Target = field(default_factory=default_target)
 ```
 
 - constraints:
   - itself a `Stmt`, not a separate top-level node; returns no value.
     `verify_prim_function` enforces the rules below.
-
-`PrimFunction` is itself a `Stmt`, not a separate top-level node;
-it sits inside the TIR Stmt tree along with everything else.
 
 `tir.verify.verify_prim_function(fn, *, module_fns=())` enforces:
 
@@ -143,8 +200,7 @@ class Evaluate(Stmt):
   - TIR's single Stmt-position wrapper for a no-result invocation; verify and
     lowering dispatch on `type(callable)`.
 
-`Evaluate` is TIR's single Stmt-position wrapper for a callable
-invocation that has no result value. The `callable` is one of:
+The `callable` is one of:
 
 - an effect-form `Op` (e.g. `tir.memory.Copy`, `tir.cuda.nn.Mma`,
   `tir.tensor.Reduce`, `tir.Launch` [§2.3](#23-tir-ops)). `args` are
@@ -156,8 +212,7 @@ invocation that has no result value. The `callable` is one of:
   buffers; the callee is resolved uniquely at module level
   ([§1.3](#13-primfunction)).
 
-Verify and lowering MUST dispatch on `type(callable)`. The per-Op
-verify / codegen handlers are keyed by `Op` type and receive the Op
+The per-Op verify / codegen handlers are keyed by `Op` type and receive the Op
 together with `args`; an `Op` callable carries no result, so its
 `Call` form is unit-typed.
 
@@ -334,13 +389,9 @@ class Abort(Stmt):
 - constraints:
   - a terminating Stmt on believed-unreachable paths (notably `DispatchCall.fallback`).
 
-- `Abort` is terminating. It exists in code paths the compiler
-  believes are unreachable (notably `DispatchCall.fallback`).
 - The CUDA emitter renders `Abort` as `__trap();` in device contexts
   and `assert(false);` in host contexts so a runtime hit is loud
   rather than silent.
-- `message` is a debug surface; it does not carry semantics.
-
 ### 1.8 `@intrinsic` — user-defined effect Stmts
 
 ```python
@@ -354,21 +405,21 @@ def <name>(<param>: Expr, ...) -> None: ...    # decorated function's signature 
     parser dispatch under the snake-case name; parameters are annotated `Expr` and
     the return annotation is `None`.
 
-`tilefoundry.ir.tir.intrinsic.intrinsic` synthesises a Stmt subclass
-from the decorated function's signature, registers the function
-body as the Stmt's verifier, and wires the parser dispatch entry
-under the function's snake-case name. Parameters MUST be annotated
-`Expr`; the return annotation MUST be `None`.
-
 ## 2. TIR Expr and callable constructs
 
 ### 2.1 `SymbolRef`
 
 ```python
 class SymbolRef(Expr):
-    name: str                       # canonical name of the callee PrimFunction (may be a mangled specialization name)
-    nested: tuple[str, ...] = ()    # empty — the Module holds only top-level functions
-    # type: CallableType — the resolved callee's CallableType, set at construction
+    """Name a primitive-function callee.
+
+    Attributes:
+        name: attribute; Canonical callee name.
+        nested: attribute; Nested path, empty for the flat Module symbol table.
+    """
+
+    name: str
+    nested: tuple[str, ...] = ()
 ```
 
 - constraints:
@@ -416,8 +467,15 @@ carries its `type` directly.
 
 ```python
 class ShapeOf(Expr):
-    param: Var    # a parameter Var of the enclosing PrimFunction
-    axis: int     # a valid axis index of param.type
+    """Produce one runtime tensor extent.
+
+    Attributes:
+        param: attribute; Enclosing primitive-function tensor parameter.
+        axis: attribute; Tensor axis.
+    """
+
+    param: Var
+    axis: int
 ```
 
 - constraints:
@@ -459,9 +517,10 @@ below; code carries only a one-line purpose docstring
   concrete level; the unmaterialized `umat` ([types §2](./types.md#2-tensortype)) is an
   HIR-only value and MUST already be materialized to a concrete level by the
   time `HirToTirPass` produces TIR — it never appears in TIR.
-- `Reshard` does not appear in TIR; HIR-side `Reshard` is lowered
-  into `LetStmt(AllocTensor)` + `Evaluate(Copy, ...)` chains
-  during `HirToTirPass` ([passes](./passes.md)).
+- `Reshard` does not appear in TIR. HIR-side `Reshard` without a storage change
+  lowers to a `TensorView` and performs no allocation or copy; a storage change
+  lowers to `LetStmt(AllocTensor)` plus `Evaluate(Copy, ...)` during
+  `HirToTirPass` ([passes §7.1](./passes.md#71-hirtotirpass)).
 
 #### Memory Ops (`tir.memory.*`)
 
@@ -490,8 +549,7 @@ class MemorySpan(Op):
 
     x: Tensor
 ```
-- constraints:
-  - re-interpret a memory region as a typed tensor; a value Op.
+- constraints: []
 
 ##### PtrOf
 ```python
@@ -504,8 +562,7 @@ class PtrOf(Op):
 
     x: Tensor
 ```
-- constraints:
-  - take the device address of a tensor for downstream view ops; a value Op.
+- constraints: []
 
 ##### TensorView
 ```python
@@ -523,8 +580,7 @@ class TensorView(Op):
     layout: object
     shape: tuple | None = None
 ```
-- constraints:
-  - derive a sub-view of a tensor; a value Op.
+- constraints: []
 
 ##### Copy
 ```python
@@ -532,15 +588,14 @@ class Copy(Op):
     """Effect form; byte-equivalent copy between two tensors.
 
     Attributes:
-        source: input; copy source.
-        destination: input; copy destination.
+        src: input; Copy source.
+        dst: input; Copy destination.
     """
 
-    source: Tensor
-    destination: Tensor
+    src: Tensor
+    dst: Tensor
 ```
-- constraints:
-  - byte-equivalent copy between two tensors.
+- constraints: []
 
 ##### Fill
 ```python
@@ -555,8 +610,7 @@ class Fill(Op):
     tensor: Tensor
     value: Tensor
 ```
-- constraints:
-  - broadcast a scalar value into a tensor.
+- constraints: []
 
 #### NN Ops (`tir.nn.*`)
 
@@ -596,8 +650,7 @@ class ReLU(Op):
     src: Tensor
     dst: Tensor
 ```
-- constraints:
-  - pointwise `max(x, 0)`.
+- constraints: []
 
 ##### RMSNorm
 ```python
@@ -616,8 +669,7 @@ class RMSNorm(Op):
     weight: Tensor
     eps: float
 ```
-- constraints:
-  - fused RMS normalisation.
+- constraints: []
 
 #### Tensor Ops (`tir.tensor.*`)
 
@@ -653,7 +705,31 @@ class Reduce(Op):
 `Binary` / `Unary` are effect-form Ops that dispatch on a kind enum rather than
 per-op classes; they appear as `Evaluate(op, args)`. `BinaryKind` /
 `UnaryKind` / `ReduceKind` are compiler-wide tag enums shared across HIR and
-TIR; lowering preserves the kind value without re-mapping.
+TIR; lowering preserves the kind value without re-mapping. Their owning
+definitions are [core-ir §4](./core-ir.md#4-shared-operation-kinds).
+
+##### Clamp
+
+```python
+class Clamp(Op):
+    """Effect form; clamp a source tensor into a destination.
+
+    Attributes:
+        min_val: attribute; Lower bound.
+        max_val: attribute; Upper bound.
+        src: input; Source tensor.
+        dst: input; Destination tensor.
+    """
+
+    min_val: float
+    max_val: float
+    src: Tensor
+    dst: Tensor
+```
+
+- constraints:
+  - `src` and `dst` MUST carry the same dtype; the effect writes
+    `min(max(src, min_val), max_val)` elementwise into `dst`.
 
 ##### Binary
 ```python
@@ -709,7 +785,11 @@ class CudaLaunchAttr(IntEnum):
 
 
 class LaunchAttrs:
-    """Authored launch attribute selector/value pairs."""
+    """Carry authored launch attribute selector/value pairs.
+
+    Attributes:
+        entries: attribute; Selector/value pairs interpreted by target lowering.
+    """
 
     entries: tuple[tuple[CudaLaunchAttr, object], ...] = ()
 ```
@@ -880,6 +960,7 @@ an enclosing `MeshScope` ([§1.2](#12-structural-stmts-tirstmts)); `T.mma` is
 verify-only and MUST NOT fuse the loads or the store.
 
 ```python
+# example
 atom = T.cuda.mma.atom(op=T.cuda.mma.SM80_16x8x16_F32BF16BF16F32_TN)
 with Mesh(Topology("thread", 32), Layout(shape=(4, 8), strides=(1, 4))) as warp:
     a_frag = T.alloc_tensor(TensorType(..., layout=atom.A, storage=rmem))

--- a/docs/spec/types.md
+++ b/docs/spec/types.md
@@ -2,7 +2,7 @@
 
 ```mermaid
 flowchart TB
-    IRType["<b>IRType</b><br/>(abstract base)"]
+    Type["<b>Type</b><br/>(union alias)"]
     TensorType["<b>TensorType</b>"]
     TupleType["<b>TupleType</b>"]
     UnitType["<b>UnitType</b>"]
@@ -12,45 +12,52 @@ flowchart TB
     dim["<b>dim ops</b>"]
     Layout["<b>Layout family</b><br/>(see shard)"]
 
-    IRType --> TensorType
-    IRType --> TupleType
-    IRType --> UnitType
-    IRType --> CallableType
+    TensorType -. member of .-> Type
+    TupleType -. member of .-> Type
+    UnitType -. member of .-> Type
+    CallableType -. member of .-> Type
 
     DType -. dtype .-> TensorType
     dim -. shape elements .-> TensorType
     Layout -. layout .-> TensorType
 
     TensorType -. element of .-> TupleType
-    IRType -. return type and parameter types .-> CallableType
+    Type -. return type and parameter types .-> CallableType
 ```
 
-## 1. `IRType`
+## 1. `Type`
 
 ```python
-class IRType:      # abstract base; concrete IR types derive from it
-    ...
+Type = TensorType | TupleType | UnitType | CallableType
 ```
-
-- constraints:
-  - every `core_ir.Expr.type` is one of its derivations (`TensorType` /
-    `TupleType` / `UnitType` / `CallableType`).
-
-`IRType` is the abstract base. Every `core_ir.Expr.type` is one of
-its derivations: `TensorType` / `TupleType` / `UnitType` /
-`CallableType`.
 
 ---
 
 ## 2. `TensorType`
 
 ```python
-# ShapeDim = int | DimVar | Expr — a static int, a bounded `DimVar` Op, or a dim-arithmetic `Expr` (see §4)
-class TensorType(IRType):
-    shape: tuple[ShapeDim, ...]                      # logical shape; invariant under sharding / storage / layout
-    dtype: DType                                     # element dtype
-    layout: LayoutBase | None                        # member of the Layout family, or no assigned layout (see shard)
-    storage: StorageKind | None                      # abstract result residency, or umat / None
+class TensorType:
+    """Describe a tensor's logical type.
+
+    Attributes:
+        shape: attribute; Logical shape, invariant under sharding, storage, and layout.
+        dtype: attribute; Element dtype.
+        layout: attribute; Layout-family member, or no assigned layout.
+        storage: attribute; Abstract result residency, unmaterialized residency, or None.
+    """
+
+    shape: tuple[ShapeDim, ...]
+    dtype: DType
+    layout: LayoutBase | None
+    storage: StorageKind | None
+
+    def scalar(
+        dtype: DType,
+        layout: LayoutBase | None = None,
+        storage: StorageKind | None = StorageKind.RMEM,
+    ) -> "TensorType": ...
+
+    def meta_scalar(dtype: DType = DType.i64) -> "TensorType": ...
 ```
 
 - constraints:
@@ -90,7 +97,16 @@ dispatch is described in
 ### 2.1 Recursive local projection
 
 ```python
-def local_type_of(type: IRType) -> IRType: ...
+def local_type_of(type: Type) -> Type:
+    """Project every tensor leaf to its per-shard local type.
+
+    Args:
+        type: Type to project.
+
+    Returns:
+        The recursively projected type.
+    """
+    ...
 ```
 
 - constraints:
@@ -105,9 +121,27 @@ def local_type_of(type: IRType) -> IRType: ...
 ### 2.2 Logical size
 
 ```python
-def numel(type: IRType) -> int: ...
+def numel(type: Type) -> int:
+    """Return the logical element count over all tensor leaves.
 
-def tensor_bytes(type: IRType) -> int: ...
+    Args:
+        type: Type to measure.
+
+    Returns:
+        The logical element count.
+    """
+    ...
+
+def tensor_bytes(type: Type) -> int:
+    """Return the logical byte size over all tensor leaves.
+
+    Args:
+        type: Type to measure.
+
+    Returns:
+        The logical byte size.
+    """
+    ...
 ```
 
 - constraints:
@@ -168,8 +202,8 @@ class DType:
     """Describe an element type.
 
     Attributes:
-        name: Canonical DSL spelling.
-        bit_width: Logical number of bits per element.
+        name: attribute; Canonical DSL spelling.
+        bit_width: attribute; Logical number of bits per element.
     """
 
     name: str
@@ -180,8 +214,8 @@ class FloatDType(DType):
     """Describe a floating-point element type.
 
     Attributes:
-        exponent_bits: Number of exponent bits.
-        mantissa_bits: Number of explicit mantissa bits.
+        exponent_bits: attribute; Number of exponent bits.
+        mantissa_bits: attribute; Number of explicit mantissa bits.
     """
 
     exponent_bits: int
@@ -192,7 +226,7 @@ class IntegerDType(DType):
     """Describe an integer element type.
 
     Attributes:
-        signed: Whether the integer representation is signed.
+        signed: attribute; Whether the integer representation is signed.
     """
 
     signed: bool
@@ -242,8 +276,7 @@ The canonical descriptors are:
 
 ## 4. `dim.*` — symbolic shape dimensions
 
-`shape` elements are values of the `ShapeDim` family (see [§2](#2-tensortype)'s
-field declaration: `ShapeDim = int | DimVar | Expr`):
+`shape` elements are values of the `ShapeDim` family:
 
 - a plain Python `int` for fully static dims;
 - a `DimVar(name, lo, hi)` value type (`core_ir.dim.DimVar`) for
@@ -252,56 +285,218 @@ field declaration: `ShapeDim = int | DimVar | Expr`):
   dim expressions, returning a rank-0 integer `Expr` of dtype
   `i64` and `storage=None`. This rank-0 meta-scalar type
   (`shape=()`, `layout=EMPTY_LAYOUT`, `storage=None`) has exactly one
-  constructor, `TensorType.meta_scalar(dtype)`; construction sites MUST NOT
-  restate the field tuple, so structural type equality holds across layers.
+  constructor, `TensorType.meta_scalar(dtype)`.
 
-The family covers:
+```python
+ShapeDim = int | DimVar | Expr
 
-- `DimConst(value: int)` — integer literal.
-- `DimVar(name: str, lo: int, hi: int)` — a bounded named shape
-  symbol (`"M"` / `"N"` / `"K"` / ...). The **half-open** envelope
-  `[lo, hi)` lives on the dim itself: `lo` is inclusive and `hi` is
-  exclusive, so `hi` is one past the maximum runtime value the dim
-  may take (the dim ranges over `lo .. hi-1`). `DimVar` MUST validate
-  `name` non-empty and `lo < hi`; a single-point envelope is
-  `[k, k+1)` (a fixed dim known symbolically). Identity is canonical per
-  `(name, lo, hi)`: every construction of `DimVar("N", a, b)`
-  returns the same object (via a per-`(name, lo, hi)` cache), so
-  identical entries compare equal across Ops. A second
-  `DimVar("N", a', b')` with `(a', b') != (a, b)` simply produces
-  a distinct canonical object; within a single function signature
-  same-name `DimVar`s MUST agree on bounds, and HIR
-  `verify_function` raises a `VerifyError` otherwise.
-- Arithmetic: `DimAdd` / `DimSub` / `DimMul` / `DimFloorDiv` /
-  `DimMod` / `DimMin` / `DimMax`, each taking two rank-0 integer
-  `Expr` inputs.
 
-These rank-0 shape-element tensors MUST use `storage=None` and carry no
-runtime memory.
+class DimConst(Op):
+    """Produce a constant symbolic dimension.
 
-**Construction-time folding.** Producers of arithmetic dim Calls
-(typeinfer rules, parser slice / range sugar, etc.) MUST route
-construction through `simplify_dim(op_cls, args)`. When every
-entry of `args` is an `int`-valued `Constant`, `simplify_dim`
-returns a folded `Constant` directly; otherwise it returns the
-canonical `Call(target=op_cls(), args=args)` unchanged. This
-keeps the IR free of all-`Constant` arithmetic chains and lets
-downstream consumers (printer, viewer, codegen) read the literal
-value without inspecting nested arithmetic. Two cases preserve
-the original `Call` even when all args are `Constant`:
-`DimFloorDiv` / `DimMod` with a zero divisor (so verify can flag
-the error) and Constants whose payload is not `int` (e.g.
-`bool`). No algebraic identity folding (`x + 0` → `x`, `x * 1`
-→ `x`) is performed at construction time; future passes own that
-optimisation.
+    Attributes:
+        value: attribute; Integer dimension value.
+    """
+
+    value: int
+
+
+class DimVar(Op):
+    """Produce a bounded named symbolic dimension.
+
+    Attributes:
+        name: attribute; Non-empty symbolic name.
+        lo: attribute; Inclusive lower bound.
+        hi: attribute; Exclusive upper bound.
+    """
+
+    name: str
+    lo: int
+    hi: int
+
+
+class DimAdd(Op):
+    """Produce the sum of two dimensions.
+
+    Attributes:
+        a: input; Left operand.
+        b: input; Right operand.
+    """
+
+    a: Expr
+    b: Expr
+
+
+class DimSub(Op):
+    """Produce the difference of two dimensions.
+
+    Attributes:
+        a: input; Left operand.
+        b: input; Right operand.
+    """
+
+    a: Expr
+    b: Expr
+
+
+class DimMul(Op):
+    """Produce the product of two dimensions.
+
+    Attributes:
+        a: input; Left operand.
+        b: input; Right operand.
+    """
+
+    a: Expr
+    b: Expr
+
+
+class DimFloorDiv(Op):
+    """Produce the floor quotient of two dimensions.
+
+    Attributes:
+        a: input; Dividend.
+        b: input; Divisor.
+    """
+
+    a: Expr
+    b: Expr
+
+
+class DimMod(Op):
+    """Produce the remainder of two dimensions.
+
+    Attributes:
+        a: input; Dividend.
+        b: input; Divisor.
+    """
+
+    a: Expr
+    b: Expr
+
+
+class DimMin(Op):
+    """Produce the minimum of two dimensions.
+
+    Attributes:
+        a: input; Left operand.
+        b: input; Right operand.
+    """
+
+    a: Expr
+    b: Expr
+
+
+class DimMax(Op):
+    """Produce the maximum of two dimensions.
+
+    Attributes:
+        a: input; Left operand.
+        b: input; Right operand.
+    """
+
+    a: Expr
+    b: Expr
+
+
+def simplify_dim(op_cls: type[Op], args: tuple) -> Expr:
+    """Build or constant-fold a dimension operation.
+
+    Args:
+        op_cls: Dimension operation class to construct.
+        args: Operation operands.
+
+    Returns:
+        A folded constant or the canonical call.
+    """
+    ...
+
+
+def is_dim_expr(value) -> bool:
+    """Return whether a value is a valid dimension expression.
+
+    Args:
+        value: Candidate value.
+
+    Returns:
+        Whether the value belongs to the dimension-expression family.
+    """
+    ...
+
+
+def dim_min(a, b) -> Expr:
+    """Build a symbolic minimum.
+
+    Args:
+        a: Left dimension.
+        b: Right dimension.
+
+    Returns:
+        The folded constant or symbolic minimum.
+    """
+    ...
+
+
+def dim_max(a, b) -> Expr:
+    """Build a symbolic maximum.
+
+    Args:
+        a: Left dimension.
+        b: Right dimension.
+
+    Returns:
+        The folded constant or symbolic maximum.
+    """
+    ...
+
+
+def ceildiv(a, b) -> Expr:
+    """Build symbolic ceiling division.
+
+    Args:
+        a: Dividend dimension.
+        b: Divisor dimension.
+
+    Returns:
+        The folded constant or symbolic ceiling quotient.
+    """
+    ...
+```
+
+- constraints:
+  - Rank-0 shape-element tensors MUST use `storage=None` and carry no runtime
+    memory.
+  - Construction sites MUST use `TensorType.meta_scalar(dtype)` instead of
+    restating its field tuple, so structural type equality holds across layers.
+  - `DimVar` MUST use a non-empty `name` and plain integer `lo` and `hi` bounds
+    satisfying `lo < hi`. Its envelope is half-open, `[lo, hi)`; `[k, k+1)` is
+    the fixed symbolic dimension `k`.
+  - `DimVar` identity MUST be canonical per `(name, lo, hi)`. Same-name
+    dimensions in one function signature MUST agree on bounds.
+  - Producers of arithmetic dimension calls MUST route construction through
+    `simplify_dim`.
+  - `simplify_dim` MUST fold two integer-valued constant operands, except
+    division or modulo by zero; otherwise it MUST retain the canonical call.
+    It MUST NOT perform algebraic identity folding.
+  - `is_dim_expr` MUST accept non-boolean integers, `DimVar`, integer-valued
+    `Constant`, and recursively valid calls to the seven dimension arithmetic
+    operations, and MUST reject other values.
+  - `ceildiv(a, b)` MUST compose the existing add, subtract, and floor-divide
+    operations; it does not introduce a distinct Op.
 
 ---
 
 ## 5. `TupleType`
 
 ```python
-class TupleType(IRType):
-    fields: tuple[IRType, ...]    # the tuple's field types; result type of a multi-output Op (nested TupleType is uncommon)
+class TupleType:
+    """Describe a tuple of result types.
+
+    Attributes:
+        fields: attribute; Field types in result order.
+    """
+
+    fields: tuple[TensorType | "TupleType", ...]
 ```
 
 - constraints:
@@ -320,29 +515,29 @@ class TupleType(IRType):
 ## 6. `UnitType`
 
 ```python
-class UnitType(IRType):    # no payload; result type of an effect-form Op
-    ...
+class UnitType:
+    """Describe the empty result type of an effect-form Op."""
 ```
 
 - constraints:
   - the result type of an effect-form Op; produces no readable value and
     appears in Stmt position as `Evaluate(op, args)`.
 
-`UnitType` is the result type of an effect-form Op (such as
-`tir.cuda.nn.Mma`, `tir.memory.Copy`), which produces no value its
-consumers can read; in Stmt position such an Op appears as
-`Evaluate(op, args)` ([tir §1.4](./tir.md#14-evaluate)). The
-effect-form vs value-form classification is owned by
-[core-ir §2.3](./core-ir.md#23-op).
-
 ---
 
 ## 7. `CallableType`
 
 ```python
-class CallableType(IRType):
-    return_type: IRType                # the callable's result type
-    parameters: tuple[IRType, ...]     # parameter types (names are not part of the type)
+class CallableType:
+    """Describe the type of a callable expression.
+
+    Attributes:
+        return_type: attribute; Callable result type.
+        parameters: attribute; Parameter types in declaration order.
+    """
+
+    return_type: Type
+    parameters: tuple[Type, ...]
 ```
 
 - constraints:
@@ -358,3 +553,90 @@ class CallableType(IRType):
     storage / layout are reached through `type` rather than restated. The
     two live in different layers and are disambiguated by import path; do
     not conflate them.
+
+---
+
+## 8. Tensor type convenience constructors
+
+```python
+def make_tensor_type(
+    shape: tuple,
+    dtype: DType = DType.f32,
+    storage: str | StorageKind | None = "gmem",
+    layout: object = None,
+) -> TensorType:
+    """Build a plain tensor type.
+
+    Args:
+        shape: Logical tensor shape.
+        dtype: Element dtype.
+        storage: Abstract tensor residency.
+        layout: Optional unsharded layout.
+
+    Returns:
+        The tensor type.
+    """
+    ...
+
+
+def make_shard_tensor_type(
+    shape: tuple,
+    dtype: DType = DType.f32,
+    storage: str | StorageKind | None = "gmem",
+    mesh: Mesh | None = None,
+    attrs: tuple = (),
+) -> TensorType:
+    """Build a canonical sharded tensor type.
+
+    Args:
+        shape: Logical tensor shape.
+        dtype: Element dtype.
+        storage: Abstract tensor residency.
+        mesh: Optional sharding mesh.
+        attrs: Shard attributes in mesh-axis order.
+
+    Returns:
+        The plain or canonically sharded tensor type.
+    """
+    ...
+```
+
+- constraints:
+  - `make_tensor_type` MUST preserve `shape` as a tuple and pass the remaining
+    fields to `TensorType`.
+  - `make_shard_tensor_type` MUST return a plain tensor type when `mesh` is
+    `None` or `attrs` is empty; otherwise it MUST build the layout through
+    `canonical_shard_layout`.
+
+## 9. Callable type projection
+
+```python
+def callable_type_for(params, return_type: Type) -> CallableType:
+    """Project parameters and a return type into a callable type.
+
+    Args:
+        params: Parameter values whose types are projected.
+        return_type: Callable result type.
+
+    Returns:
+        The callable type.
+    """
+    ...
+
+
+def callable_type_for_prim_function(fn) -> CallableType:
+    """Project a TIR primitive function into a callable type.
+
+    Args:
+        fn: Primitive function to project.
+
+    Returns:
+        The callable type with a unit result.
+    """
+    ...
+```
+
+- constraints:
+  - `callable_type_for` MUST preserve parameter order and project only each
+    parameter's `.type`; parameter names are not part of `CallableType`.
+  - `callable_type_for_prim_function` MUST use `UnitType` as the return type.

--- a/docs/spec/visitor-mutator.md
+++ b/docs/spec/visitor-mutator.md
@@ -54,10 +54,6 @@ it, falling back to `generic_visit(node)` when no such override exists.
   caught by `visit_Call`; per-Op dispatch is the analysis registry's
   responsibility ([visitor-registry](./visitor-registry.md)).
 
-`visit_<ClassName>` is preferred over `singledispatch` because
-overrides are greppable, the inheritance chain is explicit, and it
-does not depend on Python-version-specific dispatch behaviour.
-
 ## 3. `ExprVisitor[T]`
 
 Read-only Expr-tree traversal. `T` is user-chosen (`None` for
@@ -81,12 +77,16 @@ table that grows whenever a new Expr subclass appears:
 |---|---|
 | `Var` | `()` |
 | `Constant` | `()` |
-| `Tuple` | `fields` |
+| `SymbolRef` | `()` |
+| `Tuple` | `elements` |
 | `Call` | `args` |
+| `GridRegionExpr` | `init_args`, `body`, `yield_values` (binding-site Vars are excluded) |
+| `hir.Function` | `body` (parameter binding-site Vars are excluded) |
 
 Example — collect every `Var`:
 
 ```python
+# example
 class VarCollector(ExprVisitor[None]):
     def __init__(self) -> None:
         self.vars: set[Var] = set()
@@ -156,8 +156,10 @@ come back via `StmtExprMutator`):
 | `If` | `(then_body, else_body)` |
 | `MeshScope` | `(body,)` |
 | `LetStmt` | `(body,)` |
+| `DispatchCall` | `case_calls`, then `fallback` |
 | `Return` | `()` |
 | `Evaluate` | `()` (leaf in the Stmt tree; its Expr fields are `args`, plus `callable` when `callable` is a `SymbolRef`) |
+| `Abort` | `()` |
 
 `StmtVisitor` / `StmtMutator` do **not** descend into Expr fields
 embedded in Stmts — `For.start` / `For.stop` / `For.step` /
@@ -195,7 +197,6 @@ when needed:
 | `Evaluate` | `args` (and `callable` when it is a `SymbolRef`) |
 | `MeshScope` / `Sequential` | (none) |
 
-The rewrite scope is **embedded value Exprs**, not binding `Var`s.
 `α-renaming` and similar `Var`-rewriting passes use `StmtMutator`
 directly to rebuild Stmts; they do not reuse `StmtExprMutator`.
 
@@ -220,11 +221,28 @@ position, instead of `Evaluate(op, args)`, is malformed IR
 
 ## 8. Implementation location
 
-- File: `src/tilefoundry/ir/visitor.py`.
 - Public exports: `ExprVisitor`, `ExprMutator`, `StmtVisitor`,
-  `StmtMutator`, `StmtExprMutator`.
+  `StmtMutator`, `StmtExprMutator`, `walk_prim_function`,
+  `rewrite_prim_function`.
 - The four child-enumeration / rebuild tables
   (`_expr_children`, `_rebuild_expr`, `_stmt_children`,
   `_rewrite_stmt_exprs`) are module-private. Adding a new Expr or
   Stmt subclass requires extending the relevant tables in this
   single file; downstream IR node files are not affected.
+
+## 9. PrimFunction helpers
+
+```python
+def walk_prim_function(visitor: StmtVisitor, pf: PrimFunction) -> None: ...
+def rewrite_prim_function(
+    mutator: StmtMutator,
+    pf: PrimFunction,
+) -> PrimFunction: ...
+```
+
+- constraints:
+  - `walk_prim_function` visits `pf.body`; it does not visit the
+    `PrimFunction` wrapper itself.
+  - `rewrite_prim_function` rewrites `pf.body` and returns the original
+    `PrimFunction` when the body is identity-unchanged. Otherwise it returns a
+    copy with the rewritten `Sequential` body.

--- a/docs/spec/visitor-registry.md
+++ b/docs/spec/visitor-registry.md
@@ -2,8 +2,9 @@
 
 The derived-visitor pattern: every `analysis` / `verify` / `codegen`
 walker is the same template — **base visitor + custom Context +
-per-class registry**. This spec defines the template and its four
-instances (`typeinfer` / `verify` / `codegen_<target>` / `cost`).
+per-class registry**. This spec defines the template and its five
+instances (`typeinfer` / `verify` / `codegen_<target>` / `cost` /
+`hir_lowering`).
 
 The settled split:
 
@@ -78,16 +79,10 @@ are pure traversal scaffolds (see
 `VerifyVisitor` explicitly, not granted to every `StmtVisitor`
 subclass automatically.
 
-```python
-# StmtVisitor itself does not consult any registry:
-class StmtVisitor(Generic[T]):
-    def generic_visit(self, stmt): ...   # pure recursion, no registry lookup
-
-# VerifyVisitor is the derived class that holds a registry reference:
-class VerifyVisitor(StmtVisitor[None]):
-    def __init__(self, ctx: VerifyContext, registry=verify_stmt_registry): ...   # explicit binding point
-    def generic_visit(self, stmt: Stmt) -> None: ...   # look up type(stmt) in the registry, then recurse
-```
+The canonical `StmtVisitor` interface and its pure-recursion contract are
+owned by [visitor-mutator §5](./visitor-mutator.md#5-stmtvisitort--stmtmutator).
+`VerifyVisitor`, defined in [§5](#5-instance-2--verify), is the derived class
+that adds an explicit registry binding point.
 
 `@register_verify_stmt(Copy)` writes a handler into
 `verify_stmt_registry`; `VerifyVisitor.generic_visit` reads from the
@@ -127,10 +122,11 @@ instances split as follows:
 
 | Instance | Op-branch handler | Stmt-branch handler | Notes |
 |---|---|---|---|
-| **typeinfer** | `(Call, TypeInferContext) -> TensorType \| TupleType` | — | Value-producing only |
+| **typeinfer** | `(Call, TypeInferContext) -> Type` | — | Call result typing, including `UnitType` for effect Ops |
 | **verify** | — | `(Stmt, VerifyContext) -> None` | Effect-side constraints; for `Evaluate(op, args)`, dispatch keys on the Op class — see [§5](#5-instance-2--verify) |
 | **codegen_\<target\>** | `(Call, CodegenContext) -> str` | `(Stmt, CodegenContext) -> None` | Both sides are emitted |
 | **cost** | `(Call, CostContext) -> Cost` | `(Stmt, CostContext) -> Cost` (optional) | Recursive-local logical work |
+| **hir_lowering** | `(lowerer, Op, Call) -> Var` | — | HIR-to-TIR lowering; see [§11](#11-instance-5--hir_lowering) |
 
 Generic control-flow / binding Stmts (`For` / `If` / `While` /
 `LetStmt` / `Sequential` / `MeshScope` / `Return`) are handled by
@@ -169,10 +165,23 @@ Context:
 ```python
 @dataclass
 class TypeInferContext:
-    module: Module                              # the Module being type-checked
-    cache: dict[Expr, TensorType | TupleType]   # memoized Expr → TensorType | TupleType
-    def type_of(self, expr: Expr) -> TensorType | TupleType: ...   # lazy-compute + cache a node's type; supports recursive child queries
-    def error(self, node, msg: str): ...        # raise a constraint failure — see §7
+    """Walk-local type cache, mesh scope, and elaboration cache.
+
+    Attributes:
+        module: attribute; module being checked, or ``None`` when no module is
+            required.
+        cache: attribute; memoized ``id(expr)`` to inferred ``Type``.
+        mesh_scope: attribute; enclosing mesh scope tuple.
+        elaboration_cache: attribute; memoized specialization instances.
+    """
+
+    module: Any = None
+    cache: dict[int, Type] = field(default_factory=dict)
+    mesh_scope: tuple = ()
+    elaboration_cache: dict[tuple, Any] = field(default_factory=dict)
+
+    def type_of(self, expr: Expr) -> Type: ...
+    def error(self, node: Expr | Stmt, msg: str) -> NoReturn: ...
 ```
 
 - constraints:
@@ -190,11 +199,10 @@ def register_typeinfer(op_cls: type[Op]): ...     # decorator: register a typein
 ```
 
 - constraints:
-  - handler signature is `(call: Call, ctx: TypeInferContext) -> TensorType | TupleType`.
-
-Handler signature: `(call: Call, ctx: TypeInferContext) -> TensorType | TupleType`.
+  - handler signature is `(call: Call, ctx: TypeInferContext) -> Type`.
 
 ```python
+# example
 # a typeinfer handler pins the (call, ctx) -> type shape:
 @register_typeinfer(Binary)
 def _(call: Call, ctx: TypeInferContext) -> TensorType: ...
@@ -203,13 +211,14 @@ def _(call: Call, ctx: TypeInferContext) -> TensorType: ...
 Visitor:
 
 ```python
-class TypeInferVisitor(ExprVisitor[TensorType | TupleType]):
+class TypeInferVisitor(ExprVisitor[Type]):
     def __init__(self, ctx: TypeInferContext): ...   # ctx carries the cache and helpers
     def visit_Var(self, var: Var): ...               # return the Var's type
     def visit_Constant(self, c: Constant): ...       # the node's own declared type
     def visit_Call(self, call: Call): ...            # typeinfer_registry.lookup(type(call.target))
     def visit_Tuple(self, tup: Tuple): ...            # structural: TupleType over each element's type
     def visit_GridRegionExpr(self, grid): ...         # carry/body — hir §1.2
+    def visit_ShapeOf(self, shape_of: ShapeOf) -> Type: ...
 ```
 
 - constraints:
@@ -222,6 +231,7 @@ class TypeInferVisitor(ExprVisitor[TensorType | TupleType]):
     unregistered `Op` call routes through `ctx.error`.
   - `visit_Tuple` derives a structural `TupleType` from `ctx.type_of` of each
     element — never the `Tuple` node's own stamped `.type`.
+  - `visit_ShapeOf` returns the node's declared rank-0 i32 type.
   - `hir.Function` is itself a valid `Call.target` ([§4](#4-instance-1--typeinfer) above): its registered
     typeinfer handler elaborates the callee under the call's actual argument
     types ([hir §1.1](./hir.md#11-function)) rather than reading the target's
@@ -346,7 +356,14 @@ Context (extends `TypeInferContext` to share the type-of cache):
 ```python
 @dataclass
 class VerifyContext(TypeInferContext):   # inherits module / cache / type_of
-    mesh_stack: list                     # active mesh-scope stack maintained during the walk
+    """Type inference context extended with the active mesh stack.
+
+    Attributes:
+        mesh_stack: attribute; active mesh-scope stack maintained during the
+            verification walk.
+    """
+
+    mesh_stack: list = field(default_factory=list)
 ```
 
 - constraints:
@@ -363,9 +380,6 @@ def register_verify_stmt(cls: type): ...        # decorator: register a verify h
   - handler signature is `(node, ctx: VerifyContext) -> None`; failure routes
     through `ctx.error(node, msg)`, which raises `VerifyError`.
 
-Handler signature: `(node, ctx: VerifyContext) -> None`. Failure
-routes through `ctx.error(node, msg)` which raises `VerifyError`.
-
 **`Evaluate(op, args)` dispatch.** TIR effect-form Ops
 (`Copy` / `Fill` / `Mma` / `ReLU` / `RMSNorm` / `Reduce`) appear in
 Stmt position as `Evaluate(callable=op, args)`. The verify path keys
@@ -381,6 +395,7 @@ for the matching visitor entry-form contract and
 [tir §1.4](./tir.md#14-evaluate) for the wrapper definition.
 
 ```python
+# example
 # a verify handler keys on the Op class and returns None:
 @register_verify_stmt(Copy)
 def _(call: Call, ctx: VerifyContext) -> None: ...
@@ -412,20 +427,9 @@ fallback; their semantic constraints (e.g. `For.step != 0`,
 
 ## 6. Instance 3 — `codegen_<target>`
 
-Context (skeleton; per-target fields live in [target](./target.md)):
-
-```python
-@dataclass
-class CodegenContext:
-    module: Module              # the Module being emitted
-    output: list[str]           # accumulated code fragments
-    symbol_table: dict          # Var → emitted identifier
-    indent: int = 0             # current indent level
-    # target-specific fields owned by target.md
-```
-
-- constraints:
-  - skeleton only; per-target fields and helpers are owned by [target](./target.md).
+The concrete `CodegenContext` interface is owned by
+[codegen §2.3](./codegen.md#23-codegencontext). This section owns only the
+registry-dispatch contract that consumes that context.
 
 Registry per target:
 
@@ -438,11 +442,6 @@ def register_codegen_cuda(cls: type[Op] | type[Stmt]): ...   # decorator: regist
   - each target has its own registry; keys may be `type[Op]` (TIR-owned Expr Op
     handlers) or `type[Stmt]`.
 
-Each target has its own registry. Keys may be `type[Op]` (TIR-owned
-Expr Op handlers — `tir.memory.AllocTensor` /
-`tir.memory.{PtrOf,MemorySpan,TensorView}` / `tir.scalar.*`) or
-`type[Stmt]` (Stmt handlers).
-
 Handler signatures:
 
 - Op-branch: `(call: Call, ctx: CodegenContext) -> str` — returns a
@@ -452,6 +451,7 @@ Handler signatures:
   one or more lines into `ctx.output`.
 
 ```python
+# example
 # Op-branch handler returns a code fragment; Stmt-branch handler emits lines:
 @register_codegen_cuda(TirScalarReLU)
 def _(call: Call, ctx: CodegenContext) -> str: ...
@@ -493,26 +493,48 @@ candidate Types through `CostContext`; it does not select hardware resources.
 ```python
 @dataclass
 class TrafficBytes:
+    """Per-operand traffic.
+
+    Attributes:
+        read: attribute; bytes read from the operand.
+        write: attribute; bytes written to the operand.
+        total_bytes: attribute; derived read-only traffic in both directions.
+    """
+
     read: int = 0
     write: int = 0
 
-    @property
     def total_bytes(self) -> int: ...
 
 @dataclass
 class Cost:
+    """Leaf-local work for one selected candidate.
+
+    Attributes:
+        flops: attribute; logical work grouped by compute dtype.
+        traffic: attribute; per-operand traffic in argument order, with the
+            result last.
+        bytes: attribute; derived read-only traffic over every operand.
+    """
+
     flops: Mapping[DType, int]
     traffic: tuple[TrafficBytes, ...]
 
-    @property
     def bytes(self) -> int: ...
 
 class CostContext(TypeInferContext):
-    selected_types: Mapping[int, IRType] = {}
-    selected_output_type: IRType | None = None
+    """Selected candidate types used for recursive-local costing.
 
-    def local_type_of(self, expr: Expr) -> IRType: ...
-    def local_output_type(self, call: Call) -> IRType: ...
+    Attributes:
+        selected_types: attribute; selected ``id(expr)`` to ``Type`` mapping.
+        selected_output_type: attribute; selected output type, when supplied.
+    """
+
+    selected_types: Mapping[int, Type] = field(default_factory=dict)
+    selected_output_type: Type | None = None
+
+    def local_type_of(self, expr: Expr) -> Type: ...
+    def local_output_type(self, call: Call) -> Type: ...
 
 cost_evaluator_registry: AnalysisRegistry[type[Op]]
 def register_cost_evaluator(op_cls: type[Op]): ...
@@ -529,6 +551,8 @@ class CostEvaluator(ExprVisitor[Cost]): ...
     from a target package would make one backend's presence decide whether any
     consumer can cost a program at all.
   - `flops` MUST group leaf-local logical work by compute `DType`.
+  - `TrafficBytes.total_bytes` and `Cost.bytes` MUST be read-only derived
+    properties and MUST NOT be accepted as constructor fields.
   - `traffic` MUST carry exactly one `TrafficBytes` per operand of the call, in
     argument order with the result last, so an Op that only touches part of an
     input says so where it knows it. `bytes` is derived: every operand's traffic
@@ -558,16 +582,9 @@ def error(self, node: Expr | Stmt, msg: str) -> NoReturn: ...   # node: the offe
   - provided by `TypeInferContext` and every Context that inherits it; raises
     `VerifyError` with a stable format.
 
-Handlers MUST surface constraint failures via `ctx.error(node, msg)`;
-hand-rolled `raise` is not the convention. This keeps the error
-format stable.
-
 ### 8.2 Other helpers
 
-`_constant_type` / `_broadcast` / `_merge_layout` /
-`_merge_storage` are implementation-side helpers. They live next to
-the Op files that use them (`ir/types/`, op modules) and are not
-constrained by this spec.
+Local helper implementation is not part of this contract.
 
 ## 9. Registration timing — import-time side effects
 
@@ -589,6 +606,7 @@ the four-step recipe.
 ### Step 1 — define a Context
 
 ```python
+# example
 @dataclass
 class AliasContext(TypeInferContext):
     alias_sets: dict[Var, set[Var]] = field(default_factory=dict)
@@ -597,6 +615,7 @@ class AliasContext(TypeInferContext):
 ### Step 2 — declare a registry + decorator
 
 ```python
+# example
 alias_registry: AnalysisRegistry[type[Op]]   # the new analysis's registry
 def register_alias(op_cls: type[Op]): ...     # decorator: register a handler for one Op class
 ```
@@ -608,6 +627,7 @@ needed.
 ### Step 3 — derive a Visitor that holds the registry explicitly
 
 ```python
+# example
 class AliasVisitor(ExprVisitor[None]):
     def __init__(self, ctx: AliasContext, registry: AnalysisRegistry = alias_registry): ...   # explicit binding
     def visit_Call(self, call: Call) -> None: ...   # look up type(call.target), invoke, then recurse
@@ -616,13 +636,14 @@ class AliasVisitor(ExprVisitor[None]):
 ### Step 4 — register handlers in the Op files
 
 ```python
+# example
 # an alias handler keys on the Op class and returns None:
 @register_alias(Reshape)
 def _(call: Call, ctx: AliasContext) -> None: ...
 ```
 
-These four steps are what every existing instance
-(typeinfer / verify / codegen) is doing. A new analysis is **peer**
+These four steps are what the extensible instances in this spec are doing.
+A new analysis is **peer**
 to them — no existing visitor / registry / dispatch code changes.
 
 The contract: callers own their `AnalysisRegistry`, their `Visitor`
@@ -630,3 +651,23 @@ subclass (built on
 [visitor-mutator](./visitor-mutator.md)), and their `Context`
 dataclass. Composition is explicit; there is no hidden
 framework-side magic that auto-binds them.
+
+## 11. Instance 5 — `hir_lowering`
+
+`hir_lowering_registry` dispatches each HIR `Call` to the handler that lowers
+that op to TIR. The pass-owned lowerer is the first handler argument.
+
+```python
+hir_lowering_registry: AnalysisRegistry[type[Op]]
+def register_hir_lowering(op_cls: type[Op]): ...
+```
+
+- constraints:
+  - Handler signature is
+    `(lowerer: _Lowerer, target: Op, expr: Call) -> Var`.
+  - `HirToTirPass` performs the lookup on `type(expr.target)` and invokes the
+    handler as `handler(lowerer, expr.target, expr)`; a missing handler is a
+    lowering error naming the op class.
+  - The registry and decorator are public from `tilefoundry.visitor_registry`.
+    Concrete handlers remain beside the pass or target-owned op that defines
+    the lowering; see [passes §7.1](./passes.md#71-hirtotirpass).


### PR DESCRIPTION
## Why
- Specs had drifted from their contracts and mixed self-describing surfaces with durable design guidance.

## What
- Reconcile the 119-item audit across 20 specs.
- Add concise admission rules and normalize interfaces, references, and ownership.
- Remove only duplicate or incidental details while preserving internal design invariants.

## Contract
- Tensor dtype remains explicit; JIT cache identity covers every Module function.
- Catalog membership and `models --source` do not imply a runnable decode path; CLI option inventories remain owned by `--help`.

## Verification
- `python scripts/spec_rules_lint.py docs/spec/*.md` — passed with ruff available.
- `python3.13 scripts/spec_refs_lint.py docs/spec src tests include` — passed.
- `python3.13 scripts/{no_machine_paths_lint,english_only_lint}.py docs/SPEC-RULES.md docs/spec/*.md` — passed.
- `tilefoundry spec` section queries and `git diff --check` — passed.

## Risk
- Docs-only; pytest and CUDA tests were not run. Tensor dtype rejection and whole-Module JIT cache-key enforcement remain implementation follow-ups.
