### PR TITLE
refactor(ci): run checks in one clean job container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,10 @@ jobs:
           .wheel-venv/bin/python -m pip install --no-deps \
             "$RUNNER_TEMP"/wheel/tilefoundry-*.whl
       - name: Verify the installed surface
-        run: .wheel-venv/bin/python -m pytest tests/installed -o python_files='smoke_*.py' -q -n 8
+        run: |
+          TF_SMOKE_VENV="$PWD/.wheel-venv" \
+            .wheel-venv/bin/python -m pytest tests/installed \
+            -o python_files='smoke_*.py' -q -n 8
       - name: Decode the published checkpoint with the shipped source
         run: |
           .wheel-venv/bin/python tests/installed/qwen3_1_7b_l3.py \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,5 +55,5 @@ jobs:
       - name: Decode the published checkpoint with the shipped source
         run: |
           .wheel-venv/bin/python tests/installed/qwen3_1_7b_l3.py \
-            --venv .wheel-venv \
+            --venv "$PWD/.wheel-venv" \
             --work "$RUNNER_TEMP/l3"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,37 +14,37 @@ concurrency:
 permissions:
   contents: read
 
-# Jobs run directly inside the self-hosted runner container, which carries the
-# toolchain (torch, CUDA, cutlass headers at /opt/cutlass/include, ruff,
-# clang-format, pre-commit). The runner container is launched pinned to one GPU
-# (--gpus device=1), so no per-job GPU selection is needed. `tilefoundry`
-# is the runner label — set it in the runner's RUNNER_LABELS at launch.
-#
-# That GPU must be in the default compute mode. Under `Exclusive_Process` only one
-# process may hold a context, and `-n 4` below is four of them: three workers fail
-# to initialise CUDA with `cudaErrorDevicesUnavailable`, which reads like a broken
-# toolchain rather than a busy card.
+# The runner image provides Python, CUDA, the selected GPU, and the large
+# read-only assets. This workflow only checks out the repository and runs the
+# project commands.
+
 jobs:
   lint:
     runs-on: [self-hosted, tilefoundry]
     steps:
       - uses: actions/checkout@v4
       - name: pre-commit run --all-files
-        run: pre-commit run --all-files
+        run: python -m pre_commit run --all-files
 
   test:
     needs: lint
     runs-on: [self-hosted, tilefoundry]
     steps:
       - uses: actions/checkout@v4
-      - name: Link baked cutlass headers
-        run: mkdir -p third_party/cutlass && ln -sf /opt/cutlass/include third_party/cutlass/include
-      - name: Install tilefoundry (editable, deps already in the image)
-        run: pip install -e '.[test]'
+      - name: Link CUTLASS headers
+        shell: bash
+        run: |
+          mkdir -p third_party/cutlass
+          if [[ -e third_party/cutlass/include && ! -L third_party/cutlass/include ]]; then
+            echo 'third_party/cutlass/include is not an empty link target' >&2
+            exit 1
+          fi
+          rm -f third_party/cutlass/include
+          ln -s /opt/cutlass/include third_party/cutlass/include
       # Each worker can instantiate an independent f32 HF reference model. Four
       # fit on the one pinned GPU; eight OOMed in PR #38 run 30478400012.
       - name: pytest tests/ -n 4
-        run: pytest tests/ -n 4
+        run: python -m pytest tests/ -n 4
 
   # Two runners against one installed environment: the shipped files must resolve
   # under it, then the model source it ships must decode a real checkpoint. After
@@ -52,14 +52,7 @@ jobs:
   install-smoke:
     needs: test
     runs-on: [self-hosted, tilefoundry]
-    # Part of the runner's contract, like the baked cutlass headers. Not a
-    # repository variable: `vars` is empty for a `pull_request` from a fork.
-    env:
-      TILEFOUNDRY_QWEN3_1_7B_CKPT: /checkpoints/Qwen3-1.7B
     steps:
