### PR TITLE
docs(plan): define milestone target state design

### DIFF
--- a/docs/develop.md
+++ b/docs/develop.md
@@ -112,9 +112,12 @@ short bullet list — keep it that way.
 ### Tests
 
 - Write meaningful positive tests that exercise the intended path.
-- Each milestone starts from a Golden Reference: an external source, measured
-  behaviour, existing workflow, or public contract that defines its result.
-  Tests prove its listed functional points.
+- Each milestone defines its own Target State Design before implementation.
+  Show every part the milestone settles in its delivered form as code or compact
+  pseudocode. Implementation and review match that design; tests exercise its
+  externally observable behavior.
+- A Target State Design covers every step its milestone lists. A step with no
+  delivered shape is a reviewer's finding before implementation begins.
 - Start with the smallest existing workflow that reaches the changed behaviour;
   extend it before creating another test file or harness.
 - One workflow may evidence several acceptance criteria. An acceptance criterion

--- a/docs/plans/TEMPLATE.md
+++ b/docs/plans/TEMPLATE.md
@@ -4,30 +4,18 @@ component: <component name>
 target_repo: tilefoundry
 ---
 
-<!-- A plan is written in two passes by two different people.
-
-     Pass 1 — discussion (human + planner). Settles what "right" looks like:
-     Description, Goal, Constraints, and each milestone's Golden Reference and
-     Acceptance Criteria. `#### Plan` gets coarse steps only. The discipline
-     here is one rule: DO NOT WRITE A QUANTIFIER, `file:line`, OR `§x.y` YOU
-     HAVE NOT LOOKED UP. "the `reference.py` files that call `linear_weight`"
-     is a fine coarse step; "the four dense models' `reference.py`" is not,
-     unless the grep was run. Coarse means few steps, not vague ones.
-
-     Pass 2 — dispatch (the reviewer, before the implementer writes anything).
-     Explores the repository and corrects the plan: resolves every reference,
-     settles every quantifier by running the grep, fixes `#### Related Files`,
-     and turns the coarse steps into executable ones. The person writing the
-     steps is the person who just read the code, so the premises are built
-     rather than recalled. Then finalize and tell the implementer to start. -->
+<!-- Pass 1 settles the intended result, each milestone's Target State Design,
+     constraints, and acceptance criteria; Plan steps stay coarse. Pass 2 audits
+     the repository, resolves references and quantifiers, fixes Related Files,
+     makes the steps executable, and finalizes. Do not state a count or reference
+     that has not been checked. -->
 
 # [TYPE][component] <short description>
 
 ## Description
 
-<!-- Free prose, in whatever shape this plan needs: what is observed, why it
-     happens, what it would take. Nothing here is required and nothing reads it,
-     so say the thing rather than filling a form. -->
+<!-- Explain the problem, intended result, and constraints in the shape this plan
+     needs. -->
 
 ## Milestones
 
@@ -36,42 +24,30 @@ target_repo: tilefoundry
 #### Depends
 - None
 
-#### Golden Reference
-<!-- State the source of truth before describing code: an external implementation,
-     measured current behaviour, existing end-to-end workflow, or a precise public
-     contract. List only the functional points this milestone must preserve or
-     reach; naming the mechanism they land on is welcome — that is what makes the
-     coarse plan below writable. A refactor's Golden Reference is the behaviour it
-     preserves. Every reference in `Source:` must resolve; pass 2 completes it. -->
-- Source: <reference implementation, document, contract, or existing workflow>
-- Functional points: <observable behaviour determined by that source>
+#### Target State Design
+<!-- Show every part this milestone designs in its delivered form. Use code or
+     compact pseudocode. -->
+```python
+# <delivered code shape>
+```
 
 #### Related Files
