### PR TITLE
docs(tutorial,cli): surface advisor commands in opportunity-driven optimization

### DIFF
--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -1,42 +1,28 @@
 # TileFoundry in two steps
 
-The work is two steps, and the second one is a loop.
-
 **Step one — describe the model.** Write the published model as authored HIR: one
-`Module` per boundary somebody will implement, its kernels as `@func`s, its
-weights as `ConstTensor` parameters. What you are building is a *reference* — the
-thing every later answer is measured against. It is finished when it agrees with
-the published implementation on real weights.
+`Module` per boundary somebody will implement, its kernels as `@func`s, its weights
+as `ConstTensor` parameters. That is the *reference*. It is finished when it agrees
+with the published implementation on real weights.
 
-**Step two — make it fast.** Write a runtime twin of one Module, compare it to the
-reference the first step produced, and keep going while the numbers disagree. Then
-take the next Module. Then fuse neighbours and repeat.
+**Step two — make it fast.** The authored HIR stays the reference. Write a runtime
+twin beside it and `check` the two against each other. `analyze` and `schedule`
+report what the program costs and what a plan for it looks like; you decide what to
+do with that, including changing the authored HIR.
 
-## Why the source is the reference
-
-TileFoundry is **source to source**. The Module you author is source code; the fast
-implementation is also source code; both are readable, and each is checkable
-against the other. Nothing is hidden behind an opaque graph, so the two can be put
-side by side and asked whether they compute the same thing.
-
-That is what makes this way of working available at all: pin one point, optimise it
-against a fixed reference, and spread outwards. Without a reference that is itself
-readable source, "is it still correct?" has no cheap answer, and the loop stops
-being a loop.
+TileFoundry is **source to source**. The reference is source code, the fast
+implementation is source code, and either can be pointed at any command.
 
 ## Where the other answers are
 
-This tutorial teaches the **workflow** — what to do, in what order, at what
-granularity. It deliberately does not restate reference material that already has a
-home:
-
 - `tilefoundry spec <topic>` — the normative contracts: the IR, the parser, the
-  runtime, the target. When a page here says "the contract is X", the spec is where
-  X is stated.
+  runtime, the target.
 - `tilefoundry check --help` — the comparison predicates and their bounds, with the
   arithmetic for choosing a tolerance.
+- `tilefoundry analyze --help` — flops, traffic, roofline bounds, a timeline.
+- `tilefoundry schedule --help` — placement, resharding and timing for one topology
+  level.
 - `tilefoundry models` — the models already described, and their authored source to
   copy from.
-- `tilefoundry tutorial orchestrator causal_lm` — the shipped autoregressive
-  decode loop. `tilefoundry models NAME --source` names the model directory to
-  copy from.
+- `tilefoundry tutorial orchestrator causal_lm` — the shipped autoregressive decode
+  loop.

--- a/docs/tutorial/migrate.md
+++ b/docs/tutorial/migrate.md
@@ -1,101 +1,43 @@
 # Step one: describe the published model
 
-The output of this step is a reference: authored HIR that computes what the
-published model computes. Everything after it is measured against this, so it is
-worth getting right before anything is made fast.
-
-The code on this page is not an example written for the page. It is the shipped
-source of `qwen3_5_35b_a3b`, quoted by name — a hybrid model, because a
-dense one cannot show you the thing that catches people out: layers of two
-different kinds in a published cycle.
-
-`tilefoundry models qwen3_5_35b_a3b --source` names the directory that holds it
-and lists the shipped files.
-
-## The five access faces
-
-One Module, five things you can ask it for. Mixing them up is the most common
-first-day confusion, so they are listed together:
-
-| expression | what you get |
-|---|---|
-| `Mod.some_func(*all parameters)` | runs it; nothing is bound, so `ConstTensor` parameters are passed explicitly |
-| `Mod.some_child` | the child `Module` node |
-| `Mod.lookup("some_func")` | the `ModuleFunction` IR node |
-| `loaded.some_func(*activations only)` | runs it; `ConstTensor` parameters come from this loading's bindings |
-| `loaded.some_child` | the child `LoadedModule` |
-
-What `entry` means, how `forward` relates to `__call__`, and what a twin may and
-may not declare are stated once, normatively, in `tilefoundry spec runtime 1.1`.
-Read it there rather than here: a second copy is the one that goes stale.
-
-## The four things to get right
-
-Each of these is a decision you make in the first ten minutes and pay for later.
-The comment on the biting line in the shipped source says what it costs.
-
-### 1. A weight is a `ConstTensor` parameter
-
-Weights are declared, not passed. A `ConstTensor` parameter is what puts a tensor
-in `Module.weights`, which is what `load(resource)` binds and what the runtime twin
-reads by name. Declare it as a plain `Tensor` and none of that happens: the Module
-owns no weights, `load` has nothing to bind, and every caller has to hand the
-tensor over positionally, forever.
+Write the published model as authored HIR. One Module per boundary somebody will
+implement, its kernels as `@func`s, its weights as `ConstTensor` parameters:
 
 {{fixture: qwen3_5_35b_a3b/model.py:Qwen3_5Router}}
 