-      # For the two runner files only. `tilefoundry` is not importable from a
-      # checkout — the package lives under `src/` — so the IR under test is the
-      # installed one.
       - uses: actions/checkout@v4
       # Built here and read off disk. Handing it between jobs as an artifact needs
       # the runner to reach GitHub's artifact API, which failed with ECONNRESET and
@@ -67,18 +60,17 @@ jobs:
       # to do with the wheel.
       - name: Build the wheel
         run: >-
-          pip wheel . --no-deps
+          pip wheel . --no-deps --no-build-isolation
           --wheel-dir ${{ runner.temp }}/wheel-${{ github.run_id }}-${{ github.run_attempt }}
       # Built once here; the shards reuse it through TF_SMOKE_VENV.
       - name: Install the wheel into a clean environment
         run: |
-          python -m venv --system-site-packages ${{ runner.temp }}/smoke-${{ github.run_id }}-${{ github.run_attempt }}
-          ${{ runner.temp }}/smoke-${{ github.run_id }}-${{ github.run_attempt }}/bin/pip install --no-deps \
+          smoke_venv=${{ runner.temp }}/smoke-${{ github.run_id }}-${{ github.run_attempt }}
+          python -m venv --system-site-packages "$smoke_venv"
+          "$smoke_venv/bin/pip" install --no-deps \
             ${{ runner.temp }}/wheel-${{ github.run_id }}-${{ github.run_attempt }}/tilefoundry-*.whl
-      # The image carries pytest without xdist; the editable install that brings it in
-      # is the `test` job's, not this one's.
-      - name: Install pytest-xdist
-        run: pip install 'pytest-xdist>=3'
+      # pytest and pytest-xdist come from the read-only runner environment. The
+      # smoke venv only receives the project wheel and remains disposable.
       # Default collection misses smoke_*.py, so the pattern is named here. These tests
       # spend their time in `tilefoundry` subprocesses, so the workers share the
       # container's cores.
@@ -86,7 +78,8 @@ jobs:
         env:
           TF_SMOKE_VENV: ${{ runner.temp }}/smoke-${{ github.run_id }}-${{ github.run_attempt }}
         run: >-
-          pytest tests/installed -o python_files='smoke_*.py' -q -n 8
+          ${{ runner.temp }}/smoke-${{ github.run_id }}-${{ github.run_attempt }}/bin/python
+          -m pytest tests/installed -o python_files='smoke_*.py' -q -n 8
       # Run by the environment above. `--work` holds the emitted source and the
       # canonical store `prepare` writes.
       - name: Decode the published checkpoint with the shipped source

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,57 +19,38 @@ defaults:
     shell: bash
 
 jobs:
-  lint:
+  ci:
     runs-on: [self-hosted, tilefoundry]
     container: tilefoundry-ci-runner:local
     steps:
       - uses: actions/checkout@v4
-      - name: pre-commit run --all-files
-        run: python -m pre_commit run --all-files
-
-  test:
-    needs: lint
-    runs-on: [self-hosted, tilefoundry]
-    container: tilefoundry-ci-runner:local
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install the checkout
+      - name: Prepare the project environment
         run: |
-          test_venv="$RUNNER_TEMP/test-venv"
-          python -m venv --system-site-packages "$test_venv"
-          "$test_venv/bin/python" -m pip install \
+          python -m venv --system-site-packages .venv
+          .venv/bin/python -m pip install \
             --no-deps --no-build-isolation --editable .
-          echo "$test_venv/bin" >> "$GITHUB_PATH"
+      - name: Run pre-commit
+        run: .venv/bin/python -m pre_commit run --all-files
       - name: Link CUTLASS headers
         run: |
           mkdir -p third_party/cutlass
           ln -sfnT /opt/cutlass/include third_party/cutlass/include