-<!-- Per-milestone touch surface. Drives the policy-AC injection into this milestone's
-     `#### Acceptance Criteria → policy_ac` range. Use `- inherit: top-level` as an
-     explicit fallback to the plan-level `### Related Files`; implicit inheritance is
-     not allowed. List `docs/spec/*.md` here when this milestone changes a spec. -->
+<!-- Files this milestone touches. List owning docs/spec/*.md files when it
+     changes a public contract. -->
 - <path>
 
 #### Plan
-<!-- Pass 1 leaves coarse steps; pass 2 makes them executable — real files, real call
-     sites, real order. -->
+<!-- Pass 1 leaves coarse steps; pass 2 resolves real files, call sites, and order. -->
 - [ ] step 0.1 <action with affected files>
 - [ ] step 0.2 <action>
 
 #### Acceptance Criteria
-<!-- State observable completed behaviour. An AC is not a request for its own test:
-     one complete workflow may evidence several ACs. Do not specify source scans,
-     private calls, object identities, line counts, or other implementation shape
-     unless that form is itself a public contract. The evidence that an AC is met
-     belongs in the gate request, not here — before implementation there is no
-     receipt to write down. -->
+<!-- State observable completed behaviour, not one test per AC. Keep implementation
+     shape in Target State Design; evidence belongs in the gate request. -->
 - [ ] AC-0-1: <author-written, milestone-specific observable behaviour>
 - [ ] AC-0-2: <author-written, milestone-specific observable behaviour>
 <!-- policy_ac:start -->
-- [ ] Milestone MUST name a `#### Golden Reference` before implementation steps, with the source of truth and the observable functional points it determines. <!-- policy_ac: milestone_review-0 -->
-- [ ] The gate request MUST show the Golden Reference's functional points exercised through the smallest real workflow, naming the retained evidence; one workflow MAY cover several ACs, and a new test requires a stated reachability gap. <!-- policy_ac: milestone_review-1 -->
-- [ ] Touched tests and comments MUST be reviewed for redundancy: remove ones superseded by the retained workflow, and do not add source-shape or hypothetical-refactor guards unless that form is a public contract. <!-- policy_ac: milestone_review-2 -->
+- [ ] Touched tests and comments MUST be reviewed for redundancy: remove ones superseded by the retained workflow, and do not add source-shape or hypothetical-refactor guards unless that form is a public contract. <!-- policy_ac: milestone_review-0 -->
 <!-- policy_ac:end -->
 
 ### Milestone M1: <name>
@@ -79,9 +55,12 @@ target_repo: tilefoundry
 #### Depends
 - M0
 
-#### Golden Reference
-- Source: <reference implementation, document, contract, or existing workflow>
-- Functional points: <observable behaviour determined by that source>
+#### Target State Design
+<!-- Show every part this milestone designs in its delivered form. Use code or
+     compact pseudocode. -->
+```python
+# <delivered code shape>
+```
 
 #### Related Files
 - <path>
@@ -93,16 +72,12 @@ target_repo: tilefoundry
 #### Acceptance Criteria
 - [ ] AC-1-1: <author-written observable behaviour>
 <!-- policy_ac:start -->
-- [ ] Milestone MUST name a `#### Golden Reference` before implementation steps, with the source of truth and the observable functional points it determines. <!-- policy_ac: milestone_review-0 -->
-- [ ] The gate request MUST show the Golden Reference's functional points exercised through the smallest real workflow, naming the retained evidence; one workflow MAY cover several ACs, and a new test requires a stated reachability gap. <!-- policy_ac: milestone_review-1 -->
-- [ ] Touched tests and comments MUST be reviewed for redundancy: remove ones superseded by the retained workflow, and do not add source-shape or hypothetical-refactor guards unless that form is a public contract. <!-- policy_ac: milestone_review-2 -->
+- [ ] Touched tests and comments MUST be reviewed for redundancy: remove ones superseded by the retained workflow, and do not add source-shape or hypothetical-refactor guards unless that form is a public contract. <!-- policy_ac: milestone_review-0 -->
 <!-- policy_ac:end -->
 
 ## Final Gate
 
-<!-- This block is auto-filled by `scripts/finalize_plan_context.py` once per
-     plan. It holds repository-wide checks such as spec discipline and
-     clang-format; do not repeat those gates in every milestone. -->
+<!-- Auto-filled repository-wide gates. -->
 <!-- final_gate:start -->
 - [ ] Spec section MUST NOT enumerate test names; the pre-commit `spec-rules-lint` and `english-only` hooks already reject forbidden section headers, plan / milestone / task / PR / commit references, agent names, and non-English text. <!-- policy_final: spec_discipline-0 -->
 - [ ] No touched C++/CUDA files in this plan — clang-format gate N/A <!-- policy_final: clang_format-na -->

--- a/docs/policies/project-policy.json
+++ b/docs/policies/project-policy.json
@@ -20,13 +20,11 @@
     {
       "id": "milestone_review",
       "name": "Milestone review",
-      "description": "Each milestone names its Golden Reference, verifies its functional points through real workflows, and removes redundant test/comment scaffolding.",
+      "description": "Touched tests and comments retain only meaningful contract coverage after each milestone.",
       "when": {
         "path_glob": ["**"]
       },
       "ac": [
-        "Milestone MUST name a `#### Golden Reference` before implementation steps, with the source of truth and the observable functional points it determines.",
-        "The gate request MUST show the Golden Reference's functional points exercised through the smallest real workflow, naming the retained evidence; one workflow MAY cover several ACs, and a new test requires a stated reachability gap.",
         "Touched tests and comments MUST be reviewed for redundancy: remove ones superseded by the retained workflow, and do not add source-shape or hypothetical-refactor guards unless that form is a public contract."
       ],
       "rules": {

--- a/scripts/finalize_plan_context.py
+++ b/scripts/finalize_plan_context.py
@@ -19,8 +19,8 @@ nobody rereads.
 
 The finalizer never touches handwritten content outside the marker
 ranges. A ``policy_*`` HTML comment appearing outside any allowed
-range is a hard validation failure. Every milestone must name its
-Golden Reference; a milestone that changes a public contract declares
+range is a hard validation failure. Every milestone must define its
+Target State Design; a milestone that changes a public contract declares
 so by listing the owning ``docs/spec/*.md`` path in its Related Files.
 """
 from __future__ import annotations
@@ -288,7 +288,7 @@ class PlanModel:
         sections: dict[str, tuple[int, int]] = {}
         for required in (
             "Depends",
-            "Golden Reference",
+            "Target State Design",
             "Related Files",
             "Plan",
             "Acceptance Criteria",
@@ -302,7 +302,7 @@ class PlanModel:
             # line in the body.
             body = [
                 ln
-                for ln in lines[span[0] + 1 : span[1]]
+                for ln in self.lines[span[0] + 1 : span[1]]
                 if ln.strip() and ln.strip() not in (
                     MILESTONE_AC_START,
                     MILESTONE_AC_END,
@@ -326,8 +326,6 @@ class PlanModel:
                     "List the paths this milestone touches."
                 )
             effective_paths.append(_strip_path_bullet(item))
-
-        self._validate_golden_reference(name, sections["Golden Reference"])
 
         ac_section = sections["Acceptance Criteria"]
 
@@ -359,19 +357,6 @@ class PlanModel:
             "policy_ac_end_idx": ac_end,
             "policy_states": _policy_check_states(lines, ac_start, ac_end),
         }
-
-    def _validate_golden_reference(
-        self, milestone_name: str, section: tuple[int, int]
-    ) -> None:
-        items = _list_bullets(self.scan, section[0] + 1, section[1])
-        label = f"{self.path}: milestone {milestone_name!r} `#### Golden Reference`"
-        required = ("Source:", "Functional points:")
-        missing = [prefix for prefix in required if not any(item.startswith(prefix) for item in items)]
-        if missing:
-            raise FinalizeError(
-                f"{label} must contain {', '.join(repr(prefix) for prefix in missing)} "
-                "bullet(s)."
-            )
 
 # ---------------------------------------------------------------------------
 # Render

--- a/tests/scripts/test_finalize_plan_context.py
+++ b/tests/scripts/test_finalize_plan_context.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 
-from scripts.finalize_plan_context import finalize_plan
+import pytest
+
+from scripts.finalize_plan_context import FinalizeError, finalize_plan
 
 
 def test_template_finalizer_keeps_milestone_and_final_gate_scoped(
@@ -14,21 +16,28 @@ def test_template_finalizer_keeps_milestone_and_final_gate_scoped(
     plan.write_text(canonical.replace("<path>", "src/example.py"))
     before, after = finalize_plan(plan, write=False)
     assert before != after
-    assert after.count("Milestone MUST name a `#### Golden Reference`") == 2
-    assert after.count("The gate request MUST show the Golden Reference") == 2
+    assert after.count("#### Target State Design") == 2
     assert after.count("Touched tests and comments MUST be reviewed") == 2
     assert after.count("MUST list the owning `docs/spec/*.md` path") == 2
     assert after.count("Spec section MUST NOT reference plans") == 0
     assert after.count("No touched C++/CUDA files in this plan") == 1
 
-    checked = after.replace(
-        "- [ ] Milestone MUST name a `#### Golden Reference`",
-        "- [x] Milestone MUST name a `#### Golden Reference`",
+    legacy = after.replace(
+        "- [ ] Touched tests and comments MUST be reviewed",
+        "- [x] Touched tests and comments MUST be reviewed",
+        1,
+    ).replace(
+        "<!-- policy_ac: milestone_review-0 -->",
+        "<!-- policy_ac: milestone_review-0 -->\n"
+        "- [ ] Retired policy check. <!-- policy_ac: milestone_review-1 -->\n"
+        "- [ ] Retired policy check. <!-- policy_ac: milestone_review-2 -->",
         1,
     )
-    plan.write_text(checked)
-    _, preserved = finalize_plan(plan, write=False)
-    assert "- [x] Milestone MUST name a `#### Golden Reference`" in preserved
+    plan.write_text(legacy)
+    _, normalized = finalize_plan(plan, write=False)
+    assert "- [x] Touched tests and comments MUST be reviewed" in normalized
+    assert "milestone_review-1" not in normalized
+    assert "milestone_review-2" not in normalized
 
 
 def test_a_fenced_comment_line_is_quoted_output_not_a_heading(tmp_path: Path) -> None:
@@ -48,5 +57,42 @@ def test_a_fenced_comment_line_is_quoted_output_not_a_heading(tmp_path: Path) ->
     plan = tmp_path / "quoting.md"
     plan.write_text(quoted)
     _, after = finalize_plan(plan, write=False)
-    assert after.count("Milestone MUST name a `#### Golden Reference`") == 2
+    assert after.count("#### Target State Design") == 2
     assert "# traffic gmem=r3322101984/w100868096" in after
+
+
+def test_every_milestone_requires_a_target_state_design(
+    tmp_path: Path,
+) -> None:
+    template = Path(__file__).parents[2] / "docs/plans/TEMPLATE.md"
+    canonical, _ = finalize_plan(template, write=False)
+    retired_heading = "Golden" + " Reference"
+    invalid = canonical.replace("<path>", "src/example.py").replace(
+        "#### Target State Design",
+        f"#### {retired_heading}",
+        1,
+    )
+
+    plan = tmp_path / "missing-target-state-shape.md"
+    plan.write_text(invalid)
+    with pytest.raises(FinalizeError, match="missing `#### Target State Design`"):
+        finalize_plan(plan, write=False)
+
+
+def test_a_code_only_target_state_design_is_not_empty(tmp_path: Path) -> None:
+    template = Path(__file__).parents[2] / "docs/plans/TEMPLATE.md"
+    canonical, _ = finalize_plan(template, write=False)
+    code_only = canonical.replace(
+        "#### Target State Design\n"
+        "<!-- Show every part this milestone designs in its delivered form. Use code or\n"
+        "     compact pseudocode. -->\n"
+        "```python\n"
+        "# <delivered code shape>\n"
+        "```",
+        "#### Target State Design\n```python\nvalue = 1\n```",
+        1,
+    ).replace("<path>", "src/example.py")
+
+    plan = tmp_path / "code-only-target-state-design.md"
+    plan.write_text(code_only)
+    finalize_plan(plan, write=False)


### PR DESCRIPTION
## Why
- Land the plan-tooling half of #61 intentionally excluded from #70; #70 merged as e345b3b and #61 is closed.

## What
- Replace Golden Reference with Target State Design and update finalization policy context.
- Accept code-only fenced designs without treating them as empty.

## Contract
- Every milestone defines a Target State Design covering each listed step before implementation.
- Existing plans with legacy milestone-review markers still finalize, retaining those entries unchanged rather than rewriting them to the new policy.

## Risk
- Legacy plans are not automatically migrated and retain retired AC text. None are tracked today, but gitignored local plans remain affected; automatic migration is follow-up work.
