### PR TITLE
feat(codegen,runtime): emit the unary kinds the DSL already exposes

### DIFF
--- a/include/tilefoundry/runtime/cuda/ops/unary.cuh
+++ b/include/tilefoundry/runtime/cuda/ops/unary.cuh
@@ -25,6 +25,46 @@ struct square_op {
 struct identity_op {
     template <class T> __device__ T operator()(T x) const { return x; }
 };
+// Transcendentals go through the precise `<math.h>` forms (`expf`, not
+// `__expf`), so a compiled kernel matches the evaluator's torch oracle rather
+// than the faster intrinsic's looser result.
+struct exp_op {
+    template <class T> __device__ T operator()(T x) const {
+        return static_cast<T>(expf(static_cast<float>(x)));
+    }
+};
+struct exp2_op {
+    template <class T> __device__ T operator()(T x) const {
+        return static_cast<T>(exp2f(static_cast<float>(x)));
+    }
+};
+struct log_op {
+    template <class T> __device__ T operator()(T x) const {
+        return static_cast<T>(logf(static_cast<float>(x)));
+    }
+};
+struct log2_op {
+    template <class T> __device__ T operator()(T x) const {
+        return static_cast<T>(log2f(static_cast<float>(x)));
+    }
+};
+struct abs_op {
+    template <class T> __device__ T operator()(T x) const {
+        return static_cast<T>(fabsf(static_cast<float>(x)));
+    }
+};
+struct ceil_op {
+    template <class T> __device__ T operator()(T x) const {
+        return static_cast<T>(ceilf(static_cast<float>(x)));
+    }
+};
+// `rintf` rounds halfway cases to even, which is what the torch oracle does;
+// `roundf` rounds them away from zero and would disagree at every .5.
+struct round_op {
+    template <class T> __device__ T operator()(T x) const {
+        return static_cast<T>(rintf(static_cast<float>(x)));
+    }
+};
 
 #include "unary/unary_impl.h"
 

--- a/src/tilefoundry/codegen/cuda/tir/arith.py
+++ b/src/tilefoundry/codegen/cuda/tir/arith.py
@@ -23,7 +23,17 @@ _UNARY_TAG = {
     UnaryKind.NEG: "tilefoundry::ops::neg_op",
     UnaryKind.RELU: "tilefoundry::ops::relu_op",
     UnaryKind.SQUARE: "tilefoundry::ops::square_op",
+    UnaryKind.EXP: "tilefoundry::ops::exp_op",
+    UnaryKind.EXP2: "tilefoundry::ops::exp2_op",
+    UnaryKind.LOG: "tilefoundry::ops::log_op",
+    UnaryKind.LOG2: "tilefoundry::ops::log2_op",
+    UnaryKind.ABS: "tilefoundry::ops::abs_op",
+    UnaryKind.CEIL: "tilefoundry::ops::ceil_op",
+    UnaryKind.ROUND: "tilefoundry::ops::round_op",
 }
+# ``CAST`` is emitted by its own handler, and ``NOT`` is a boolean operation
+# whose element type is not the float path these functors assume; both are
+# deliberately absent rather than pending.
 
 
 

--- a/tests/integration/test_unary_codegen.py
+++ b/tests/integration/test_unary_codegen.py
@@ -1,0 +1,124 @@
+"""Every unary kind the DSL exposes compiles and matches its torch oracle.
+
+`tf.exp`, `tf.log`, `tf.abs` and friends type-infer and evaluate, but only a
+handful of `UnaryKind` members had a `_UNARY_TAG` row and a runtime functor, so
+the rest could be written and checked and then failed to emit.
+
+Each kernel here is a separate top-level function: the compiled artifact is
+cached per function, so a factory producing several same-named kernels would
+hand every op whichever one compiled first.
+
+Exactness matters for two of these. `round` must break halfway cases to even to
+agree with torch — `roundf` would send them away from zero instead — so the
+input grid below lands exactly on `.5`. The transcendentals use the precise
+`<math.h>` entries rather than the `__`-prefixed intrinsics, which is why they
+are compared at a tight tolerance rather than a loose one.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+import tilefoundry
+from tilefoundry import func
+from tilefoundry.dsl import Tensor, tf
+from tilefoundry.dsl.storage import gmem, rmem
+from tilefoundry.ir.types.shard import Layout, Mesh, Topology
+
+_ROWS, _COLS = 64, 32
+
+
+@func(topologies=(Topology("cta", _ROWS),))
+def u_exp(a: Tensor[(_ROWS, _COLS), "f32"]) -> Tensor[(_ROWS, _COLS), "f32"]:
+    with Mesh(topology="cta", layout=Layout(shape=(_ROWS,), strides=(1,))) as cta:
+        r = tf.reshard(a, layout=(_ROWS @ cta, _COLS), storage=rmem)
+        return tf.reshard(tf.exp(r), layout=(_ROWS @ cta, _COLS), storage=gmem)
+
+
+@func(topologies=(Topology("cta", _ROWS),))
+def u_exp2(a: Tensor[(_ROWS, _COLS), "f32"]) -> Tensor[(_ROWS, _COLS), "f32"]:
+    with Mesh(topology="cta", layout=Layout(shape=(_ROWS,), strides=(1,))) as cta:
+        r = tf.reshard(a, layout=(_ROWS @ cta, _COLS), storage=rmem)
+        return tf.reshard(tf.exp2(r), layout=(_ROWS @ cta, _COLS), storage=gmem)
+
+
+@func(topologies=(Topology("cta", _ROWS),))
+def u_log(a: Tensor[(_ROWS, _COLS), "f32"]) -> Tensor[(_ROWS, _COLS), "f32"]:
+    with Mesh(topology="cta", layout=Layout(shape=(_ROWS,), strides=(1,))) as cta:
+        r = tf.reshard(a, layout=(_ROWS @ cta, _COLS), storage=rmem)
+        return tf.reshard(tf.log(r), layout=(_ROWS @ cta, _COLS), storage=gmem)
+
+
+@func(topologies=(Topology("cta", _ROWS),))
+def u_log2(a: Tensor[(_ROWS, _COLS), "f32"]) -> Tensor[(_ROWS, _COLS), "f32"]:
+    with Mesh(topology="cta", layout=Layout(shape=(_ROWS,), strides=(1,))) as cta:
+        r = tf.reshard(a, layout=(_ROWS @ cta, _COLS), storage=rmem)
+        return tf.reshard(tf.log2(r), layout=(_ROWS @ cta, _COLS), storage=gmem)
+
+
+@func(topologies=(Topology("cta", _ROWS),))
+def u_abs(a: Tensor[(_ROWS, _COLS), "f32"]) -> Tensor[(_ROWS, _COLS), "f32"]:
+    with Mesh(topology="cta", layout=Layout(shape=(_ROWS,), strides=(1,))) as cta:
+        r = tf.reshard(a, layout=(_ROWS @ cta, _COLS), storage=rmem)
+        return tf.reshard(tf.abs(r), layout=(_ROWS @ cta, _COLS), storage=gmem)
+
+
+@func(topologies=(Topology("cta", _ROWS),))
+def u_ceil(a: Tensor[(_ROWS, _COLS), "f32"]) -> Tensor[(_ROWS, _COLS), "f32"]:
+    with Mesh(topology="cta", layout=Layout(shape=(_ROWS,), strides=(1,))) as cta:
+        r = tf.reshard(a, layout=(_ROWS @ cta, _COLS), storage=rmem)
+        return tf.reshard(tf.ceil(r), layout=(_ROWS @ cta, _COLS), storage=gmem)
+
+
+@func(topologies=(Topology("cta", _ROWS),))
+def u_round(a: Tensor[(_ROWS, _COLS), "f32"]) -> Tensor[(_ROWS, _COLS), "f32"]:
+    with Mesh(topology="cta", layout=Layout(shape=(_ROWS,), strides=(1,))) as cta:
+        r = tf.reshard(a, layout=(_ROWS @ cta, _COLS), storage=rmem)
+        return tf.reshard(tf.round(r), layout=(_ROWS @ cta, _COLS), storage=gmem)
+
+
+def _positive() -> torch.Tensor:
+    """Strictly positive input, for the ops whose domain needs it."""
+    torch.manual_seed(0)
+    return torch.rand(_ROWS, _COLS, dtype=torch.float32, device="cuda") * 8.0 + 0.25
+
+
+def _signed() -> torch.Tensor:
+    torch.manual_seed(0)
+    return torch.randn(_ROWS, _COLS, dtype=torch.float32, device="cuda") * 4.0
+
+
+def _halves() -> torch.Tensor:
+    """A grid landing exactly on .5 boundaries, where rounding mode shows."""
+    n = _ROWS * _COLS
+    return (
+        (torch.arange(n, dtype=torch.float32, device="cuda") - n // 2) * 0.5
+    ).reshape(_ROWS, _COLS)
+
+
+@pytest.mark.parametrize(
+    "kernel,oracle,make_input",
+    [
+        (u_exp, torch.exp, _signed),
+        (u_exp2, torch.exp2, _signed),
+        (u_log, torch.log, _positive),
+        (u_log2, torch.log2, _positive),
+        (u_abs, torch.abs, _signed),
+        (u_ceil, torch.ceil, _signed),
+        (u_round, torch.round, _halves),
+    ],
+    ids=["exp", "exp2", "log", "log2", "abs", "ceil", "round"],
+)
+def test_a_unary_kernel_matches_its_torch_oracle(kernel, oracle, make_input) -> None:
+    rm = tilefoundry.compile(kernel, target="cuda")
+    x = make_input()
+    out = torch.full_like(x, float("nan"))
+    rm(x, out)
+    torch.cuda.synchronize()
+
+    expected = oracle(x)
+    # abs / ceil / round are exact; the transcendentals are compared at single
+    # -precision ulp scale, which the precise math entries meet and the
+    # ``__``-prefixed intrinsics would not.
+    torch.testing.assert_close(out, expected, rtol=1e-6, atol=1e-6)


### PR DESCRIPTION
# feat(codegen,runtime): emit the unary kinds the DSL already exposes

Fixes #71.

## What was wrong

`tf.exp`, `tf.exp2`, `tf.log`, `tf.log2`, `tf.abs`, `tf.ceil` and `tf.round` are
all reachable from the DSL and all type-infer and evaluate, but `_UNARY_TAG`
carried rows for only `RSQRT`, `NEG`, `RELU` and `SQUARE`. Everything else
failed at emission with a bare `KeyError: <UnaryKind.LOG: 'log'>` — writable and
checkable, but not compilable.

## The change

The seven missing runtime functors and their tag rows, following the existing
pattern in `unary.cuh`.

Two choices worth calling out:

- **The transcendentals use the precise `<math.h>` entries** (`expf`, `logf`,
  `exp2f`, `log2f`) rather than the `__`-prefixed intrinsics, so a compiled
  kernel agrees with the evaluator's torch oracle instead of being slightly
  faster and slightly different. A kernel that would rather have the intrinsic
  can still reach for it explicitly.
- **`round` uses `rintf`**, which breaks halfway cases to even, matching
  `torch.round`. `roundf` rounds them away from zero and would disagree at every
  `.5`.

`CAST` and `NOT` stay absent deliberately, and the table now says so rather than
leaving them looking pending: `CAST` has its own handler, and `NOT` is a boolean
operation rather than the float path these functors assume.

## Tests

`tests/integration/test_unary_codegen.py` compiles one kernel per op and
compares against the torch oracle on GPU. Verified to fail on `main` first —
all seven raise `KeyError` at emission — and pass after.

The inputs are chosen per op rather than shared: `log` / `log2` get a strictly
positive domain, and `round` gets a grid landing exactly on `.5` boundaries so
the rounding-mode choice above is actually exercised instead of assumed.

Each kernel is a separate top-level function because the compiled artifact is
cached per function — a factory emitting several same-named kernels hands every
op whichever one compiled first.

## Verification

```
pytest tests/ -q     644 passed (main @ e55e4b0)  ->  651 passed (+7 new)
```

Every `.pre-commit-config.yaml` hook clean: ruff, spec-rules, spec-refs,
spec-entropy, forward-references, comment-hygiene, no-machine-paths,
english-only, and clang-format over all C++ files.