-      - name: pytest tests/ -n 4
-        run: python -m pytest tests/ -n 4
-
-  install-smoke:
-    needs: test
-    runs-on: [self-hosted, tilefoundry]
-    container: tilefoundry-ci-runner:local
-    steps:
-      - uses: actions/checkout@v4
+      - name: Run tests
+        run: .venv/bin/python -m pytest tests/ -n 4
       - name: Build the wheel
         run: |
           mkdir -p "$RUNNER_TEMP/wheel"
-          pip wheel . --no-deps --no-build-isolation \
+          .venv/bin/python -m pip wheel . --no-deps --no-build-isolation \
             --wheel-dir "$RUNNER_TEMP/wheel"
       - name: Install the wheel into a clean environment
         run: |
-          smoke_venv="$RUNNER_TEMP/smoke-venv"
-          python -m venv --system-site-packages "$smoke_venv"
-          "$smoke_venv/bin/python" -m pip install --no-deps \
+          python -m venv --system-site-packages .wheel-venv
+          .wheel-venv/bin/python -m pip install --no-deps \
             "$RUNNER_TEMP"/wheel/tilefoundry-*.whl
-          echo "$smoke_venv/bin" >> "$GITHUB_PATH"
-          echo "TF_SMOKE_VENV=$smoke_venv" >> "$GITHUB_ENV"
       - name: Verify the installed surface
-        run: python -m pytest tests/installed -o python_files='smoke_*.py' -q -n 8
+        run: .wheel-venv/bin/python -m pytest tests/installed -o python_files='smoke_*.py' -q -n 8
       - name: Decode the published checkpoint with the shipped source
         run: |
-          python tests/installed/qwen3_1_7b_l3.py \
-            --venv "$TF_SMOKE_VENV" \
+          .wheel-venv/bin/python tests/installed/qwen3_1_7b_l3.py \
+            --venv .wheel-venv \
             --work "$RUNNER_TEMP/l3"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,14 @@ concurrency:
 permissions:
   contents: read
 
-# The runner image provides Python, CUDA, the selected GPU, and the large
-# read-only assets. This workflow only checks out the repository and runs the
-# project commands.
+defaults:
+  run:
+    shell: bash
 
 jobs:
   lint:
     runs-on: [self-hosted, tilefoundry]
+    container: tilefoundry-ci-runner:local
     steps:
       - uses: actions/checkout@v4
       - name: pre-commit run --all-files
@@ -29,62 +30,46 @@ jobs:
   test:
     needs: lint
     runs-on: [self-hosted, tilefoundry]
+    container: tilefoundry-ci-runner:local
     steps:
       - uses: actions/checkout@v4
+      - name: Install the checkout
+        run: |
+          test_venv="$RUNNER_TEMP/test-venv"
+          python -m venv --system-site-packages "$test_venv"
+          "$test_venv/bin/python" -m pip install \
+            --no-deps --no-build-isolation --editable .
+          echo "$test_venv/bin" >> "$GITHUB_PATH"
       - name: Link CUTLASS headers
-        shell: bash
         run: |
           mkdir -p third_party/cutlass
-          if [[ -e third_party/cutlass/include && ! -L third_party/cutlass/include ]]; then
-            echo 'third_party/cutlass/include is not an empty link target' >&2
-            exit 1
-          fi
-          rm -f third_party/cutlass/include
-          ln -s /opt/cutlass/include third_party/cutlass/include
-      # Each worker can instantiate an independent f32 HF reference model. Four
-      # fit on the one pinned GPU; eight OOMed in PR #38 run 30478400012.
+          ln -sfnT /opt/cutlass/include third_party/cutlass/include
       - name: pytest tests/ -n 4
         run: python -m pytest tests/ -n 4
 
-  # Two runners against one installed environment: the shipped files must resolve
-  # under it, then the model source it ships must decode a real checkpoint. After
-  # `test` because the decode wants the whole card, and `lint` is upstream of that.
   install-smoke:
     needs: test
     runs-on: [self-hosted, tilefoundry]