-### 2. The decode contract: one token, a prior cache, and this step's own K/V
+The whole of `qwen3_5_35b_a3b` is written that way. Read the model itself rather
+than a description of it: `tilefoundry models qwen3_5_35b_a3b` prints its Module
+forest, and `--source` names the directory and lists its files.
 
-A decode step is handed the cache before it and the token it is adding. Two
-declarations state that, and they are the whole contract:
+## What each part of a declaration means
 
-{{fixture: qwen3_5_35b_a3b/model.py:S}}
+- A `ConstTensor` parameter is a weight. It lands in `Module.weights`, `load(resource)`
+  binds it, and a runtime twin reads it by name; a plain `Tensor` parameter does none
+  of that — [core-ir §1](../spec/core-ir.md#1-module).
+- `entry` names the function the Module runs by default. What a runtime twin may and
+  may not declare is [runtime §1.1](../spec/runtime.md#11-runtimemodule).
+- A dimension the model leaves open is a `DimVar` and appears in types. A decode step
+  takes the prior cache and returns its own entry; for the fixed-capacity form see
+  [hir § CacheUpdate](../spec/hir.md#cacheupdate).
+- The root Module declares the target its tree runs on and the topology levels it
+  divides over — [target §6](../spec/target.md#6-target-ownership-and-compile-resolution).
+- A weight whose published layout differs from the one a `@func` wants is converted by
+  `@<func>.converter` — [runtime §1.1.2](../spec/runtime.md#112-weight-converter-and-prepare--forward).
+- Dimensions come from the published config. `head_dim` is a published field, not
+  `hidden ÷ num_heads`; for this model those differ.
 
-{{fixture: qwen3_5_35b_a3b/model.py:C}}
+## The five access faces
 
-`ctx_len` is the length of the **prior** cache and starts at 0 — a first step has
-nothing cached and attends the one position it brings itself. The exclusive upper
-bound is one past the longest prior cache the model admits, which for this model is
-`config.max_ctx`; read the field's own meaning before copying the form, because it
-differs between published models.
-
-The step takes `k_cache` / `v_cache` and hands back the entry its caller appends.
-Two forms fit different callers; which one fits is a property of the caller, not
-a preference.
-
-| Form | Fits when | Cost |
-|---|---|---|
-| Caller-managed concat | The cache grows each step, execution is eager, or `ctx_len` participates in types as a `DimVar`. | Each step replaces the cache buffer, so one fixed-address graph cannot replay it. |
-| `cache_update` | The cache has fixed capacity, its write window advances each step, or it must be captured and replayed in a CUDA graph. | Shape stays static, the write window is runtime data, and traffic falls back to the whole tensor when its bounds cannot be derived. |
-
-See [spec hir § CacheUpdate](../spec/hir.md#cacheupdate) for the operation's
-contract.
-
-{{fixture: qwen3_5_35b_a3b/model.py:Qwen3_5FullAttention.full_attention}}
-
-### 3. Dimensions come from the published config, not from arithmetic
-
-`head_dim` is a published field. It is **not** `hidden ÷ num_heads` — for this
-model those differ, and a fixture that computed it would be wrong in a way every
-shape check would accept. The same holds for `rotary_dim`, which is
-`partial_rotary_factor` of the head, and for `vocab`.
-
-{{fixture: qwen3_5_35b_a3b/model.py:_D}}
-
-{{fixture: qwen3_5_35b_a3b/model.py:_ROT}}
-
-### 4. The layer-type cycle is stated, not inferred
-
-A hybrid model publishes which kind each layer is. The root reads that list and
-builds the stack from it, so the cycle is a fact of the model rather than something
-a reader of the fixture has to work out.
-
-{{fixture: qwen3_5_35b_a3b/model.py:Qwen3_5_35B_A3B}}
+| expression | what you get |
+|---|---|
+| `Mod.some_func(*all parameters)` | runs it; `ConstTensor` parameters are passed explicitly |
+| `Mod.some_child` | the child `Module` node |
+| `Mod.lookup("some_func")` | the `ModuleFunction` IR node |
+| `loaded.some_func(*activations only)` | runs it; `ConstTensor` parameters come from this loading |
+| `loaded.some_child` | the child `LoadedModule` |
 
 ## When step one is finished
 
 Prepare real weights first ([runtime §1.1.2](../spec/runtime.md#112-weight-converter-and-prepare--forward)).
 Step one is finished when the authored Module agrees with the published
-implementation at production dimensions. That is a comparison, which is what step
-two's tool does — so the next page is the one that runs it, and you will use it here
-first.
+implementation at production dimensions. `check` is the command that says so.

--- a/docs/tutorial/optimize.md
+++ b/docs/tutorial/optimize.md
@@ -1,108 +1,61 @@
 # Step two: make it fast
 
-This is the page about *how to work*, not about which flags exist. The order and
-the granularity are the whole content; every command mentioned has its own
-`--help`.
+The authored HIR stays the reference. Everything here is written beside it.
 
-## The constraint that sets the granularity
+1. **Write a runtime twin** of one Module. `@runtime_module` checks at decoration
+   time that the twin's function names and child names are exactly the authored
+   Module's, so a twin covers a whole Module at once —
+   [runtime §1.1](../spec/runtime.md#11-runtimemodule).
 
-`@runtime_module` checks, at decoration time, that the twin's function names and
-child names are exactly the authored Module's. Not a subset — equal.
+2. **Check it.** `check` runs the implementation and its reference and says, output
+   by output, whether it meets the bounds you stated. The reference is the authored
+   Module through the evaluator, so the comparison is available from the twin's
+   first line. `tilefoundry check --help` has the predicates and the arithmetic for
+   choosing a tolerance.
 
-So **there is no half a twin.** You cannot implement one kernel of a Module and
-leave the rest for later, which means the unit you extend by is a Module, never a
-function. Pick your Module boundaries in step one with that in mind: a boundary is
-a thing somebody will have to implement all of, at once.
+3. **Ask for evidence when you want it.** `analyze` reports what the authored
+   program costs: flops, traffic, roofline bounds, a timeline. `schedule` proposes
+   a plan for one topology level you name: placement, resharding, timing. Both read
+   the authored source, both are optional, and neither decides anything.
+   `tilefoundry analyze --help` and `tilefoundry schedule --help` say what each
+   reports.
 
-## The loop
+4. **Change the authored HIR when that is the answer.** Fusion is done by writing
+   the fused form: two equations in one `@func`, two `@func`s merged into one, or
+   work that crossed several Modules pulled into one. For a CUDA target one `@func`
+   is one kernel symbol ([codegen §4.1](../spec/codegen.md#41-linkablefunction)), so
+   a bigger `@func` is a bigger kernel. The fused Module's twin is then an ordinary
+   twin, written the same way.
 
-```python
-def optimize(module):
-    # Leaves first: a parent's numbers are only meaningful once the children it
-    # calls are trusted, and a leaf is the smallest thing with a reference.
-    for leaf in sorted(leaves_of(module), key=how_easily_judged):
+5. **Repeat wherever there is an opportunity.** There is no required order and no
+   point at which some change becomes allowed.
 
-        # Inner loop: write the twin, compare, fix what disagrees. The reference
-        # is the authored leaf run through the evaluator, so the comparison is
-        # available from the first line of the twin onwards.
-        while True:
-            report = check(twin=your_twin_of(leaf), reference=leaf, inputs=...)
-            if report.passed:
-                break
-            fix(report)                       # the report names the output and the predicate
+## Working on a copy
 
-        # A dimension nobody bound was pinned to run at all. That pin is a
-        # decision, and it is reported precisely so it can become a real one.
-        if report.unresolved_dimvars:
-            specialize(leaf, over=report.unresolved_dimvars)
-            # And then check that dispatch lands where you think: run several
-            # extents across the boundary and read back which variant each chose.
-            check(twin=..., reference=..., dims={name: [several, extents]})
-
-    # Assemble upwards. Every child is trusted before its parent is measured, so a
-    # parent that disagrees has exactly one new suspect: the parent.
-    for parent in bottom_up(module):
-        check(twin=your_twin_of(parent), reference=parent, inputs=...)
-
-    # Fusion is the same loop at a coarser boundary. Rewrite the source so two
-    # neighbours become one Module -- your copy, since the authored one is the
-    # reference and must not move -- and optimise that.
-    coarse = your_copy_of(module.source, fusing=adjacent_boundaries)
-    optimize(coarse)
-```
-
-When to stop is yours to judge. Nothing in here decides that the numbers are good
-enough; it only makes sure that whatever you decide, you decided it against a
-reference and not against the last thing you happened to measure.
-
-## Where your copy comes from
-
-`your_copy_of` starts with the shipped directory:
+The shipped model directory is the reference and lives in the installation. Copy it
+before changing it:
 
 ```sh
 source=$(tilefoundry models qwen3_5_35b_a3b --source | sed -n '1p')
 cp -r "$source" mine
 ```
 
-Then edit `mine/model.py` — merge two of a Module's functions into one, move a
-boundary, whatever the fusion is — and point the tools at it:
+Every command takes `file:Class[.child...][.function]`, and the file is any file you
+can read:
 
 ```sh
 tilefoundry check mine/model.py:MyFused.fused --inputs random --out output \
     --fn allclose --atol 1e-6 --rtol 1e-6
+tilefoundry analyze mine/model.py:MyFused --roofline
+tilefoundry schedule mine/model.py:MyFused --topology cta --first-plan
 ```
 
-A target is `file:Class[.child...][.function]`, and that file is any file you can
-read. Nothing in the command surface knows or cares that the shipped models exist,
-so a fused copy is not a special case: it is the ordinary case pointed at your file.
+`analyze` and `schedule` need a Module that reaches a declared target, so name it
+from the root down.
 
-You do not have to protect the original. The directory `--source` names lives in
-the installation, and an installation is not where you edit — so the reference
-stays the reference because of where it sits, not because anything stops you.
-Keeping it intact is the point: the moment you fuse, that copy is the only thing
-that still says what the answer was supposed to be.
+## What check cannot do
 
-## Siblings are independent; a parent is not
-
-There is no dependency edge between siblings. Two leaves under one parent neither
-call nor constrain each other, so they can be worked on — and checked — in parallel,
-by different people or in any order you like.
-
-The parent is the opposite: it depends on **every** child. Its numbers only mean
-something once all of them are trusted, which is why the loop finishes the whole
-row of leaves before it measures the thing above them.
-
-## Why in that order
-
-- **Leaves before parents**, and *easiest to judge* before hardest, because a
-  failing comparison should have one suspect. If you implement a parent first, a
-  disagreement could be the parent or any child under it.
-- **Compare before you specialize.** A run that was pinned to one extent is a real
-  run and may already be right; specializing first commits you to variants you have
-  no evidence you need.
-- **Verify dispatch after you specialize**, at several extents. Variants are chosen
-  by size, and a boundary that picks the wrong implementation still produces a
-  plausible number.
-- **Fuse last, and by rewriting source.** Fusion changes the boundaries, so it
-  invalidates the reference you were using; the way through is a new copy whose
-  reference is the old one, which is the recursion above.
+A fused boundary replaces a composition of unfused ones. `check` compares one
+implementation against one reference; it cannot take several composed unfused
+boundaries on one side and one fused boundary on the other. That equivalence stays
+yours to keep, at a boundary the commands can express.

--- a/src/tilefoundry/cli/__init__.py
+++ b/src/tilefoundry/cli/__init__.py
@@ -7,11 +7,14 @@ import sys
 from typing import Sequence
 
 from tilefoundry.analysis import AnalysisError, ExtractError
-from tilefoundry.cli.analyze import ANALYSES, run_authored_analysis
+from tilefoundry.cli.analyze import ANALYSES, EVIDENCE, run_authored_analysis
+from tilefoundry.cli.analyze import guidance as analyze_guidance
 from tilefoundry.cli.check import add_arguments as add_check_arguments
-from tilefoundry.cli.check import guidance, run_check
+from tilefoundry.cli.check import guidance as check_guidance
+from tilefoundry.cli.check import run_check
 from tilefoundry.cli.inspect import run_capabilities
 from tilefoundry.cli.models import run_models
+from tilefoundry.cli.schedule import guidance as schedule_guidance
 from tilefoundry.cli.schedule import run_schedule
 from tilefoundry.cli.source import load_authored_ir, one_extent_per_dim, parse_dims
 from tilefoundry.cli.spec import read_spec, run_spec, spec_path
@@ -29,8 +32,12 @@ _COMMANDS = {
     "spec": "read one specification: its sections, or one of them",
     "tutorial": "learn the two-step workflow: its pages, or one of them",
     "check": "compare an implementation against its reference, output by output",
-    "analyze": "type-check and analyze authored HIR",
-    "schedule": "schedule authored HIR at one declared topology level",
+    # Named by the evidence they report, not by what they read. Both read authored
+    # HIR, which is step one's output, so a description that led with the input read
+    # as "step one's command" -- and a reader who has finished step one never opened
+    # them again.
+    "analyze": "report what a program costs: flops, traffic, bounds, timing",
+    "schedule": "propose a plan for one topology level: placement and timing",
     "inspect": "inspect installed target facts",
 }
 
@@ -164,17 +171,20 @@ def build_parser() -> argparse.ArgumentParser:
     check = commands.add_parser(
         "check",
         help=_COMMANDS["check"],
-        epilog=guidance(),
+        epilog=check_guidance(),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     add_check_arguments(check)
 
-    analyze = commands.add_parser("analyze", help=_COMMANDS["analyze"])
+    analyze = commands.add_parser(
+        "analyze",
+        help=_COMMANDS["analyze"],
+        epilog=analyze_guidance(),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     _add_source_argument(analyze)
     for analysis in _ANALYSES:
-        analyze.add_argument(
-            f"--{analysis}", action="store_true", help=f"run the {analysis} analysis"
-        )
+        analyze.add_argument(f"--{analysis}", action="store_true", help=EVIDENCE[analysis])
     analyze.add_argument(
         "--dim",
         action="append",
@@ -185,7 +195,12 @@ def build_parser() -> argparse.ArgumentParser:
         "--json", action="store_true", help="print the report as JSON instead of text"
     )
 
-    schedule = commands.add_parser("schedule", help=_COMMANDS["schedule"])
+    schedule = commands.add_parser(
+        "schedule",
+        help=_COMMANDS["schedule"],
+        epilog=schedule_guidance(),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     _add_source_argument(schedule)
     schedule.add_argument(
         "--topology",

--- a/src/tilefoundry/cli/analyze.py
+++ b/src/tilefoundry/cli/analyze.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+import textwrap
 from typing import Mapping
 
 from tilefoundry.analysis.api import analyze
@@ -16,8 +17,47 @@ from tilefoundry.inspection.analysis_report import (
 )
 from tilefoundry.ir.hir.specialize import dim_vars_reached
 
+#: What each root analysis reports. One table, so the flag that asks for an
+#: analysis and the help that explains it cannot name different evidence.
+EVIDENCE: dict[str, str] = {
+    "compute-cost": "the logical work and traffic of every value: flops by dtype, bytes moved",
+    "memory": "where that traffic lands, and the footprint it holds live against the capacity",
+    "roofline": "which of compute or memory limits each value, and the limit in time",
+    "timeline": "when each value runs under those limits, and over how many units",
+}
+
 # The root analyses `analyze` can be asked for, in the order they are reported.
-ANALYSES = ("compute-cost", "memory", "roofline", "timeline")
+ANALYSES: tuple[str, ...] = tuple(EVIDENCE)
+
+
+def guidance() -> str:
+    """What the command reports, and what it leaves to whoever read it.
+
+    What each analysis reports is not restated here: the flags above already say
+    it, off the same table, and a second copy is one more thing that can drift.
+    """
+    return textwrap.dedent(
+        """\
+        evidence, not a decision. This reports what a program would cost. It
+        searches nothing, rewrites nothing, and picks no optimization: what to do
+        about a number is yours.
+
+        Complete inferred types are printed whatever the flags are; each flag above
+        adds one root analysis, and with no flag every one of them runs.
+
+        It reads the authored program, so it answers before any implementation of it
+        exists -- and its numbers are the floor an implementation is read against,
+        not a measurement of one. That is the whole use: without an independent
+        bound, the fastest thing you have measured becomes the ceiling you believe
+        in, and "already at roofline" is a claim about your own best attempt.
+        Reading authored HIR is what it takes as input; making something fast is
+        what it is for.
+
+        The selection must be a Module that reaches a declared target, so name it
+        from the root down. That Module's resolved Target is the hardware every
+        number is measured against, which is why there is no --target.
+        """
+    )
 
 
 def run_authored_analysis(
@@ -68,4 +108,4 @@ def run_authored_analysis(
     return 0
 
 
-__all__ = ["ANALYSES", "run_authored_analysis"]
+__all__ = ["ANALYSES", "EVIDENCE", "guidance", "run_authored_analysis"]

--- a/src/tilefoundry/cli/schedule.py
+++ b/src/tilefoundry/cli/schedule.py
@@ -3,11 +3,41 @@
 from __future__ import annotations
 
 import sys
+import textwrap
 from dataclasses import replace
 from typing import Mapping
 
 from tilefoundry.cli.source import entry_function, load_authored_ir
 from tilefoundry.schedule import ScheduleOptions, schedule
+
+
+def guidance() -> str:
+    """What the plan is, and what it is not."""
+    return textwrap.dedent(
+        """\
+        advice, not a rewrite. By the time you ask, you have already chosen the
+        program, the logical tile, the fusion boundary and the level -- this answers
+        what a plan at that level costs, and nothing about whether you chose well.
+
+        It does not rewrite the source, is not a stage of compilation, and decides
+        nothing: accept the plan, reject it, or change the candidate and ask again.
+        The Module it answers about is the one you handed it, unchanged.
+
+        What a plan says is the level's own algorithm's to say, so two levels answer
+        in different shapes. A CUDA partition plan names where each step sits across
+        the level's positions, the layout changes it needs -- including the ones it
+        synthesized for you -- and the interval each step lands in against the bound.
+
+        A search that ends with no answer is reported as the search ending, not as
+        the selection having no schedule. --first-plan asks for a plan rather than
+        the best one, which is what you want while you are still deciding whether
+        the candidate is worth the search at all.
+
+        --topology must name a level the Module declares. The target is not a flag:
+        it is the selected Module's own, because a kernel is authored against one
+        target.
+        """
+    )
 
 
 def run_schedule(
@@ -45,4 +75,4 @@ def run_schedule(
     return 0
 
 
-__all__ = ["run_schedule"]
+__all__ = ["guidance", "run_schedule"]

--- a/src/tilefoundry/inspection/analysis_report.py
+++ b/src/tilefoundry/inspection/analysis_report.py
@@ -401,34 +401,19 @@ def render_text(data: dict[str, object]) -> str:
     if "timeline" in records:
         lines.append(f"theoretical-makespan={records['timeline']['end_ns']}ns")
     for call in data["calls"]:
-        parts = [f"value={call['value']}"]
-        if "compute-cost" in call:
-            cost = call["compute-cost"]
-            parts.append(
-                "flops="
-                + (
-                    ",".join(
-                        f"{name}:{value}"
-                        for name, value in sorted(cost["flops"].items())
-                    )
-                    or "0"
-                )
-            )
-        if "roofline" in call:
-            parts.append(f"bound={call['roofline']['theoretical_ns']}ns")
-        if "timeline" in call:
-            timeline = call["timeline"]
-            parts.append(
-                f"placement={timeline['start_ns']}-{timeline['end_ns']}ns "
-                f"units={timeline['grid_units']} waves={timeline['waves']}"
-            )
-        lines.append(" ".join(parts))
+        # Only what the annotated program does not already say on the value's own
+        # line. Its flops, its bound and its placement are all there, against the
+        # name that produced them; repeating them here made the report a second
+        # copy of the program, and the copy was the one whose labels are ambiguous.
+        # The per-operand split is not there -- the annotation carries the sum --
+        # so this is where it lives, and text and `--json` still agree.
         operands = call.get("compute-cost", {}).get("operands")
-        if operands is not None:
-            lines.append(
-                "  operands "
-                + ", ".join(_operand_text(operand) for operand in operands)
-            )
+        if operands is None:
+            continue
+        lines.append(
+            f"value={call['value']} operands "
+            + ", ".join(_operand_text(operand) for operand in operands)
+        )
     return "\n".join(f"# {line}" for line in lines)
 
 

--- a/src/tilefoundry/inspection/python_printer.py
+++ b/src/tilefoundry/inspection/python_printer.py
@@ -101,21 +101,22 @@ def _compact_type(ty: object) -> str:
     return repr(ty)
 
 
-def _comments(
-    expr: Expr,
-    options: PythonPrintOptions,
-    *,
-    include_binding: bool = False,
-    emitted_name: str | None = None,
-) -> str:
+def _comments(expr: Expr, options: PythonPrintOptions) -> str:
+    """The same-line annotations for one printed statement.
+
+    The binding label is not among them. It is the name on the left of the very
+    line these comments sit on -- printing it again as ``loc="x"`` said ``x``
+    twice, and said the *emitted* name at that, so the one thing a second copy
+    could have carried (that two printed values share one authored label) was
+    what it dropped. Re-parsing recovers the label from the left-hand side.
+
+    The type carries no key either. The fragment is a type, which is what a type
+    annotation looks like, so ``type=`` in front of it was a word saying what the
+    reader can already see.
+    """
     comments: list[str] = []
-    authored_name = binding_name(expr)
-    if include_binding and authored_name is not None:
-        label = emitted_name or authored_name
-        if label:
-            comments.append(f'loc="{label}"')
     if options.show_types:
-        comments.append(f"type={_compact_type(expr.type)}")
+        comments.append(_compact_type(expr.type))
     for metadata_type in options.comment_metadata_types:
         metadata = get_metadata(expr, metadata_type)
         if metadata is None:
@@ -892,7 +893,7 @@ def _emit_def(
         name = _names[id(expr)]
         lines.append(
             f"{level}{name} = {_format_call(expr, level)}"
-            f"{_comments(expr, options, emitted_name=name)}"
+            f"{_comments(expr, options)}"
         )
         printed.add(id(expr))
 
@@ -984,7 +985,7 @@ def _emit_def(
             name = _names[id(expr)]
             lines.append(
                 f"{indent}{name} = {_format_call(expr, indent)}"
-                f"{_comments(expr, options, include_binding=True, emitted_name=name)}"
+                f"{_comments(expr, options)}"
             )
             line = _constraint_line(expr, indent, name)
             if line is not None:

--- a/tests/inspection/test_python_printer.py
+++ b/tests/inspection/test_python_printer.py
@@ -1,9 +1,9 @@
 """Inspection printer: what the emitted source carries besides the program.
 
 The program itself round-trips on every corpus model. What has no such witness is
-the material around it — an opt-in type annotation, the ``# loc`` comment that
-names a binding, and the target header, whose value must rebuild the *same*
-Target when the emitted source is executed.
+the material around it — an opt-in type annotation, the binding label the emitted
+left-hand side carries, and the target header, whose value must rebuild the
+*same* Target when the emitted source is executed.
 """
 
 from dataclasses import replace
@@ -28,14 +28,17 @@ def test_inspection_types_are_opt_in_same_line_comments():
     annotated = as_script(fn, options=PythonPrintOptions(show_types=True))
 
     assert canonical != annotated
-    assert "type=Tensor[" in annotated
+    assert "# Tensor[" in annotated
+    # Same line as the statement it types, never a line of its own: a comment the
+    # reader has to look up is a comment about a different program.
     assert all(
-        not line.lstrip().startswith("# type=")
+        line.split("# Tensor[")[0].strip()
         for line in annotated.splitlines()
+        if "# Tensor[" in line
     )
 
 
-def test_binding_metadata_preserves_the_canonical_loc_comment():
+def test_binding_metadata_names_the_emitted_binding():
     tensor_type = TensorType.scalar(DType.f32)
     source = Var(name="source", type=tensor_type)
     result = Call(
@@ -53,8 +56,9 @@ def test_binding_metadata_preserves_the_canonical_loc_comment():
 
     canonical = as_script(function)
 
+    # The label is the emitted name, and the emitted name is the whole record of
+    # it: re-parsing reads it back off the left-hand side.
     assert "result = add(source, source)" in canonical
-    assert '# loc="result"' in canonical
 
     unbound = Call(
         target=Binary(kind=BinaryKind.ADD),
@@ -67,7 +71,8 @@ def test_binding_metadata_preserves_the_canonical_loc_comment():
         body=unbound,
         return_type=tensor_type,
     )
-    assert "# loc=" not in as_script(unbound_function)
+    # Nothing to name it after, so the printer numbers it.
+    assert "v0 = add(source, source)" in as_script(unbound_function)
 
 
 class TestPythonPrinterTargetRoundTrip:

--- a/tests/inspection/test_roundtrip.py
+++ b/tests/inspection/test_roundtrip.py
@@ -70,8 +70,10 @@ def test_insert_slice_tuple_offset_arg_roundtrips() -> None:
 def test_shadowed_call_loc_roundtrips() -> None:
     """When a call's source loc collides with an op name (``vals, idx = topk``
     gives the ``topk`` call loc ``"topk"``), the printer renames the binding to
-    ``topk_out`` to avoid shadowing the op; the emitted ``# loc`` comment must
-    reflect the emitted binding, so the source re-parses and re-prints identically."""
+    ``topk_out`` to avoid shadowing the op. The renamed binding is carried by the
+    left-hand side and nothing else, so re-printing the re-parsed source is what
+    proves the label survived: had it come back as ``topk``, the fixed point would
+    not hold."""
     fn = parse_script(
         _HEADER
         + "\n@func\n"
@@ -81,7 +83,6 @@ def test_shadowed_call_loc_roundtrips() -> None:
     )
     script = as_script(fn)
     assert 'topk_out = topk(' in script, script
-    assert 'loc="topk_out"' in script and 'loc="topk"' not in script, script
     assert as_script(parse_script(script)) == script
 
 

--- a/tests/installed/smoke_analyze.py
+++ b/tests/installed/smoke_analyze.py
@@ -75,7 +75,7 @@ def test_analyze_json_and_text_report_the_same_conclusions(tf, cwide) -> None:
     assert f"by={payload['function_records']['roofline']['bound_by']}" in text
 
     assert text.startswith("# analysis target=cuda module=Model function=main")
-    assert "type=Tensor[" in text
+    assert "# Tensor[" in text
     assert "compute-cost flops=f32:" in text
     assert "roofline bound=" in text
     assert "timeline units=168 waves=2" in text


### PR DESCRIPTION
## Why
- The tutorial names `check` ten times and `analyze` / `schedule` zero times, so the workflow has no edge to either. Both one-line help descriptions lead with "authored HIR" — step one's output — so a reader who has finished step one files them under a finished step. A pilot round spent an hour rebuilding by measurement what `analyze --roofline` reports statically, then reported headroom against its own fastest run instead of an independent bound.
- `optimize.md` ordered fusion last and never said that a bigger CUDA `@func` is a bigger kernel. All three pages explained why more than they stated what, and `migrate.md` re-narrated the model source declaration by declaration when `tilefoundry models --source` already hands it over.
- `analyze` printed every value's flops, bound and placement twice — once in the report header, once inline — and the header is the copy whose label is ambiguous. `loc="x"` restated the left-hand side on the same line by construction.

## What
- Step two is stated as a method: keep the authored HIR as the reference, write a runtime twin, `check` it, ask `analyze` and `schedule` for evidence when you want it, change the authored HIR when that is the answer, repeat wherever there is an opportunity. No `Fuse last`, no required traversal.
- Both commands are described by what they report rather than what they read, and each grows an `epilog` the way `check` already has one. Fusion granularity, the kernel-symbol fact, and the validation limit are stated: `check` cannot put several composed unfused boundaries on one side and one fused boundary on the other.
- Pages cut to what they state: index 42 → 28 lines, migrate 101 → 43, optimize 108 → 61. `migrate` shows one shipped Module, then a line and a spec link per thing a declaration means.
- `analyze` output: per-value header lines removed, keeping the per-operand traffic split that no inline annotation carries; `loc=` removed; the type comment drops its `type=` prefix. 54 → 45 lines on one router.

## Contract
- No behavior change to what `analyze`, `schedule` or `check` compute, select or accept, and no `docs/spec/*.md` change. Command display order, `ScheduleResult.module`, and the reporting contracts are untouched.
- Removing `loc=` does not weaken round-tripping: the label comes back off the left-hand side, and `test_shadowed_call_loc_roundtrips`' fixed-point assertion is what proves it.
- `as_script` has one consumer outside `inspection`: `_canonical_module_text` in `compile.py`, which feeds the JIT cache key. Every key therefore changes. It stays discriminating — `loc=` only ever repeated the left-hand side, which is still in the text — and two programs differing only in a binding name still hash apart (checked directly). `_jit_cache` is an in-process dict, so no stored cache is invalidated and no stale entry can be mis-hit.

## Risk
- Tutorial and help prose are accepted by human reading, not by assertions; no new prose pins were added, and every existing pin in `tests/installed/smoke_tutorial.py` still holds unchanged.
- The report still labels a value by its authored label, which several printed values may share. The surviving line is distinguishable by its operand names; making the two labelings agree would mean sharing the printer's SSA naming and is left out.

Evidence: pre-commit (all files), 644 passed (`tests/`, 4 workers), and 158 passed on the installed surface against a built wheel; both `analyze` and `schedule` tutorial commands run as written.