+    container: tilefoundry-ci-runner:local
     steps:
       - uses: actions/checkout@v4
-      # Built here and read off disk. Handing it between jobs as an artifact needs
-      # the runner to reach GitHub's artifact API, which failed with ECONNRESET and
-      # skipped both steps below — a hop that can break for reasons having nothing
-      # to do with the wheel.
       - name: Build the wheel
-        run: >-
-          pip wheel . --no-deps --no-build-isolation
-          --wheel-dir ${{ runner.temp }}/wheel-${{ github.run_id }}-${{ github.run_attempt }}
-      # Built once here; the shards reuse it through TF_SMOKE_VENV.
+        run: |
+          mkdir -p "$RUNNER_TEMP/wheel"
+          pip wheel . --no-deps --no-build-isolation \
+            --wheel-dir "$RUNNER_TEMP/wheel"
       - name: Install the wheel into a clean environment
         run: |
-          smoke_venv=${{ runner.temp }}/smoke-${{ github.run_id }}-${{ github.run_attempt }}
+          smoke_venv="$RUNNER_TEMP/smoke-venv"
           python -m venv --system-site-packages "$smoke_venv"
-          "$smoke_venv/bin/pip" install --no-deps \
-            ${{ runner.temp }}/wheel-${{ github.run_id }}-${{ github.run_attempt }}/tilefoundry-*.whl
-      # pytest and pytest-xdist come from the read-only runner environment. The
-      # smoke venv only receives the project wheel and remains disposable.
-      # Default collection misses smoke_*.py, so the pattern is named here. These tests
-      # spend their time in `tilefoundry` subprocesses, so the workers share the
-      # container's cores.
+          "$smoke_venv/bin/python" -m pip install --no-deps \
+            "$RUNNER_TEMP"/wheel/tilefoundry-*.whl
+          echo "$smoke_venv/bin" >> "$GITHUB_PATH"
+          echo "TF_SMOKE_VENV=$smoke_venv" >> "$GITHUB_ENV"
       - name: Verify the installed surface
-        env:
-          TF_SMOKE_VENV: ${{ runner.temp }}/smoke-${{ github.run_id }}-${{ github.run_attempt }}
-        run: >-
-          ${{ runner.temp }}/smoke-${{ github.run_id }}-${{ github.run_attempt }}/bin/python
-          -m pytest tests/installed -o python_files='smoke_*.py' -q -n 8
-      # Run by the environment above. `--work` holds the emitted source and the
-      # canonical store `prepare` writes.
+        run: python -m pytest tests/installed -o python_files='smoke_*.py' -q -n 8
       - name: Decode the published checkpoint with the shipped source
-        run: >-
-          ${{ runner.temp }}/smoke-${{ github.run_id }}-${{ github.run_attempt }}/bin/python
-          tests/installed/qwen3_1_7b_l3.py
-          --venv ${{ runner.temp }}/smoke-${{ github.run_id }}-${{ github.run_attempt }}
-          --work ${{ runner.temp }}/l3-${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          python tests/installed/qwen3_1_7b_l3.py \
+            --venv "$TF_SMOKE_VENV" \
+            --work "$RUNNER_TEMP/l3"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,54 +23,27 @@ defaults:
     shell: bash
 
 jobs:
-  build-and-verify:
+  build:
     runs-on: [self-hosted, tilefoundry]
     container: tilefoundry-ci-runner:local
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Prepare release environment
+      - name: Prepare packaging environment
         run: |
-          release_venv="$RUNNER_TEMP/release-venv"
-          python -m venv --system-site-packages "$release_venv"
-          "$release_venv/bin/python" -m pip install --upgrade build twine
-          echo "$release_venv/bin" >> "$GITHUB_PATH"
-      - name: Install packaging tools
-        run: python -c 'import build, twine'
+          python -m venv --system-site-packages .venv
+          .venv/bin/python -m pip install --upgrade build twine
       - name: Build tag distributions
         if: github.event_name == 'push'
-        run: python -m build
+        run: .venv/bin/python -m build
       - name: Build TestPyPI distributions
         if: github.event_name == 'workflow_dispatch'
         env:
           SETUPTOOLS_SCM_PRETEND_VERSION: ${{ inputs.testpypi-version }}
-        run: python -m build
+        run: .venv/bin/python -m build
       - name: Check distribution metadata
-        run: twine check dist/*
-      - name: Link baked cutlass headers
-        run: |
-          mkdir -p third_party/cutlass
-          ln -sfnT /opt/cutlass/include third_party/cutlass/include
-      - name: Verify the distribution wheel
-        env:
-          EVIDENCE_DIR: ${{ runner.temp }}/release-evidence
-        run: |
-          mkdir -p "$EVIDENCE_DIR"
-          wheel_venv="$RUNNER_TEMP/release-wheel"
-          python -m venv --system-site-packages "$wheel_venv"
-          "$wheel_venv/bin/python" -m pip install --no-deps dist/*.whl
-          PATH="$wheel_venv/bin:$PATH" TF_SMOKE_VENV="$wheel_venv" \
-            python -m pytest tests/integration/installed \
-            -o python_files='smoke_*.py' -q -n 4 --tb=short \
-            --junitxml="$EVIDENCE_DIR/direct.xml" > "$EVIDENCE_DIR/direct.txt" 2>&1
-      - name: Upload verification evidence
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: release-verification
-          path: ${{ runner.temp }}/release-evidence/
-          if-no-files-found: warn
+        run: .venv/bin/twine check dist/*
       - name: Upload distributions
         uses: actions/upload-artifact@v4
         with:
@@ -79,7 +52,7 @@ jobs:
           if-no-files-found: error
 
   publish:
-    needs: build-and-verify
+    needs: build
     runs-on: ubuntu-latest
     environment:
       name: ${{ github.event_name == 'workflow_dispatch' && 'testpypi' || 'pypi' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,15 +18,26 @@ concurrency:
 permissions:
   contents: read
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build-and-verify:
     runs-on: [self-hosted, tilefoundry]
+    container: tilefoundry-ci-runner:local
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Prepare release environment
+        run: |
+          release_venv="$RUNNER_TEMP/release-venv"
+          python -m venv --system-site-packages "$release_venv"
+          "$release_venv/bin/python" -m pip install --upgrade build twine
+          echo "$release_venv/bin" >> "$GITHUB_PATH"
       - name: Install packaging tools
-        run: python -m pip install --upgrade build twine
+        run: python -c 'import build, twine'
       - name: Build tag distributions
         if: github.event_name == 'push'
         run: python -m build
@@ -38,16 +49,19 @@ jobs:
       - name: Check distribution metadata
         run: twine check dist/*
       - name: Link baked cutlass headers
-        run: mkdir -p third_party/cutlass && ln -sf /opt/cutlass/include third_party/cutlass/include
+        run: |
+          mkdir -p third_party/cutlass
+          ln -sfnT /opt/cutlass/include third_party/cutlass/include
       - name: Verify the distribution wheel
         env:
-          EVIDENCE_DIR: ${{ runner.temp }}/release-evidence-${{ github.run_id }}-${{ github.run_attempt }}
-          WHEEL_VENV: ${{ runner.temp }}/release-wheel-${{ github.run_id }}-${{ github.run_attempt }}
+          EVIDENCE_DIR: ${{ runner.temp }}/release-evidence
         run: |
           mkdir -p "$EVIDENCE_DIR"
-          python -m venv --system-site-packages "$WHEEL_VENV"
-          "$WHEEL_VENV/bin/pip" install --no-deps dist/*.whl
-          TF_SMOKE_VENV="$WHEEL_VENV" pytest tests/integration/installed \
+          wheel_venv="$RUNNER_TEMP/release-wheel"
+          python -m venv --system-site-packages "$wheel_venv"
+          "$wheel_venv/bin/python" -m pip install --no-deps dist/*.whl
+          PATH="$wheel_venv/bin:$PATH" TF_SMOKE_VENV="$wheel_venv" \
+            python -m pytest tests/integration/installed \
             -o python_files='smoke_*.py' -q -n 4 --tb=short \
             --junitxml="$EVIDENCE_DIR/direct.xml" > "$EVIDENCE_DIR/direct.txt" 2>&1
       - name: Upload verification evidence
@@ -55,7 +69,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: release-verification
-          path: ${{ runner.temp }}/release-evidence-${{ github.run_id }}-${{ github.run_attempt }}/
+          path: ${{ runner.temp }}/release-evidence/
           if-no-files-found: warn
       - name: Upload distributions
         uses: actions/upload-artifact@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ tilefoundry = "tilefoundry.cli:main"
 
 [project.optional-dependencies]
 test = ["pytest>=8", "pytest-xdist>=3"]
-dev = ["pre-commit>=3"]
+dev = ["pre-commit>=3", "ruff>=0.14", "setuptools>=68", "setuptools-scm>=8"]
 
 [tool.setuptools_scm]
 
@@ -73,6 +73,7 @@ where = ["src"]
 markers = [
     "no_dump: opt out of the autouse DumpScope for tests that emit excessive dump output",
 ]
+pythonpath = ["src"]
 
 [tool.ruff]
 # Snapshot examples are evidence; reformatting them to satisfy lint would change that evidence.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,6 @@ where = ["src"]
 markers = [
     "no_dump: opt out of the autouse DumpScope for tests that emit excessive dump output",
 ]
-pythonpath = ["src"]
 
 [tool.ruff]
 # Snapshot examples are evidence; reformatting them to satisfy lint would change that evidence.

--- a/src/tilefoundry/__init__.py
+++ b/src/tilefoundry/__init__.py
@@ -6,11 +6,16 @@ Re-exports the stable public API from `tilefoundry.ir.*` for convenience.
 
 from __future__ import annotations
 
+from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _distribution_version
 
 # ruff: noqa: I001 -- curated re-export order; alphabetical sort breaks staged imports.
 
-__version__ = _distribution_version("tilefoundry")
+try:
+    __version__ = _distribution_version("tilefoundry")
+except PackageNotFoundError:
+    # A source checkout can be imported before it is installed.
+    __version__ = "0+unknown"
 
 # Core IR
 from tilefoundry.ir.core import (

--- a/src/tilefoundry/__init__.py
+++ b/src/tilefoundry/__init__.py
@@ -6,16 +6,11 @@ Re-exports the stable public API from `tilefoundry.ir.*` for convenience.
 
 from __future__ import annotations
 
-from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _distribution_version
 
 # ruff: noqa: I001 -- curated re-export order; alphabetical sort breaks staged imports.
 
-try:
-    __version__ = _distribution_version("tilefoundry")
-except PackageNotFoundError:
-    # A source checkout can be imported before it is installed.
-    __version__ = "0+unknown"
+__version__ = _distribution_version("tilefoundry")
 
 # Core IR
 from tilefoundry.ir.core import (


### PR DESCRIPTION
## Why

- The self-hosted CI split one validation flow across multiple jobs and repeated functional tests during Release.
- Shared dependencies should remain a read-only base while each checkout owns its `.venv`.

## What

- Run PR CI as one job container with a checkout-local `.venv` for lint, full tests, and wheel smoke.
- Limit Release to building distributions, running `twine check`, and uploading them.
- Align runner and worktree setup scripts with the shared environment plus a worktree-local `.venv`.

## Contract

- Do not commit `uv.lock` or change the dependency ranges in `pyproject.toml`.
- Shared dependencies, CUDA, CUTLASS, and checkpoints remain read-only; job containers do not receive the Docker socket.

## Risk

- Wheel smoke still uses a separate `.wheel-venv` because it must verify a non-editable installation.