### PR TITLE
feat(target): add a B200 SXM target on the SM100 architecture

### DIFF
--- a/docs/spec/target.md
+++ b/docs/spec/target.md
@@ -181,6 +181,12 @@ class CudaTarget(Target):
     supplied directly carries no document, so it has no ID or digest and is
     exempt from that check: it is a distinct hardware value rather than a
     revision of an installed one.
+  - `CudaTarget` MUST compose any installed architecture and device pair that
+    declares compatibility. A further CUDA product is its two documents and the
+    two value identities they build
+    ([§10.2](#102-registry-and-resolution)), never a Target subclass:
+    the services and Facts are selected by the value already, so a subclass would
+    have nothing of its own to state.
   - CUDA MUST select the pipeline Scheduler at `thread` and the partition
     Scheduler at `cta` through `get_scheduler`. A CUDA subclass MUST inherit
     those services through ordinary Python inheritance unless it overrides or
@@ -487,6 +493,11 @@ conditions = "No validated number."
     search path, no overlay, and no partial document.
   - A target package MUST register its typed schemas and installed documents as
     an import side effect, into the same shared registry.
+  - A schema MAY build more than one value class when every document it validates
+    states the same fact paths. The identity a document declares MUST select the
+    class, and an identity the schema builds no class for MUST raise naming the
+    identities it does build. That selection reads the document's own recorded
+    content, so it is not a dispatch on a Target name.
   - A typed schema MUST validate exact fact paths, value types, units, required
     fields, and cross-field invariants, and MUST reject any leaf the document
     carries that the schema does not model, so a misspelled key cannot become
@@ -636,3 +647,40 @@ class CudaDevice(Device):
     ([§10](#10-installed-hardware-resources)). Selecting a different installed
     document by ID is not an override; supplying a partial or edited number
     without a document behind it is, and is not admitted.
+
+## 14. `SM100`
+
+```python
+class SM100(CudaArchitecture):
+    """SM100 compilation identity and structural capabilities."""
+```
+
+- constraints:
+  - `name` MUST be `sm_100`, the architecture identity CUDA compilation uses.
+  - SM100 MUST carry the CUDA architecture facts and add no field of its own
+    ([§12](#12-cudaarchitecture)).
+  - SM100 MUST report `f4e2m1` as a compute DType, because its MMA takes 4-bit
+    operands directly. `f8e8m0` MUST NOT be reported as one: it scales those
+    operands rather than being multiplied.
+  - SM100 MUST state a tensor-memory capacity, and its instruction capabilities
+    MUST name the MMA family that accumulates there rather than the SM90 family,
+    which this architecture does not run.
+  - Device-frequency-dependent FLOP/s values MUST NOT be stored on SM100.
+
+## 15. `B200SXM`
+
+```python
+class B200SXM(CudaDevice):
+    """One B200 SXM device."""
+```
+
+- constraints:
+  - B200SXM MUST carry the CUDA device facts and add no field of its own
+    ([§13](#13-cudadevice)).
+  - `peak_for` MUST expose a dense integer FLOP/s entry for each of `f32`,
+    `f16`, `bf16`, `fp8e4m3`, and `f4e2m1`, each value taken from the installed
+    document.
+  - Resource facts the vendor does not publish for this product, its SM count
+    and its L2 capacity among them, MUST be recorded as measured on the
+    described host rather than estimated or borrowed from a related part
+    ([§10.1](#101-document-envelope)).

--- a/docs/spec/target.md
+++ b/docs/spec/target.md
@@ -253,6 +253,9 @@ class CudaArchitecture(Architecture):
     capacity per SM and per CTA, and register-file capacity per SM. These are
     properties of the microarchitecture, so every product built on it shares
     them, and a device MUST NOT restate them.
+  - It MUST NOT carry a compute-throughput rate. A FLOP/s figure depends on the
+    clock of one product, so it is a device fact ([§4.2](#42-cudadevice)) even
+    though the instruction it rates is the architecture's.
   - `unified_l1_shared_per_sm_bytes` MUST be the size of the one physical block
     the shared-memory carveout and the L1 data cache are both taken from, and
     MUST be at least `shared_memory_per_sm_bytes`. The architecture MUST NOT
@@ -288,7 +291,6 @@ The installed `nvidia.sm90` architecture document.
     compute DTypes.
   - It MUST record no tensor-memory capacity: the SM90 MMA accumulates in the
     register file, so there is no separate store to size.
-  - Device-frequency-dependent FLOP/s values MUST NOT appear in it.
 
 #### 4.1.2 SM100
 
@@ -302,7 +304,6 @@ The installed `nvidia.sm100` architecture document.
   - It MUST record a tensor-memory capacity, and its instruction capabilities
     MUST name the MMA family that accumulates there rather than the SM90 family,
     which this architecture does not run.
-  - Device-frequency-dependent FLOP/s values MUST NOT appear in it.
 
 ### 4.2 `CudaDevice`
 
@@ -573,7 +574,7 @@ compatibility, never a single combined record.
 
 ```toml
 [spec]
-schema = "tilefoundry.cuda.device/v1"
+schema = "tilefoundry.cuda.device/v2"
 kind = "device"
 id = "nvidia.h200_sxm"
 
@@ -622,13 +623,16 @@ conditions = "No validated number."
 - constraints:
   - `HardwareSpecRegistry` MUST resolve documents by exact ID. There MUST be no
     search path, no overlay, and no partial document.
+  - A schema name carries a version. Requiring a leaf a previous version did not
+    MUST take a new version, because a document written against the old one no
+    longer loads and the failure is otherwise a missing fact rather than a
+    contract that moved.
   - A target package MUST register its typed schemas and installed documents as
     an import side effect, into the same shared registry.
-  - A schema MAY build more than one value class when every document it validates
-    states the same fact paths. The identity a document declares MUST select the
-    class, and an identity the schema builds no class for MUST raise naming the
-    identities it does build. That selection reads the document's own recorded
-    content, so it is not a dispatch on a Target name.
+  - A schema MAY validate the documents of several products when they state the
+    same fact paths, and MUST build one value type from all of them. A product is
+    what its document records, so a schema MUST NOT select a type by the identity
+    a document declares.
   - A typed schema MUST validate exact fact paths, value types, units, required
     fields, and cross-field invariants, and MUST reject any leaf the document
     carries that the schema does not model, so a misspelled key cannot become

--- a/docs/spec/target.md
+++ b/docs/spec/target.md
@@ -101,78 +101,35 @@ class Device:
 ## 2. `SM90`
 
 ```python
-class SM90:
+class SM90(CudaArchitecture):
     """SM90 compilation identity and structural capabilities."""
-
-    name: str
-    supported_compute_dtypes: tuple[DType, ...]
-    instruction_capabilities: tuple[str, ...]
-    max_threads_per_cta: int
-    max_threads_per_warp: int
-    max_warps_per_cta: int
-    max_resident_ctas_per_sm: int
-    shared_memory_per_sm_bytes: int
-    shared_memory_per_cta_bytes: int
-    unified_l1_shared_per_sm_bytes: int
-    registers_per_sm_32bit: int
-
-    def supports_compute_dtype(self, dtype: DType) -> bool: ...
-
-    def topology_limit(self, name: str) -> int: ...
 ```
 
 - constraints:
-  - `name` MUST be the architecture identity used by CUDA compilation.
-  - SM90 MUST own supported compute DTypes, instruction capabilities, and the
-    thread/CTA structural limits.
-  - SM90 MUST own the per-SM resource limits: resident CTAs, shared-memory
-    capacity per SM and per CTA, and register-file capacity per SM. These are
-    properties of the microarchitecture, so every product built on it shares
-    them, and a device MUST NOT restate them.
-  - `unified_l1_shared_per_sm_bytes` MUST be the size of the one physical block
-    the shared-memory carveout and the L1 data cache are both taken from, and
-    MUST be at least `shared_memory_per_sm_bytes`. The architecture MUST NOT
-    state an L1 capacity: how much L1 remains depends on how much shared memory
-    a program asked for, which is not a property of the hardware.
+  - `name` MUST be `sm_90`, the architecture identity CUDA compilation uses.
+  - SM90 MUST carry the CUDA architecture facts and add no field of its own
+    ([§12](#12-cudaarchitecture)).
   - Storage and scale DTypes `f4e2m1` and `f8e8m0` MUST NOT be reported as
     compute DTypes by SM90.
+  - SM90 MUST state no tensor-memory capacity: its MMA accumulates in the
+    register file, so there is no separate store to size.
   - Device-frequency-dependent FLOP/s values MUST NOT be stored on SM90.
-  - No field MAY carry a default: every value comes from the installed
-    document ([§1](#1-target)0), so the class declares shape and never content.
 
 ## 3. `H200SXM`
 
 ```python
-class H200SXM:
-    """One H200 SXM device with fixed hard resource limits."""
-
-    name: str
-    sm_count: int
-    hbm_capacity_bytes: int
-    hbm_bandwidth_bytes_per_second: int
-    l2_capacity_bytes: int | None
-    _dense_flops: tuple[tuple[DType, int], ...]
-
-    def peak_for(self, dtype: DType) -> int: ...
+class H200SXM(CudaDevice):
+    """One H200 SXM device."""
 ```
 
 - constraints:
-  - H200SXM MUST describe one device and MUST NOT carry a GPU count.
-  - H200SXM MUST describe how many SMs the product has and how its memory
-    system and compute units perform. Per-SM structural limits belong to the
-    architecture ([§2](#2-sm90)).
+  - H200SXM MUST carry the CUDA device facts and add no field of its own
+    ([§13](#13-cudadevice)).
   - `peak_for` MUST expose a dense integer FLOP/s entry for each of `f32`,
     `f16`, `bf16`, and `fp8e4m3`, each value taken from the installed document.
-  - `f4e2m1` and `f8e8m0` MUST have no compute-throughput entry.
-  - Unknown compute DTypes MUST raise an actionable error.
-  - `l2_capacity_bytes` MUST be `None` when the installed document records no
-    value for it. A recorded absence and a number are both statements about the
-    product; a substituted figure would not be.
-  - No field MAY carry a default, and no resource value MAY be written as a
-    Python literal: the installed document is the single source ([§1](#1-target)0).
-    Selecting a different installed document by ID is not an override; supplying
-    a partial or edited number without a document behind it is, and is not
-    admitted.
+  - `f4e2m1` MUST be recorded unavailable rather than omitted: the Hopper tensor
+    cores have no FP4 mode, so the product has no such rate, which is a fact
+    about it and not a number nobody published.
 
 ## 4. `CudaTarget`
 
@@ -241,6 +198,11 @@ class CudaTarget(Target):
     `architecture.shared_memory_per_cta_bytes`, and MUST be reported as belonging
     to the `cta` scope even when the level being scheduled is `thread`
     ([schedule §5](./schedule.md#5-scheduling-facts)).
+  - The tensor-memory level MUST be projected as
+    `architecture.tensor_memory_per_cta_bytes` and MUST report no capacity where
+    the architecture states none. A level naming a capacity on hardware that has
+    no such store would offer a plan somewhere to hold accumulators that does not
+    exist.
   - The partition projection MUST state the device's SM count as the parallel
     units, its HBM bandwidth and capacity, and its dense peak rate per DType
     ([schedule §5.2](./schedule.md#52-partitionfacts)). Every one of those MUST be
@@ -584,3 +546,93 @@ class Target:
     state. It only converts what the specification already records.
   - There MUST be no public Facts registration step or global Target Facts
     table. A custom Target provider registers only its Target class.
+
+## 12. `CudaArchitecture`
+
+```python
+class CudaArchitecture(Architecture):
+    """What one CUDA architecture states about itself."""
+
+    name: str
+    supported_compute_dtypes: tuple[DType, ...]
+    instruction_capabilities: tuple[str, ...]
+    max_threads_per_cta: int
+    max_threads_per_warp: int
+    max_warps_per_cta: int
+    max_resident_ctas_per_sm: int
+    shared_memory_per_sm_bytes: int
+    shared_memory_per_cta_bytes: int
+    unified_l1_shared_per_sm_bytes: int
+    registers_per_sm_32bit: int
+    tensor_memory_per_cta_bytes: int | None
+
+    def supports_compute_dtype(self, dtype: DType) -> bool: ...
+
+    def topology_limit(self, name: str) -> int: ...
+```
+
+- constraints:
+  - `name` MUST be the architecture identity CUDA compilation uses, and a
+    concrete architecture value MUST be immutable.
+  - A CUDA architecture MUST own supported compute DTypes, instruction
+    capabilities, and the thread/CTA structural limits.
+  - It MUST own the per-SM resource limits: resident CTAs, shared-memory
+    capacity per SM and per CTA, and register-file capacity per SM. These are
+    properties of the microarchitecture, so every product built on it shares
+    them, and a device MUST NOT restate them.
+  - `unified_l1_shared_per_sm_bytes` MUST be the size of the one physical block
+    the shared-memory carveout and the L1 data cache are both taken from, and
+    MUST be at least `shared_memory_per_sm_bytes`. The architecture MUST NOT
+    state an L1 capacity: how much L1 remains depends on how much shared memory
+    a program asked for, which is not a property of the hardware.
+  - `tensor_memory_per_cta_bytes` MUST be the whole tensor-memory store on an
+    architecture whose MMA accumulates in one, because that store is allocated
+    in columns spanning every lane and one CTA may hold all of them. It MUST be
+    `None` where the architecture has no such store, which is the same statement
+    the document makes by recording that leaf unavailable.
+  - The leaf behind every field MUST be declared by each architecture document,
+    so a value the architecture does not have is recorded as absent rather than
+    left out ([§10.2](#102-registry-and-resolution)).
+  - No field MAY carry a default: every value comes from the installed document
+    ([§10](#10-installed-hardware-resources)), so the class declares shape and
+    never content.
+
+## 13. `CudaDevice`
+
+```python
+class CudaDevice(Device):
+    """One CUDA device: how many SMs, and the memory and compute rates."""
+
+    name: str
+    sm_count: int
+    hbm_capacity_bytes: int
+    hbm_bandwidth_bytes_per_second: int
+    l2_capacity_bytes: int | None
+    _dense_flops: tuple[tuple[DType, int], ...]
+
+    def peak_for(self, dtype: DType) -> int: ...
+```
+
+- constraints:
+  - A CUDA device value MUST be immutable, MUST describe one device, and MUST
+    NOT carry a GPU count.
+  - It MUST describe how many SMs the product has and how its memory system and
+    compute units perform. Per-SM structural limits belong to the architecture
+    ([§12](#12-cudaarchitecture)).
+  - `peak_for` MUST answer from the installed document for every compute DType
+    the product's tensor cores have a mode for, and MUST raise an actionable
+    error for any other DType. A product with no such mode records that leaf
+    unavailable, so asking for its rate fails instead of reading as a rate
+    nobody published.
+  - `_dense_flops` MUST hold a dense integer FLOP/s entry per DType. A published
+    sparse peak MUST be halved and the division stated as the document's
+    evidence, so no plan is priced against a rate structured sparsity is
+    required to reach.
+  - `l2_capacity_bytes` MUST be `None` when the installed document records no
+    value for it. A recorded absence and a number are both statements about the
+    product; a substituted figure would not be.
+  - No field MAY carry a default, and no resource value MAY be written as a
+    Python literal: the installed document is the single source
+    ([§10](#10-installed-hardware-resources)). Selecting a different installed
+    document by ID is not an override; supplying a partial or edited number
+    without a document behind it is, and is not admitted.

--- a/docs/spec/target.md
+++ b/docs/spec/target.md
@@ -98,39 +98,6 @@ class Device:
     system, and its measured or published throughput. A fact MUST be recorded on
     exactly one side, and the other side MUST NOT restate it.
 
-## 2. `SM90`
-
-```python
-class SM90(CudaArchitecture):
-    """SM90 compilation identity and structural capabilities."""
-```
-
-- constraints:
-  - `name` MUST be `sm_90`, the architecture identity CUDA compilation uses.
-  - SM90 MUST carry the CUDA architecture facts and add no field of its own
-    ([§12](#12-cudaarchitecture)).
-  - Storage and scale DTypes `f4e2m1` and `f8e8m0` MUST NOT be reported as
-    compute DTypes by SM90.
-  - SM90 MUST state no tensor-memory capacity: its MMA accumulates in the
-    register file, so there is no separate store to size.
-  - Device-frequency-dependent FLOP/s values MUST NOT be stored on SM90.
-
-## 3. `H200SXM`
-
-```python
-class H200SXM(CudaDevice):
-    """One H200 SXM device."""
-```
-
-- constraints:
-  - H200SXM MUST carry the CUDA device facts and add no field of its own
-    ([§13](#13-cudadevice)).
-  - `peak_for` MUST expose a dense integer FLOP/s entry for each of `f32`,
-    `f16`, `bf16`, and `fp8e4m3`, each value taken from the installed document.
-  - `f4e2m1` MUST be recorded unavailable rather than omitted: the Hopper tensor
-    cores have no FP4 mode, so the product has no such rate, which is a fact
-    about it and not a number nobody published.
-
 ## 4. `CudaTarget`
 
 ```python
@@ -166,7 +133,8 @@ class CudaTarget(Target):
 - constraints:
   - `device` and `architecture` MUST each accept an installed document ID or a
     concrete value. An ID MUST resolve immediately to the typed value, and the
-    resolved ID and content digest MUST be retained ([§1](#1-target)0.2).
+    resolved ID and content digest MUST be retained
+    ([§10.2](#102-registry-and-resolution)).
   - `arch`, when provided, MUST equal the resolved architecture's `name`; it is
     a consistency check and MUST NOT select or override an architecture.
   - `device` MUST be required. The constructor MUST NOT select hardware for a
@@ -182,11 +150,11 @@ class CudaTarget(Target):
     exempt from that check: it is a distinct hardware value rather than a
     revision of an installed one.
   - `CudaTarget` MUST compose any installed architecture and device pair that
-    declares compatibility. A further CUDA product is its two documents and the
-    two value identities they build
-    ([§10.2](#102-registry-and-resolution)), never a Target subclass:
-    the services and Facts are selected by the value already, so a subclass would
-    have nothing of its own to state.
+    declares compatibility. A further CUDA product is its two documents
+    ([§10.2](#102-registry-and-resolution)) and nothing else: no Target subclass,
+    and no architecture or device type of its own. The services and Facts are
+    selected by the value already, and the numbers are in the documents, so
+    either addition would carry nothing.
   - CUDA MUST select the pipeline Scheduler at `thread` and the partition
     Scheduler at `cta` through `get_scheduler`. A CUDA subclass MUST inherit
     those services through ordinary Python inheritance unless it overrides or
@@ -242,6 +210,160 @@ thread mesh layouts.
     target resource limits. `Topology("cta", None)` MUST remain valid for the
     handwritten dynamic-launch compile path.
   - Unsupported topology levels MUST fail at the generic lowering boundary.
+
+### 4.1 `CudaArchitecture`
+
+```python
+class CudaArchitecture(Architecture):
+    """What one CUDA architecture states about itself."""
+
+    name: str
+    supported_compute_dtypes: tuple[DType, ...]
+    instruction_capabilities: tuple[str, ...]
+    max_threads_per_cta: int
+    max_threads_per_warp: int
+    max_warps_per_cta: int
+    max_resident_ctas_per_sm: int
+    shared_memory_per_sm_bytes: int
+    shared_memory_per_cta_bytes: int
+    unified_l1_shared_per_sm_bytes: int
+    registers_per_sm_32bit: int
+    tensor_memory_per_cta_bytes: int | None
+
+    def supports_compute_dtype(self, dtype: DType) -> bool: ...
+
+    def topology_limit(self, name: str) -> int: ...
+```
+
+- constraints:
+  - One value type MUST answer for every CUDA architecture, and a concrete value
+    MUST be immutable. What separates one architecture from another is what its
+    installed document records ([§4.1.1](#411-sm90),
+    [§4.1.2](#412-sm100)), so an architecture MUST NOT be given a type of its
+    own: a class holding no number would restate an identity the value already
+    carries.
+  - `name` MUST be the architecture identity CUDA compilation uses.
+  - A CUDA architecture MUST own supported compute DTypes, instruction
+    capabilities, and the thread/CTA structural limits.
+  - It MUST own the per-SM resource limits: resident CTAs, shared-memory
+    capacity per SM and per CTA, and register-file capacity per SM. These are
+    properties of the microarchitecture, so every product built on it shares
+    them, and a device MUST NOT restate them.
+  - `unified_l1_shared_per_sm_bytes` MUST be the size of the one physical block
+    the shared-memory carveout and the L1 data cache are both taken from, and
+    MUST be at least `shared_memory_per_sm_bytes`. The architecture MUST NOT
+    state an L1 capacity: how much L1 remains depends on how much shared memory
+    a program asked for, which is not a property of the hardware.
+  - `tensor_memory_per_cta_bytes` MUST be the whole tensor-memory store on an
+    architecture whose MMA accumulates in one, because that store is allocated
+    in columns spanning every lane and one CTA may hold all of them. It MUST be
+    `None` where the architecture has no such store, which is the same statement
+    the document makes by recording that leaf unavailable.
+  - Every architecture document MUST declare the leaf behind every field, so a
+    value the architecture does not have is recorded as absent rather than left
+    out ([§10.2](#102-registry-and-resolution)).
+  - No field MAY carry a default: every value comes from the installed document
+    ([§10](#10-installed-hardware-resources)), so the type declares shape and
+    never content.
+  - A provider MAY subclass it to carry a fact of its own hardware that this
+    shape does not model. The added fields are subject to the same rule: they
+    state what a document records, not a number written in Python.
+
+#### 4.1.1 SM90
+
+The installed `nvidia.sm90` architecture document.
+
+- constraints:
+  - Its recorded identity MUST be `sm_90`.
+  - Storage and scale DTypes `f4e2m1` and `f8e8m0` MUST NOT be recorded as
+    compute DTypes.
+  - It MUST record no tensor-memory capacity: the SM90 MMA accumulates in the
+    register file, so there is no separate store to size.
+  - Device-frequency-dependent FLOP/s values MUST NOT appear in it.
+
+#### 4.1.2 SM100
+
+The installed `nvidia.sm100` architecture document.
+
+- constraints:
+  - Its recorded identity MUST be `sm_100`.
+  - It MUST record `f4e2m1` as a compute DType, because the SM100 MMA takes
+    4-bit operands directly. `f8e8m0` MUST NOT be recorded as one: it scales
+    those operands rather than being multiplied.
+  - It MUST record a tensor-memory capacity, and its instruction capabilities
+    MUST name the MMA family that accumulates there rather than the SM90 family,
+    which this architecture does not run.
+  - Device-frequency-dependent FLOP/s values MUST NOT appear in it.
+
+### 4.2 `CudaDevice`
+
+```python
+class CudaDevice(Device):
+    """One CUDA device: how many SMs, and the memory and compute rates."""
+
+    name: str
+    sm_count: int
+    hbm_capacity_bytes: int
+    hbm_bandwidth_bytes_per_second: int
+    l2_capacity_bytes: int | None
+    _dense_flops: tuple[tuple[DType, int], ...]
+
+    def peak_for(self, dtype: DType) -> int: ...
+```
+
+- constraints:
+  - One value type MUST answer for every CUDA device, on the same terms as the
+    architecture ([§4.1](#41-cudaarchitecture)): a product is its document
+    ([§4.2.1](#421-h200sxm), [§4.2.2](#422-b200sxm)), not a type.
+  - A concrete value MUST be immutable, MUST describe one device, and MUST NOT
+    carry a GPU count.
+  - It MUST describe how many SMs the product has and how its memory system and
+    compute units perform. Per-SM structural limits belong to the architecture
+    ([§4.1](#41-cudaarchitecture)).
+  - `peak_for` MUST answer from the installed document for every compute DType
+    the product's tensor cores have a mode for, and MUST raise an actionable
+    error for any other DType. A product with no such mode records that leaf
+    unavailable, so asking for its rate fails instead of reading as a rate
+    nobody published.
+  - `_dense_flops` MUST hold a dense integer FLOP/s entry per DType. A published
+    sparse peak MUST be halved and the division stated as the document's
+    evidence, so no plan is priced against a rate structured sparsity is
+    required to reach.
+  - `l2_capacity_bytes` MUST be `None` when the installed document records no
+    value for it. A recorded absence and a number are both statements about the
+    product; a substituted figure would not be.
+  - No field MAY carry a default, and no resource value MAY be written as a
+    Python literal: the installed document is the single source
+    ([§10](#10-installed-hardware-resources)). Selecting a different installed
+    document by ID is not an override; supplying a partial or edited number
+    without a document behind it is, and is not admitted.
+
+#### 4.2.1 H200SXM
+
+The installed `nvidia.h200_sxm` device document.
+
+- constraints:
+  - Its recorded identity MUST be `h200_sxm`, and it MUST declare `nvidia.sm90`
+    as the architecture it composes with.
+  - It MUST record a dense peak for each of `f32`, `f16`, `bf16`, and
+    `fp8e4m3`.
+  - `throughput.f4e2m1` MUST be recorded unavailable rather than omitted: the
+    Hopper tensor cores have no FP4 mode, so the product has no such rate, which
+    is a fact about it and not a number nobody published.
+
+#### 4.2.2 B200SXM
+
+The installed `nvidia.b200_sxm` device document.
+
+- constraints:
+  - Its recorded identity MUST be `b200_sxm`, and it MUST declare `nvidia.sm100`
+    as the architecture it composes with.
+  - It MUST record a dense peak for each of `f32`, `f16`, `bf16`, `fp8e4m3`, and
+    `f4e2m1`.
+  - Resource facts the vendor does not publish for this product, its SM count
+    and its L2 capacity among them, MUST be recorded as measured on the
+    described host rather than estimated or borrowed from a related part
+    ([§10.1](#101-document-envelope)).
 
 ## 5. `CpuTarget`
 
@@ -557,130 +679,3 @@ class Target:
     state. It only converts what the specification already records.
   - There MUST be no public Facts registration step or global Target Facts
     table. A custom Target provider registers only its Target class.
-
-## 12. `CudaArchitecture`
-
-```python
-class CudaArchitecture(Architecture):
-    """What one CUDA architecture states about itself."""
-
-    name: str
-    supported_compute_dtypes: tuple[DType, ...]
-    instruction_capabilities: tuple[str, ...]
-    max_threads_per_cta: int
-    max_threads_per_warp: int
-    max_warps_per_cta: int
-    max_resident_ctas_per_sm: int
-    shared_memory_per_sm_bytes: int
-    shared_memory_per_cta_bytes: int
-    unified_l1_shared_per_sm_bytes: int
-    registers_per_sm_32bit: int
-    tensor_memory_per_cta_bytes: int | None
-
-    def supports_compute_dtype(self, dtype: DType) -> bool: ...
-
-    def topology_limit(self, name: str) -> int: ...
-```
-
-- constraints:
-  - `name` MUST be the architecture identity CUDA compilation uses, and a
-    concrete architecture value MUST be immutable.
-  - A CUDA architecture MUST own supported compute DTypes, instruction
-    capabilities, and the thread/CTA structural limits.
-  - It MUST own the per-SM resource limits: resident CTAs, shared-memory
-    capacity per SM and per CTA, and register-file capacity per SM. These are
-    properties of the microarchitecture, so every product built on it shares
-    them, and a device MUST NOT restate them.
-  - `unified_l1_shared_per_sm_bytes` MUST be the size of the one physical block
-    the shared-memory carveout and the L1 data cache are both taken from, and
-    MUST be at least `shared_memory_per_sm_bytes`. The architecture MUST NOT
-    state an L1 capacity: how much L1 remains depends on how much shared memory
-    a program asked for, which is not a property of the hardware.
-  - `tensor_memory_per_cta_bytes` MUST be the whole tensor-memory store on an
-    architecture whose MMA accumulates in one, because that store is allocated
-    in columns spanning every lane and one CTA may hold all of them. It MUST be
-    `None` where the architecture has no such store, which is the same statement
-    the document makes by recording that leaf unavailable.
-  - The leaf behind every field MUST be declared by each architecture document,
-    so a value the architecture does not have is recorded as absent rather than
-    left out ([§10.2](#102-registry-and-resolution)).
-  - No field MAY carry a default: every value comes from the installed document
-    ([§10](#10-installed-hardware-resources)), so the class declares shape and
-    never content.
-
-## 13. `CudaDevice`
-
-```python
-class CudaDevice(Device):
-    """One CUDA device: how many SMs, and the memory and compute rates."""
-
-    name: str
-    sm_count: int
-    hbm_capacity_bytes: int
-    hbm_bandwidth_bytes_per_second: int
-    l2_capacity_bytes: int | None
-    _dense_flops: tuple[tuple[DType, int], ...]
-
-    def peak_for(self, dtype: DType) -> int: ...
-```
-
-- constraints:
-  - A CUDA device value MUST be immutable, MUST describe one device, and MUST
-    NOT carry a GPU count.
-  - It MUST describe how many SMs the product has and how its memory system and
-    compute units perform. Per-SM structural limits belong to the architecture
-    ([§12](#12-cudaarchitecture)).
-  - `peak_for` MUST answer from the installed document for every compute DType
-    the product's tensor cores have a mode for, and MUST raise an actionable
-    error for any other DType. A product with no such mode records that leaf
-    unavailable, so asking for its rate fails instead of reading as a rate
-    nobody published.
-  - `_dense_flops` MUST hold a dense integer FLOP/s entry per DType. A published
-    sparse peak MUST be halved and the division stated as the document's
-    evidence, so no plan is priced against a rate structured sparsity is
-    required to reach.
-  - `l2_capacity_bytes` MUST be `None` when the installed document records no
-    value for it. A recorded absence and a number are both statements about the
-    product; a substituted figure would not be.
-  - No field MAY carry a default, and no resource value MAY be written as a
-    Python literal: the installed document is the single source
-    ([§10](#10-installed-hardware-resources)). Selecting a different installed
-    document by ID is not an override; supplying a partial or edited number
-    without a document behind it is, and is not admitted.
-
-## 14. `SM100`
-
-```python
-class SM100(CudaArchitecture):
-    """SM100 compilation identity and structural capabilities."""
-```
-
-- constraints:
-  - `name` MUST be `sm_100`, the architecture identity CUDA compilation uses.
-  - SM100 MUST carry the CUDA architecture facts and add no field of its own
-    ([§12](#12-cudaarchitecture)).
-  - SM100 MUST report `f4e2m1` as a compute DType, because its MMA takes 4-bit
-    operands directly. `f8e8m0` MUST NOT be reported as one: it scales those
-    operands rather than being multiplied.
-  - SM100 MUST state a tensor-memory capacity, and its instruction capabilities
-    MUST name the MMA family that accumulates there rather than the SM90 family,
-    which this architecture does not run.
-  - Device-frequency-dependent FLOP/s values MUST NOT be stored on SM100.
-
-## 15. `B200SXM`
-
-```python
-class B200SXM(CudaDevice):
-    """One B200 SXM device."""
-```
-
-- constraints:
-  - B200SXM MUST carry the CUDA device facts and add no field of its own
-    ([§13](#13-cudadevice)).
-  - `peak_for` MUST expose a dense integer FLOP/s entry for each of `f32`,
-    `f16`, `bf16`, `fp8e4m3`, and `f4e2m1`, each value taken from the installed
-    document.
-  - Resource facts the vendor does not publish for this product, its SM count
-    and its L2 capacity among them, MUST be recorded as measured on the
-    described host rather than estimated or borrowed from a related part
-    ([§10.1](#101-document-envelope)).

--- a/docs/spec/target.md
+++ b/docs/spec/target.md
@@ -272,6 +272,11 @@ class CudaArchitecture(Architecture):
   - A provider MAY subclass it to carry a fact of its own hardware that this
     shape does not model. The added fields are subject to the same rule: they
     state what a document records, not a number written in Python.
+  - Any value a CUDA Target projects Facts from MUST answer for every field
+    declared here, whether it subclasses this type or `Architecture` directly
+    ([§1.1](#11-architecture)). The projection reads them by name, so a value
+    missing one is a Facts request that fails rather than a level reported
+    without a capacity.
 
 #### 4.1.1 SM90
 

--- a/src/tilefoundry/target/__init__.py
+++ b/src/tilefoundry/target/__init__.py
@@ -13,15 +13,7 @@ from tilefoundry.target.base import (
     registered_targets,
 )
 from tilefoundry.target.cpu import CpuTarget
-from tilefoundry.target.cuda import (
-    B200SXM,
-    H200SXM,
-    SM90,
-    SM100,
-    CudaArchitecture,
-    CudaDevice,
-    CudaTarget,
-)
+from tilefoundry.target.cuda import CudaArchitecture, CudaDevice, CudaTarget
 from tilefoundry.target.cuda.spec import H200_SXM_ID
 from tilefoundry.target.facts import TopologyLimitFacts
 from tilefoundry.target.services import Analyzer, Scheduler
@@ -56,15 +48,11 @@ __all__ = [
     "AppleAmx",
     "AppleM2Pro",
     "Architecture",
-    "B200SXM",
     "CpuTarget",
     "CudaArchitecture",
     "CudaDevice",
     "CudaTarget",
     "Device",
-    "H200SXM",
-    "SM90",
-    "SM100",
     "Scheduler",
     "Target",
     "TopologyLimitFacts",

--- a/src/tilefoundry/target/__init__.py
+++ b/src/tilefoundry/target/__init__.py
@@ -14,8 +14,10 @@ from tilefoundry.target.base import (
 )
 from tilefoundry.target.cpu import CpuTarget
 from tilefoundry.target.cuda import (
+    B200SXM,
     H200SXM,
     SM90,
+    SM100,
     CudaArchitecture,
     CudaDevice,
     CudaTarget,
@@ -54,6 +56,7 @@ __all__ = [
     "AppleAmx",
     "AppleM2Pro",
     "Architecture",
+    "B200SXM",
     "CpuTarget",
     "CudaArchitecture",
     "CudaDevice",
@@ -61,6 +64,7 @@ __all__ = [
     "Device",
     "H200SXM",
     "SM90",
+    "SM100",
     "Scheduler",
     "Target",
     "TopologyLimitFacts",

--- a/src/tilefoundry/target/__init__.py
+++ b/src/tilefoundry/target/__init__.py
@@ -13,7 +13,13 @@ from tilefoundry.target.base import (
     registered_targets,
 )
 from tilefoundry.target.cpu import CpuTarget
-from tilefoundry.target.cuda import H200SXM, SM90, CudaTarget
+from tilefoundry.target.cuda import (
+    H200SXM,
+    SM90,
+    CudaArchitecture,
+    CudaDevice,
+    CudaTarget,
+)
 from tilefoundry.target.cuda.spec import H200_SXM_ID
 from tilefoundry.target.facts import TopologyLimitFacts
 from tilefoundry.target.services import Analyzer, Scheduler
@@ -49,6 +55,8 @@ __all__ = [
     "AppleM2Pro",
     "Architecture",
     "CpuTarget",
+    "CudaArchitecture",
+    "CudaDevice",
     "CudaTarget",
     "Device",
     "H200SXM",

--- a/src/tilefoundry/target/cuda/__init__.py
+++ b/src/tilefoundry/target/cuda/__init__.py
@@ -1,13 +1,15 @@
 """CUDA target facts."""
 
-from .architecture import SM90, CudaArchitecture
-from .device import H200SXM, CudaDevice
+from .architecture import SM90, SM100, CudaArchitecture
+from .device import B200SXM, H200SXM, CudaDevice
 from .target import CudaTarget
 
 __all__ = [
+    "B200SXM",
     "CudaArchitecture",
     "CudaDevice",
     "CudaTarget",
     "H200SXM",
     "SM90",
+    "SM100",
 ]

--- a/src/tilefoundry/target/cuda/__init__.py
+++ b/src/tilefoundry/target/cuda/__init__.py
@@ -1,15 +1,7 @@
 """CUDA target facts."""
 
-from .architecture import SM90, SM100, CudaArchitecture
-from .device import B200SXM, H200SXM, CudaDevice
+from .architecture import CudaArchitecture
+from .device import CudaDevice
 from .target import CudaTarget
 
-__all__ = [
-    "B200SXM",
-    "CudaArchitecture",
-    "CudaDevice",
-    "CudaTarget",
-    "H200SXM",
-    "SM90",
-    "SM100",
-]
+__all__ = ["CudaArchitecture", "CudaDevice", "CudaTarget"]

--- a/src/tilefoundry/target/cuda/__init__.py
+++ b/src/tilefoundry/target/cuda/__init__.py
@@ -1,7 +1,13 @@
 """CUDA target facts."""
 
-from .architecture import SM90
-from .device import H200SXM
+from .architecture import SM90, CudaArchitecture
+from .device import H200SXM, CudaDevice
 from .target import CudaTarget
 
-__all__ = ["CudaTarget", "H200SXM", "SM90"]
+__all__ = [
+    "CudaArchitecture",
+    "CudaDevice",
+    "CudaTarget",
+    "H200SXM",
+    "SM90",
+]

--- a/src/tilefoundry/target/cuda/architecture.py
+++ b/src/tilefoundry/target/cuda/architecture.py
@@ -65,4 +65,13 @@ class SM90(CudaArchitecture):
     """SM90 compilation identity and structural capabilities."""
 
 
-__all__ = ["SM90", "CudaArchitecture"]
+@dataclass(frozen=True)
+class SM100(CudaArchitecture):
+    """SM100 compilation identity and structural capabilities.
+
+    Its MMA accumulates in a tensor-memory store of its own, so an SM100 value
+    states a tensor-memory capacity where SM90 states none.
+    """
+
+
+__all__ = ["SM90", "SM100", "CudaArchitecture"]

--- a/src/tilefoundry/target/cuda/architecture.py
+++ b/src/tilefoundry/target/cuda/architecture.py
@@ -1,8 +1,9 @@
 """CUDA compilation capabilities.
 
-Every value is built from an installed architecture document; this module holds
-the shape of a CUDA architecture value and the identities this package ships,
-never a copy of their numbers.
+One value type answers for every CUDA architecture. What separates sm_90 from
+sm_100 is what their installed documents record, not a class per architecture:
+the numbers live in the documents, so a type carrying none of them would only
+restate an identity the value already holds.
 """
 
 from __future__ import annotations
@@ -35,15 +36,15 @@ class CudaArchitecture(Architecture):
     # this figure rather than a constant of its own.
     unified_l1_shared_per_sm_bytes: int
     registers_per_sm_32bit: int
-    # None where the tensor cores accumulate in registers, so there is no
-    # separate store to state a capacity for.
+    # None where the MMA accumulates in registers, so there is no separate store
+    # to state a capacity for.
     tensor_memory_per_cta_bytes: int | None
 
     def _python_import_module(self) -> str:
-        # Every architecture this module defines is re-exported by the package, so
-        # a rendered constructor imports it from there. A provider's own subclass
-        # lives elsewhere and keeps its own module.
-        if type(self).__module__ == __name__:
+        # The package re-exports this type, so a rendered constructor imports it
+        # from there. A provider's own subclass lives elsewhere and keeps its own
+        # module.
+        if type(self) is CudaArchitecture:
             return "tilefoundry.target.cuda"
         return super()._python_import_module()
 
@@ -60,18 +61,4 @@ class CudaArchitecture(Architecture):
         )
 
 
-@dataclass(frozen=True)
-class SM90(CudaArchitecture):
-    """SM90 compilation identity and structural capabilities."""
-
-
-@dataclass(frozen=True)
-class SM100(CudaArchitecture):
-    """SM100 compilation identity and structural capabilities.
-
-    Its MMA accumulates in a tensor-memory store of its own, so an SM100 value
-    states a tensor-memory capacity where SM90 states none.
-    """
-
-
-__all__ = ["SM90", "SM100", "CudaArchitecture"]
+__all__ = ["CudaArchitecture"]

--- a/src/tilefoundry/target/cuda/architecture.py
+++ b/src/tilefoundry/target/cuda/architecture.py
@@ -1,7 +1,8 @@
-"""SM90 compilation capabilities.
+"""CUDA compilation capabilities.
 
-Every value is built from the installed ``nvidia.sm90`` document; this module
-holds the shape of an SM90 value, never a copy of its numbers.
+Every value is built from an installed architecture document; this module holds
+the shape of a CUDA architecture value and the identities this package ships,
+never a copy of their numbers.
 """
 
 from __future__ import annotations
@@ -13,11 +14,11 @@ from tilefoundry.target.base import Architecture
 
 
 @dataclass(frozen=True)
-class SM90(Architecture):
-    """SM90 compilation identity and structural capabilities.
+class CudaArchitecture(Architecture):
+    """What one CUDA architecture states about itself.
 
-    The per-SM limits live here rather than on a device: they are properties
-    of the microarchitecture, so every product built on SM90 shares them.
+    The per-SM limits live here rather than on a device: they are properties of
+    the microarchitecture, so every product built on it shares them.
     """
 
     name: str
@@ -34,18 +35,24 @@ class SM90(Architecture):
     # this figure rather than a constant of its own.
     unified_l1_shared_per_sm_bytes: int
     registers_per_sm_32bit: int
+    # None where the tensor cores accumulate in registers, so there is no
+    # separate store to state a capacity for.
+    tensor_memory_per_cta_bytes: int | None
 
     def _python_import_module(self) -> str:
-        if type(self) is SM90:
+        # Every architecture this module defines is re-exported by the package, so
+        # a rendered constructor imports it from there. A provider's own subclass
+        # lives elsewhere and keeps its own module.
+        if type(self).__module__ == __name__:
             return "tilefoundry.target.cuda"
         return super()._python_import_module()
 
     def supports_compute_dtype(self, dtype: DType) -> bool:
-        """Return whether SM90 has a compute instruction for ``dtype``."""
+        """Return whether this architecture has a compute instruction for ``dtype``."""
         return dtype in self.supported_compute_dtypes
 
     def topology_limit(self, name: str) -> int:
-        """Return the structural limit for an SM90 topology level."""
+        """Return the structural limit for a CUDA topology level."""
         if name == "thread":
             return self.max_threads_per_cta
         raise ValueError(
@@ -53,4 +60,9 @@ class SM90(Architecture):
         )
 
 
-__all__ = ["SM90"]
+@dataclass(frozen=True)
+class SM90(CudaArchitecture):
+    """SM90 compilation identity and structural capabilities."""
+
+
+__all__ = ["SM90", "CudaArchitecture"]

--- a/src/tilefoundry/target/cuda/device.py
+++ b/src/tilefoundry/target/cuda/device.py
@@ -1,8 +1,9 @@
-"""H200 SXM device resources.
+"""CUDA device resources.
 
-Every value is built from the installed ``nvidia.h200_sxm`` document; this
-module holds the shape of the device value, never a copy of its numbers. The
-per-SM structural limits belong to the architecture, not here.
+Every value is built from an installed device document; this module holds the
+shape of a CUDA device value and the products this package ships, never a copy
+of their numbers. The per-SM structural limits belong to the architecture, not
+here.
 """
 
 from __future__ import annotations
@@ -14,8 +15,8 @@ from tilefoundry.target.base import Device
 
 
 @dataclass(frozen=True)
-class H200SXM(Device):
-    """One H200 SXM device: how many SMs, and the memory and compute rates."""
+class CudaDevice(Device):
+    """One CUDA device: how many SMs, and the memory and compute rates."""
 
     name: str
     sm_count: int
@@ -27,7 +28,10 @@ class H200SXM(Device):
     _dense_flops: tuple[tuple[DType, int], ...]
 
     def _python_import_module(self) -> str:
-        if type(self) is H200SXM:
+        # Every device this module defines is re-exported by the package, so a
+        # rendered constructor imports it from there. A provider's own subclass
+        # lives elsewhere and keeps its own module.
+        if type(self).__module__ == __name__:
             return "tilefoundry.target.cuda"
         return super()._python_import_module()
 
@@ -47,4 +51,9 @@ class H200SXM(Device):
             ) from None
 
 
-__all__ = ["H200SXM"]
+@dataclass(frozen=True)
+class H200SXM(CudaDevice):
+    """One H200 SXM device."""
+
+
+__all__ = ["CudaDevice", "H200SXM"]

--- a/src/tilefoundry/target/cuda/device.py
+++ b/src/tilefoundry/target/cuda/device.py
@@ -56,4 +56,9 @@ class H200SXM(CudaDevice):
     """One H200 SXM device."""
 
 
-__all__ = ["CudaDevice", "H200SXM"]
+@dataclass(frozen=True)
+class B200SXM(CudaDevice):
+    """One B200 SXM device."""
+
+
+__all__ = ["B200SXM", "CudaDevice", "H200SXM"]

--- a/src/tilefoundry/target/cuda/device.py
+++ b/src/tilefoundry/target/cuda/device.py
@@ -1,8 +1,8 @@
 """CUDA device resources.
 
-Every value is built from an installed device document; this module holds the
-shape of a CUDA device value and the products this package ships, never a copy
-of their numbers. The per-SM structural limits belong to the architecture, not
+One value type answers for every CUDA device. What separates an H200 SXM from a
+B200 SXM is what their installed documents record, so there is no class per
+product; the per-SM structural limits belong to the architecture rather than
 here.
 """
 
@@ -28,10 +28,10 @@ class CudaDevice(Device):
     _dense_flops: tuple[tuple[DType, int], ...]
 
     def _python_import_module(self) -> str:
-        # Every device this module defines is re-exported by the package, so a
-        # rendered constructor imports it from there. A provider's own subclass
-        # lives elsewhere and keeps its own module.
-        if type(self).__module__ == __name__:
+        # The package re-exports this type, so a rendered constructor imports it
+        # from there. A provider's own subclass lives elsewhere and keeps its own
+        # module.
+        if type(self) is CudaDevice:
             return "tilefoundry.target.cuda"
         return super()._python_import_module()
 
@@ -51,14 +51,4 @@ class CudaDevice(Device):
             ) from None
 
 
-@dataclass(frozen=True)
-class H200SXM(CudaDevice):
-    """One H200 SXM device."""
-
-
-@dataclass(frozen=True)
-class B200SXM(CudaDevice):
-    """One B200 SXM device."""
-
-
-__all__ = ["B200SXM", "CudaDevice", "H200SXM"]
+__all__ = ["CudaDevice"]

--- a/src/tilefoundry/target/cuda/facts.py
+++ b/src/tilefoundry/target/cuda/facts.py
@@ -67,9 +67,16 @@ def memory_hierarchy(target: CudaTarget, query: object = None) -> MemoryHierarch
                 capacity_bytes=architecture.registers_per_sm_32bit * 4,
                 scope="sm",
             ),
-            # Tensor memory arrives with a later architecture; SM90 has none, and
-            # a level with no capacity is how that is said.
-            ExplicitMemoryLevelFacts(name="tmem", capacity_bytes=None, scope="cta"),
+            # Tensor memory is the store the tensor cores accumulate in where the
+            # architecture has one. It is allocated in columns spanning every
+            # lane, and one CTA can hold all of them, so the whole store is the
+            # capacity a CTA is bounded by. An architecture without one states no
+            # capacity, and the level then says it has none.
+            ExplicitMemoryLevelFacts(
+                name="tmem",
+                capacity_bytes=architecture.tensor_memory_per_cta_bytes,
+                scope="cta",
+            ),
         ),
         implicit_levels=(
             ImplicitMemoryLevelFacts(name="l1", capacity_bytes=None, scope="sm"),

--- a/src/tilefoundry/target/cuda/spec.py
+++ b/src/tilefoundry/target/cuda/spec.py
@@ -16,8 +16,8 @@ from tilefoundry.target.hardware.schema import SchemaReader
 # fact paths and so does every device document, which is what lets one schema
 # validate them all, and what makes a product's capability a recorded value
 # rather than a case in code.
-ARCHITECTURE_SCHEMA = "tilefoundry.cuda.architecture/v1"
-DEVICE_SCHEMA = "tilefoundry.cuda.device/v1"
+ARCHITECTURE_SCHEMA = "tilefoundry.cuda.architecture/v2"
+DEVICE_SCHEMA = "tilefoundry.cuda.device/v2"
 
 SM90_ID = "nvidia.sm90"
 SM100_ID = "nvidia.sm100"
@@ -144,16 +144,6 @@ def install(registry: HardwareSpecRegistry | None = None) -> None:
     into.install(B200_SXM_ID, _PACKAGE, "nvidia_b200_sxm.toml")
 
 
-def installed_sm90() -> CudaArchitecture:
-    """The installed SM90 architecture value."""
-    return HARDWARE_SPECS.resolve(SM90_ID).value
-
-
-def installed_h200_sxm() -> CudaDevice:
-    """The installed H200 SXM device value."""
-    return HARDWARE_SPECS.resolve(H200_SXM_ID).value
-
-
 install()
 
 
@@ -162,11 +152,9 @@ __all__ = [
     "B200_SXM_ID",
     "DEVICE_SCHEMA",
     "H200_SXM_ID",
-    "SM90_ID",
     "SM100_ID",
+    "SM90_ID",
     "build_cuda_architecture",
     "build_cuda_device",
     "install",
-    "installed_h200_sxm",
-    "installed_sm90",
 ]

--- a/src/tilefoundry/target/cuda/spec.py
+++ b/src/tilefoundry/target/cuda/spec.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 from tilefoundry.ir.types import DType
-from tilefoundry.target.cuda.architecture import SM90, SM100, CudaArchitecture
-from tilefoundry.target.cuda.device import B200SXM, H200SXM, CudaDevice
+from tilefoundry.target.cuda.architecture import CudaArchitecture
+from tilefoundry.target.cuda.device import CudaDevice
 from tilefoundry.target.hardware.envelope import (
     HardwareDocument,
     SchemaValidationError,
@@ -12,6 +12,10 @@ from tilefoundry.target.hardware.envelope import (
 from tilefoundry.target.hardware.registry import HARDWARE_SPECS, HardwareSpecRegistry
 from tilefoundry.target.hardware.schema import SchemaReader
 
+# One document format per kind: every CUDA architecture document states the same
+# fact paths and so does every device document, which is what lets one schema
+# validate them all, and what makes a product's capability a recorded value
+# rather than a case in code.
 ARCHITECTURE_SCHEMA = "tilefoundry.cuda.architecture/v1"
 DEVICE_SCHEMA = "tilefoundry.cuda.device/v1"
 
@@ -21,20 +25,6 @@ H200_SXM_ID = "nvidia.h200_sxm"
 B200_SXM_ID = "nvidia.b200_sxm"
 
 _PACKAGE = "tilefoundry.target.hardware"
-
-# One document format per kind: every CUDA architecture document states the same
-# fact paths and so does every device document, which is what lets one schema
-# validate them all. Which value class a document builds is the identity it
-# declares, because that identity is the document's own content rather than a
-# dispatch on a target name.
-_ARCHITECTURE_IDENTITIES: dict[str, type[CudaArchitecture]] = {
-    "sm_90": SM90,
-    "sm_100": SM100,
-}
-_DEVICE_IDENTITIES: dict[str, type[CudaDevice]] = {
-    "h200_sxm": H200SXM,
-    "b200_sxm": B200SXM,
-}
 
 # The compute DTypes a CUDA device document states a dense peak rate for. A
 # product whose tensor cores have no mode for one of them records it
@@ -55,24 +45,9 @@ def _dtypes(names: tuple[str, ...], document: HardwareDocument) -> tuple[DType, 
     return tuple(resolved)
 
 
-def _identity(
-    identities: dict[str, type], name: str, document: HardwareDocument
-) -> type:
-    """The value class the identity a document declares selects."""
-    try:
-        return identities[name]
-    except KeyError:
-        raise SchemaValidationError(
-            f"{document.id}: no value class for identity {name!r}; "
-            f"this schema builds {sorted(identities)}"
-        ) from None
-
-
 def build_cuda_architecture(document: HardwareDocument) -> CudaArchitecture:
     """Build the immutable CUDA architecture value from its installed document."""
     reader = SchemaReader(document)
-    name = reader.text("identity.name")
-    architecture_type = _identity(_ARCHITECTURE_IDENTITIES, name, document)
     max_threads_per_cta = reader.integer(
         "compute.max_threads_per_cta", unit="thread"
     )
@@ -80,8 +55,8 @@ def build_cuda_architecture(document: HardwareDocument) -> CudaArchitecture:
         "compute.max_threads_per_warp", unit="thread"
     )
     max_warps_per_cta = reader.integer("compute.max_warps_per_cta", unit="count")
-    architecture = architecture_type(
-        name=name,
+    architecture = CudaArchitecture(
+        name=reader.text("identity.name"),
         supported_compute_dtypes=_dtypes(
             reader.names("instruction.compute_dtypes"), document
         ),
@@ -138,15 +113,13 @@ def build_cuda_architecture(document: HardwareDocument) -> CudaArchitecture:
 def build_cuda_device(document: HardwareDocument) -> CudaDevice:
     """Build the immutable CUDA device value from its installed document."""
     reader = SchemaReader(document)
-    name = reader.text("identity.name")
-    device_type = _identity(_DEVICE_IDENTITIES, name, document)
     dense_flops: list[tuple[DType, int]] = []
     for dtype_name in _THROUGHPUT_DTYPE_NAMES:
         peak = reader.optional_integer(f"throughput.{dtype_name}", unit="flop/s")
         if peak is not None:
             dense_flops.append((getattr(DType, dtype_name), peak))
-    device = device_type(
-        name=name,
+    device = CudaDevice(
+        name=reader.text("identity.name"),
         sm_count=reader.integer("compute.sm_count", unit="count"),
         hbm_capacity_bytes=reader.integer("memory.hbm.capacity", unit="byte"),
         hbm_bandwidth_bytes_per_second=reader.integer(
@@ -171,12 +144,12 @@ def install(registry: HardwareSpecRegistry | None = None) -> None:
     into.install(B200_SXM_ID, _PACKAGE, "nvidia_b200_sxm.toml")
 
 
-def installed_sm90() -> SM90:
+def installed_sm90() -> CudaArchitecture:
     """The installed SM90 architecture value."""
     return HARDWARE_SPECS.resolve(SM90_ID).value
 
 
-def installed_h200_sxm() -> H200SXM:
+def installed_h200_sxm() -> CudaDevice:
     """The installed H200 SXM device value."""
     return HARDWARE_SPECS.resolve(H200_SXM_ID).value
 

--- a/src/tilefoundry/target/cuda/spec.py
+++ b/src/tilefoundry/target/cuda/spec.py
@@ -20,6 +20,11 @@ H200_SXM_ID = "nvidia.h200_sxm"
 
 _PACKAGE = "tilefoundry.target.hardware"
 
+# The compute DTypes a CUDA device document states a dense peak rate for. A
+# product whose tensor cores have no mode for one of them records it
+# unavailable, so the absence is a statement rather than a missing key.
+_THROUGHPUT_DTYPE_NAMES = ("f32", "f16", "bf16", "fp8e4m3", "f4e2m1")
+
 
 def _dtypes(names: tuple[str, ...], document: HardwareDocument) -> tuple[DType, ...]:
     """Resolve recorded dtype names against the IR dtype table."""
@@ -66,6 +71,9 @@ def build_sm90(document: HardwareDocument) -> SM90:
             "memory.unified_l1_shared.per_sm", unit="byte"
         ),
         registers_per_sm_32bit=reader.integer("memory.register.per_sm", unit="register"),
+        tensor_memory_per_cta_bytes=reader.optional_integer(
+            "memory.tensor.per_cta", unit="byte"
+        ),
     )
     reader.declared_unavailable("memory.shared.bandwidth")
     reader.declared_unavailable("memory.register.bandwidth")
@@ -99,10 +107,11 @@ def build_sm90(document: HardwareDocument) -> SM90:
 def build_h200_sxm(document: HardwareDocument) -> H200SXM:
     """Build the immutable H200 SXM value from its installed document."""
     reader = SchemaReader(document)
-    dense_flops = tuple(
-        (getattr(DType, name), reader.integer(f"throughput.{name}", unit="flop/s"))
-        for name in ("f32", "f16", "bf16", "fp8e4m3")
-    )
+    dense_flops: list[tuple[DType, int]] = []
+    for dtype_name in _THROUGHPUT_DTYPE_NAMES:
+        peak = reader.optional_integer(f"throughput.{dtype_name}", unit="flop/s")
+        if peak is not None:
+            dense_flops.append((getattr(DType, dtype_name), peak))
     device = H200SXM(
         name=reader.text("identity.name"),
         sm_count=reader.integer("compute.sm_count", unit="count"),
@@ -111,7 +120,7 @@ def build_h200_sxm(document: HardwareDocument) -> H200SXM:
             "memory.hbm.bandwidth", unit="byte/s"
         ),
         l2_capacity_bytes=reader.optional_integer("memory.l2.capacity", unit="byte"),
-        _dense_flops=dense_flops,
+        _dense_flops=tuple(dense_flops),
     )
     reader.declared_unavailable("memory.l2.bandwidth")
     reader.close()

--- a/src/tilefoundry/target/cuda/spec.py
+++ b/src/tilefoundry/target/cuda/spec.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 from tilefoundry.ir.types import DType
-from tilefoundry.target.cuda.architecture import SM90
-from tilefoundry.target.cuda.device import H200SXM
+from tilefoundry.target.cuda.architecture import SM90, SM100, CudaArchitecture
+from tilefoundry.target.cuda.device import B200SXM, H200SXM, CudaDevice
 from tilefoundry.target.hardware.envelope import (
     HardwareDocument,
     SchemaValidationError,
@@ -16,9 +16,25 @@ ARCHITECTURE_SCHEMA = "tilefoundry.cuda.architecture/v1"
 DEVICE_SCHEMA = "tilefoundry.cuda.device/v1"
 
 SM90_ID = "nvidia.sm90"
+SM100_ID = "nvidia.sm100"
 H200_SXM_ID = "nvidia.h200_sxm"
+B200_SXM_ID = "nvidia.b200_sxm"
 
 _PACKAGE = "tilefoundry.target.hardware"
+
+# One document format per kind: every CUDA architecture document states the same
+# fact paths and so does every device document, which is what lets one schema
+# validate them all. Which value class a document builds is the identity it
+# declares, because that identity is the document's own content rather than a
+# dispatch on a target name.
+_ARCHITECTURE_IDENTITIES: dict[str, type[CudaArchitecture]] = {
+    "sm_90": SM90,
+    "sm_100": SM100,
+}
+_DEVICE_IDENTITIES: dict[str, type[CudaDevice]] = {
+    "h200_sxm": H200SXM,
+    "b200_sxm": B200SXM,
+}
 
 # The compute DTypes a CUDA device document states a dense peak rate for. A
 # product whose tensor cores have no mode for one of them records it
@@ -39,9 +55,24 @@ def _dtypes(names: tuple[str, ...], document: HardwareDocument) -> tuple[DType, 
     return tuple(resolved)
 
 
-def build_sm90(document: HardwareDocument) -> SM90:
-    """Build the immutable SM90 value from its installed document."""
+def _identity(
+    identities: dict[str, type], name: str, document: HardwareDocument
+) -> type:
+    """The value class the identity a document declares selects."""
+    try:
+        return identities[name]
+    except KeyError:
+        raise SchemaValidationError(
+            f"{document.id}: no value class for identity {name!r}; "
+            f"this schema builds {sorted(identities)}"
+        ) from None
+
+
+def build_cuda_architecture(document: HardwareDocument) -> CudaArchitecture:
+    """Build the immutable CUDA architecture value from its installed document."""
     reader = SchemaReader(document)
+    name = reader.text("identity.name")
+    architecture_type = _identity(_ARCHITECTURE_IDENTITIES, name, document)
     max_threads_per_cta = reader.integer(
         "compute.max_threads_per_cta", unit="thread"
     )
@@ -49,8 +80,8 @@ def build_sm90(document: HardwareDocument) -> SM90:
         "compute.max_threads_per_warp", unit="thread"
     )
     max_warps_per_cta = reader.integer("compute.max_warps_per_cta", unit="count")
-    architecture = SM90(
-        name=reader.text("identity.name"),
+    architecture = architecture_type(
+        name=name,
         supported_compute_dtypes=_dtypes(
             reader.names("instruction.compute_dtypes"), document
         ),
@@ -104,16 +135,18 @@ def build_sm90(document: HardwareDocument) -> SM90:
     return architecture
 
 
-def build_h200_sxm(document: HardwareDocument) -> H200SXM:
-    """Build the immutable H200 SXM value from its installed document."""
+def build_cuda_device(document: HardwareDocument) -> CudaDevice:
+    """Build the immutable CUDA device value from its installed document."""
     reader = SchemaReader(document)
+    name = reader.text("identity.name")
+    device_type = _identity(_DEVICE_IDENTITIES, name, document)
     dense_flops: list[tuple[DType, int]] = []
     for dtype_name in _THROUGHPUT_DTYPE_NAMES:
         peak = reader.optional_integer(f"throughput.{dtype_name}", unit="flop/s")
         if peak is not None:
             dense_flops.append((getattr(DType, dtype_name), peak))
-    device = H200SXM(
-        name=reader.text("identity.name"),
+    device = device_type(
+        name=name,
         sm_count=reader.integer("compute.sm_count", unit="count"),
         hbm_capacity_bytes=reader.integer("memory.hbm.capacity", unit="byte"),
         hbm_bandwidth_bytes_per_second=reader.integer(
@@ -130,18 +163,20 @@ def build_h200_sxm(document: HardwareDocument) -> H200SXM:
 def install(registry: HardwareSpecRegistry | None = None) -> None:
     """Register the CUDA schemas and documents into *registry*."""
     into = HARDWARE_SPECS if registry is None else registry
-    into.register_schema(ARCHITECTURE_SCHEMA, build_sm90)
-    into.register_schema(DEVICE_SCHEMA, build_h200_sxm)
+    into.register_schema(ARCHITECTURE_SCHEMA, build_cuda_architecture)
+    into.register_schema(DEVICE_SCHEMA, build_cuda_device)
     into.install(SM90_ID, _PACKAGE, "nvidia_sm90.toml")
+    into.install(SM100_ID, _PACKAGE, "nvidia_sm100.toml")
     into.install(H200_SXM_ID, _PACKAGE, "nvidia_h200_sxm.toml")
+    into.install(B200_SXM_ID, _PACKAGE, "nvidia_b200_sxm.toml")
 
 
-def installed_architecture() -> SM90:
+def installed_sm90() -> SM90:
     """The installed SM90 architecture value."""
     return HARDWARE_SPECS.resolve(SM90_ID).value
 
 
-def installed_device() -> H200SXM:
+def installed_h200_sxm() -> H200SXM:
     """The installed H200 SXM device value."""
     return HARDWARE_SPECS.resolve(H200_SXM_ID).value
 
@@ -151,12 +186,14 @@ install()
 
 __all__ = [
     "ARCHITECTURE_SCHEMA",
+    "B200_SXM_ID",
     "DEVICE_SCHEMA",
     "H200_SXM_ID",
     "SM90_ID",
-    "build_h200_sxm",
-    "build_sm90",
+    "SM100_ID",
+    "build_cuda_architecture",
+    "build_cuda_device",
     "install",
-    "installed_architecture",
-    "installed_device",
+    "installed_h200_sxm",
+    "installed_sm90",
 ]

--- a/src/tilefoundry/target/hardware/nvidia_b200_sxm.toml
+++ b/src/tilefoundry/target/hardware/nvidia_b200_sxm.toml
@@ -1,0 +1,81 @@
+[spec]
+schema = "tilefoundry.cuda.device/v1"
+kind = "device"
+id = "nvidia.b200_sxm"
+
+[compatibility]
+architectures = ["nvidia.sm100"]
+
+[facts.identity.name]
+value = "b200_sxm"
+unit = "name"
+origin = "vendor"
+source = "https://www.nvidia.com/en-us/data-center/hgx/"
+conditions = "product identity of the SXM package an HGX B200 baseboard carries eight of"
+
+[facts.compute.sm_count]
+value = 148
+unit = "count"
+origin = "measured"
+source = "CUDA runtime device query on an NVIDIA B200 SXM, driver 590.48.01, CUDA 13.1"
+conditions = "cudaDevAttrMultiProcessorCount; NVIDIA publishes no SM count for this product, and the two dies it is built from present as one device"
+
+[facts.memory.hbm.capacity]
+value = 191505498112
+unit = "byte"
+origin = "measured"
+source = "CUDA runtime device query on an NVIDIA B200 SXM, driver 590.48.01, CUDA 13.1"
+conditions = "cudaMemGetInfo total on an idle device, so the figure already excludes what the driver reserves; the DGX B200 system specification states 1,440 GB across eight GPUs, which this part exceeds"
+
+[facts.memory.hbm.bandwidth]
+value = 7672320000000
+unit = "byte/s"
+origin = "derived"
+source = "CUDA runtime device query on an NVIDIA B200 SXM, driver 590.48.01, CUDA 13.1"
+conditions = "peak: the queried 7680-bit HBM3e bus at its queried 3996 MHz clock, transferring on both edges"
+
+[facts.memory.l2.capacity]
+value = 132644864
+unit = "byte"
+origin = "measured"
+source = "CUDA runtime device query on an NVIDIA B200 SXM, driver 590.48.01, CUDA 13.1"
+conditions = "cudaDevAttrL2CacheSize; NVIDIA publishes no L2 capacity for this product"
+
+[facts.memory.l2.bandwidth]
+status = "unavailable"
+conditions = "NVIDIA publishes no static L2 bandwidth to use for a roofline."
+
+[facts.throughput.f32]
+value = 75000000000000
+unit = "flop/s"
+origin = "derived"
+source = "https://www.nvidia.com/en-us/data-center/hgx/"
+conditions = "the published 600 TFLOP/s FP32 rate of an eight-GPU HGX B200 divided by eight; the FP32 figure carries no sparsity footnote"
+
+[facts.throughput.f16]
+value = 2250000000000000
+unit = "flop/s"
+origin = "derived"
+source = "https://www.nvidia.com/en-us/data-center/hgx/"
+conditions = "dense peak: the published 36 PFLOP/s sparse FP16 rate of an eight-GPU HGX B200 divided by eight, then by two for sparsity"
+
+[facts.throughput.bf16]
+value = 2250000000000000
+unit = "flop/s"
+origin = "derived"
+source = "https://www.nvidia.com/en-us/data-center/hgx/"
+conditions = "dense peak: the published 36 PFLOP/s sparse BF16 rate of an eight-GPU HGX B200 divided by eight, then by two for sparsity"
+
+[facts.throughput.fp8e4m3]
+value = 4500000000000000
+unit = "flop/s"
+origin = "derived"
+source = "https://www.nvidia.com/en-us/data-center/hgx/"
+conditions = "dense peak: the published 72 PFLOP/s sparse FP8 rate of an eight-GPU HGX B200 divided by eight, then by two for sparsity"
+
+[facts.throughput.f4e2m1]
+value = 9000000000000000
+unit = "flop/s"
+origin = "derived"
+source = "https://www.nvidia.com/en-us/data-center/hgx/"
+conditions = "dense peak: the published 72 PFLOP/s dense FP4 rate of an eight-GPU HGX B200 divided by eight; the FP4 row prints the sparse and dense rates separately, so no sparsity division applies"

--- a/src/tilefoundry/target/hardware/nvidia_b200_sxm.toml
+++ b/src/tilefoundry/target/hardware/nvidia_b200_sxm.toml
@@ -1,5 +1,5 @@
 [spec]
-schema = "tilefoundry.cuda.device/v1"
+schema = "tilefoundry.cuda.device/v2"
 kind = "device"
 id = "nvidia.b200_sxm"
 
@@ -21,11 +21,11 @@ source = "CUDA runtime device query on an NVIDIA B200 SXM, driver 590.48.01, CUD
 conditions = "cudaDevAttrMultiProcessorCount; NVIDIA publishes no SM count for this product, and the two dies it is built from present as one device"
 
 [facts.memory.hbm.capacity]
-value = 191505498112
+value = 180000000000
 unit = "byte"
-origin = "measured"
-source = "CUDA runtime device query on an NVIDIA B200 SXM, driver 590.48.01, CUDA 13.1"
-conditions = "cudaMemGetInfo total on an idle device, so the figure already excludes what the driver reserves; the DGX B200 system specification states 1,440 GB across eight GPUs, which this part exceeds"
+origin = "derived"
+source = "https://www.nvidia.com/en-us/data-center/dgx-b200/"
+conditions = "the published 1,440 GB across the eight GPUs of a DGX B200 divided by eight, decimal; a part provisioned with more HBM reports more through the CUDA runtime, so this is what every B200 SXM has rather than the most that some have"
 
 [facts.memory.hbm.bandwidth]
 value = 7672320000000
@@ -78,4 +78,4 @@ value = 9000000000000000
 unit = "flop/s"
 origin = "derived"
 source = "https://www.nvidia.com/en-us/data-center/hgx/"
-conditions = "dense peak: the published 72 PFLOP/s dense FP4 rate of an eight-GPU HGX B200 divided by eight; the FP4 row prints the sparse and dense rates separately, so no sparsity division applies"
+conditions = "dense peak: the FP4 row of an eight-GPU HGX B200 prints 144 PFLOP/s sparse and 72 PFLOP/s dense; this is the dense figure divided by eight, so no sparsity division applies"

--- a/src/tilefoundry/target/hardware/nvidia_h200_sxm.toml
+++ b/src/tilefoundry/target/hardware/nvidia_h200_sxm.toml
@@ -72,3 +72,7 @@ unit = "flop/s"
 origin = "derived"
 source = "https://www.nvidia.com/en-us/data-center/h200/"
 conditions = "dense peak; the published 3958 TFLOP/s sparse FP8 peak divided by two"
+
+[facts.throughput.f4e2m1]
+status = "unavailable"
+conditions = "The Hopper tensor cores have no FP4 mode, so this product has no FP4 peak rather than an unpublished one."

--- a/src/tilefoundry/target/hardware/nvidia_h200_sxm.toml
+++ b/src/tilefoundry/target/hardware/nvidia_h200_sxm.toml
@@ -1,5 +1,5 @@
 [spec]
-schema = "tilefoundry.cuda.device/v1"
+schema = "tilefoundry.cuda.device/v2"
 kind = "device"
 id = "nvidia.h200_sxm"
 

--- a/src/tilefoundry/target/hardware/nvidia_sm100.toml
+++ b/src/tilefoundry/target/hardware/nvidia_sm100.toml
@@ -1,0 +1,99 @@
+[spec]
+schema = "tilefoundry.cuda.architecture/v1"
+kind = "architecture"
+id = "nvidia.sm100"
+
+[compatibility]
+devices = ["nvidia.b200_sxm"]
+
+[facts.identity.name]
+value = "sm_100"
+unit = "name"
+origin = "vendor"
+source = "https://docs.nvidia.com/cuda/blackwell-tuning-guide/index.html"
+conditions = "compilation architecture identity of compute capability 10.0"
+
+[facts.instruction.capabilities]
+value = ["tensor_core", "tcgen05", "tma"]
+unit = "name"
+origin = "vendor"
+source = "https://docs.nvidia.com/cuda/parallel-thread-execution/index.html"
+conditions = "instruction families the SM100 code path may select; the fifth-generation tensor-core family is tcgen05, and the SM90 wgmma family is not available here"
+
+[facts.instruction.compute_dtypes]
+value = ["f32", "f16", "bf16", "fp8e4m3", "f4e2m1"]
+unit = "name"
+origin = "vendor"
+source = "https://github.com/NVIDIA/cutlass/blob/main/media/docs/cpp/blackwell_functionality.md"
+conditions = "dtypes with an SM100 compute instruction; tcgen05.mma adds the 4-bit e2m1 operand kinds that SM90 has no mode for, while f8e8m0 remains a block-scale type rather than a compute type"
+
+[facts.compute.max_threads_per_cta]
+value = 1024
+unit = "thread"
+origin = "measured"
+source = "CUDA runtime device query on an NVIDIA B200 SXM, driver 590.48.01, CUDA 13.1"
+conditions = "cudaDevAttrMaxThreadsPerBlock; the Blackwell tuning guide states the per-SM warp and block limits but not this one"
+
+[facts.compute.max_threads_per_warp]
+value = 32
+unit = "thread"
+origin = "measured"
+source = "CUDA runtime device query on an NVIDIA B200 SXM, driver 590.48.01, CUDA 13.1"
+conditions = "cudaDevAttrWarpSize; the architectural warp width"
+
+[facts.compute.max_warps_per_cta]
+value = 32
+unit = "count"
+origin = "derived"
+source = "https://docs.nvidia.com/cuda/blackwell-tuning-guide/index.html"
+conditions = "1024 threads per CTA divided by the 32-thread warp width; the guide's 64 warps is the per-SM residency limit, which is twice this per-CTA structural one"
+
+[facts.compute.max_resident_ctas_per_sm]
+value = 32
+unit = "count"
+origin = "vendor"
+source = "https://docs.nvidia.com/cuda/blackwell-tuning-guide/index.html"
+conditions = "the maximum number of thread blocks per SM is 32 for compute capability 10.0; resource usage can lower occupancy"
+
+[facts.memory.shared.per_sm]
+value = 233472
+unit = "byte"
+origin = "vendor"
+source = "https://docs.nvidia.com/cuda/blackwell-tuning-guide/index.html"
+conditions = "228 KiB shared-memory capacity per SM for compute capability 10.0"
+
+[facts.memory.shared.per_cta]
+value = 232448
+unit = "byte"
+origin = "vendor"
+source = "https://docs.nvidia.com/cuda/blackwell-tuning-guide/index.html"
+conditions = "227 KiB maximum shared memory per thread block for compute capability 10.0"
+
+[facts.memory.unified_l1_shared.per_sm]
+value = 262144
+unit = "byte"
+origin = "vendor"
+source = "https://docs.nvidia.com/cuda/blackwell-tuning-guide/index.html"
+conditions = "256 KiB combined L1, texture cache, and shared memory per SM; the shared-memory carveout and the L1 data cache divide this one block between them"
+
+[facts.memory.shared.bandwidth]
+status = "unavailable"
+conditions = "NVIDIA publishes no static shared-memory bandwidth to use for a roofline."
+
+[facts.memory.register.per_sm]
+value = 65536
+unit = "register"
+origin = "vendor"
+source = "https://docs.nvidia.com/cuda/blackwell-tuning-guide/index.html"
+conditions = "64K 32-bit registers per SM"
+
+[facts.memory.register.bandwidth]
+status = "unavailable"
+conditions = "NVIDIA publishes no static register-file bandwidth to use for a roofline."
+
+[facts.memory.tensor.per_cta]
+value = 262144
+unit = "byte"
+origin = "vendor"
+source = "https://github.com/NVIDIA/cutlass/blob/main/include/cute/arch/tmem_allocator_sm100.hpp"
+conditions = "the whole tensor-memory store, 128 lanes of 512 32-bit columns, which one CTA may hold at once because allocation is in columns across all lanes"

--- a/src/tilefoundry/target/hardware/nvidia_sm100.toml
+++ b/src/tilefoundry/target/hardware/nvidia_sm100.toml
@@ -1,10 +1,7 @@
 [spec]
-schema = "tilefoundry.cuda.architecture/v1"
+schema = "tilefoundry.cuda.architecture/v2"
 kind = "architecture"
 id = "nvidia.sm100"
-
-[compatibility]
-devices = ["nvidia.b200_sxm"]
 
 [facts.identity.name]
 value = "sm_100"

--- a/src/tilefoundry/target/hardware/nvidia_sm90.toml
+++ b/src/tilefoundry/target/hardware/nvidia_sm90.toml
@@ -1,5 +1,5 @@
 [spec]
-schema = "tilefoundry.cuda.architecture/v1"
+schema = "tilefoundry.cuda.architecture/v2"
 kind = "architecture"
 id = "nvidia.sm90"
 

--- a/src/tilefoundry/target/hardware/nvidia_sm90.toml
+++ b/src/tilefoundry/target/hardware/nvidia_sm90.toml
@@ -87,3 +87,7 @@ conditions = "SM90 maximum 32-bit register-file capacity per SM"
 [facts.memory.register.bandwidth]
 status = "unavailable"
 conditions = "NVIDIA publishes no static register-file bandwidth to use for a roofline."
+
+[facts.memory.tensor.per_cta]
+status = "unavailable"
+conditions = "SM90 has no tensor-memory store: wgmma accumulates in the register file, so there is no separate capacity to state."

--- a/tests/inspection/test_python_printer.py
+++ b/tests/inspection/test_python_printer.py
@@ -18,7 +18,7 @@ from tilefoundry.ir.hir.math.binary import Binary
 from tilefoundry.ir.types import DType, TensorType
 from tilefoundry.parser.hir_parser import parse_script
 from tilefoundry.target import Target, register_target
-from tilefoundry.target.cuda import SM90
+from tilefoundry.target.cuda import CudaArchitecture
 from tilefoundry.target.cuda import CudaTarget as BuiltinCudaTarget
 from tilefoundry.utils.python_source import PythonExpr
 
@@ -28,8 +28,8 @@ class CudaTarget(BuiltinCudaTarget):
 
 
 @dataclass(frozen=True)
-class ExtendedSM90(SM90):
-    twelfth_field: int
+class ExtendedCudaArchitecture(CudaArchitecture):
+    thirteenth_field: int
 
 
 def test_inspection_types_are_opt_in_same_line_comments():
@@ -105,12 +105,12 @@ def test_an_installed_target_reports_its_public_constructor():
 
 def test_direct_hardware_values_keep_added_fields_in_canonical_source():
     installed = BuiltinCudaTarget("nvidia.h200_sxm")
-    architecture = ExtendedSM90(
+    architecture = ExtendedCudaArchitecture(
         **{
             field.name: getattr(installed.architecture, field.name)
             for field in fields(installed.architecture)
         },
-        twelfth_field=12,
+        thirteenth_field=13,
     )
     target = BuiltinCudaTarget(
         architecture=architecture,
@@ -118,15 +118,15 @@ def test_direct_hardware_values_keep_added_fields_in_canonical_source():
     )
     rendered = target.to_python()
 
-    assert "twelfth_field=12" in rendered.text
+    assert "thirteenth_field=13" in rendered.text
     assert rendered.imports == (
-        "from tests.inspection.test_python_printer import ExtendedSM90",
+        "from tests.inspection.test_python_printer import ExtendedCudaArchitecture",
         "from tilefoundry.ir.types import DType",
-        "from tilefoundry.target.cuda import CudaTarget, H200SXM",
+        "from tilefoundry.target.cuda import CudaDevice, CudaTarget",
     )
     rebuilt = _rebuild(rendered)
     assert rebuilt == target
-    assert rebuilt.architecture.twelfth_field == 12
+    assert rebuilt.architecture.thirteenth_field == 13
 
 
 def test_external_same_named_cuda_target_keeps_its_provider_in_module_source():

--- a/tests/installed/smoke_inspect.py
+++ b/tests/installed/smoke_inspect.py
@@ -51,12 +51,12 @@ def test_inspect_capabilities_rejects_an_uninstalled_cuda_target(
             "from tilefoundry.target import CudaTarget",
             "from dataclasses import replace\n"
             "from tilefoundry.target import CudaTarget\n"
-            "from tilefoundry.target.cuda.spec import installed_architecture",
+            "from tilefoundry.target.cuda.spec import installed_sm90",
         )
         .replace(
             'target=CudaTarget("nvidia.h200_sxm")',
             'target=CudaTarget("nvidia.h200_sxm", '
-            'architecture=replace(installed_architecture(), name="sm_90_custom"))',
+            'architecture=replace(installed_sm90(), name="sm_90_custom"))',
         ),
         encoding="utf-8",
     )

--- a/tests/installed/smoke_inspect.py
+++ b/tests/installed/smoke_inspect.py
@@ -51,12 +51,14 @@ def test_inspect_capabilities_rejects_an_uninstalled_cuda_target(
             "from tilefoundry.target import CudaTarget",
             "from dataclasses import replace\n"
             "from tilefoundry.target import CudaTarget\n"
-            "from tilefoundry.target.cuda.spec import installed_sm90",
+            "from tilefoundry.target.cuda.spec import SM90_ID\n"
+            "from tilefoundry.target.hardware import HARDWARE_SPECS",
         )
         .replace(
             'target=CudaTarget("nvidia.h200_sxm")',
             'target=CudaTarget("nvidia.h200_sxm", '
-            'architecture=replace(installed_sm90(), name="sm_90_custom"))',
+            'architecture=replace(HARDWARE_SPECS.resolve(SM90_ID).value, '
+            'name="sm_90_custom"))',
         ),
         encoding="utf-8",
     )

--- a/tests/installed/smoke_target/v100.py
+++ b/tests/installed/smoke_target/v100.py
@@ -38,6 +38,7 @@ class Volta70(Architecture):
     shared_memory_per_cta_bytes: int = 96 * 1024
     unified_l1_shared_per_sm_bytes: int = 128 * 1024
     registers_per_sm_32bit: int = 64 * 1024
+    tensor_memory_per_cta_bytes: int | None = None
 
     def topology_limit(self, name: str) -> int:
         if name == "thread":

--- a/tests/target/test_hardware_resources.py
+++ b/tests/target/test_hardware_resources.py
@@ -63,6 +63,12 @@ def _document(old: str, new: str) -> str:
     return _MINIMAL_DEVICE.replace(old, new)
 
 
+def _hardware_text(resource: str) -> str:
+    """The installed hardware document *resource* as authored."""
+    hardware = Path(cuda_spec.__file__).parent.parent / "hardware"
+    return (hardware / resource).read_text(encoding="utf-8")
+
+
 def test_a_target_retains_the_identity_and_digest_of_what_it_resolved() -> None:
     """AC-1-1 and AC-1-3. Each side is a complete document in its own right, and
     a target is the pair composed through a declared compatibility rather than one
@@ -123,11 +129,7 @@ def test_an_explicitly_loaded_document_stays_out_of_the_installed_namespace(
     before = registry.installed_ids()
 
     custom = tmp_path / "custom_sm90.toml"
-    text = (
-        Path(cuda_spec.__file__).parent.parent
-        / "hardware"
-        / "nvidia_sm90.toml"
-    ).read_text(encoding="utf-8")
+    text = _hardware_text("nvidia_sm90.toml")
     custom.write_text(text.replace('id = "nvidia.sm90"', 'id = "vendor.sm90_custom"'))
 
     resolved = registry.load_path(custom)
@@ -179,10 +181,7 @@ def test_a_malformed_document_names_exactly_what_is_wrong(
 def test_a_schema_rejects_a_fact_it_does_not_model() -> None:
     """AC-1-2. An unknown key under ``facts`` is a spelling mistake, not an
     unused fact, so a document carrying one does not load."""
-    text = (
-        Path(cuda_spec.__file__).parent.parent / "hardware" / "nvidia_sm90.toml"
-    ).read_text(encoding="utf-8")
-    stray = text + (
+    stray = _hardware_text("nvidia_sm90.toml") + (
         '\n[facts.compute.max_threads_per_cluster]\n'
         'value = 8\nunit = "count"\norigin = "vendor"\n'
         'source = "test"\nconditions = "test"\n'
@@ -255,3 +254,12 @@ def test_an_unavailable_fact_omits_its_value_and_says_why() -> None:
         assert not any("topology" in path for path in document.facts)
         for fact in document.facts.values():
             assert (fact.value is None) == (not fact.available)
+
+    # A rate the product's tensor cores have no mode for is recorded as absent
+    # rather than left out, so asking for it fails instead of reading as a number
+    # nobody published.
+    assert HARDWARE_SPECS.document(_H200).fact("throughput.f4e2m1").status == (
+        "unavailable"
+    )
+    with pytest.raises(ValueError, match="no dense compute-throughput entry"):
+        CudaTarget(_H200).device.peak_for(DType.f4e2m1)

--- a/tests/target/test_hardware_resources.py
+++ b/tests/target/test_hardware_resources.py
@@ -21,7 +21,7 @@ import pytest
 from tilefoundry.ir.types import DType
 from tilefoundry.target.amx import AmxTarget
 from tilefoundry.target.amx import spec as amx_spec
-from tilefoundry.target.cuda import CudaTarget
+from tilefoundry.target.cuda import B200SXM, SM100, CudaTarget
 from tilefoundry.target.cuda import spec as cuda_spec
 from tilefoundry.target.hardware import (
     HARDWARE_SPECS,
@@ -37,7 +37,9 @@ from tilefoundry.target.hardware import (
 )
 
 _SM90 = "nvidia.sm90"
+_SM100 = "nvidia.sm100"
 _H200 = "nvidia.h200_sxm"
+_B200 = "nvidia.b200_sxm"
 
 _MINIMAL_DEVICE = """
 [spec]
@@ -119,6 +121,53 @@ def test_a_target_retains_the_identity_and_digest_of_what_it_resolved() -> None:
     )
 
 
+def test_a_second_cuda_product_composes_from_its_own_documents() -> None:
+    """AC-1-1, AC-1-2 and AC-1-4. A CUDA product is a pair of documents and
+    nothing else, so naming one device is enough to compose a target for
+    hardware the compiler has never been pointed at before.
+
+    Both products go through one document format per kind: every CUDA
+    architecture document states the same fact paths and so does every device
+    document, which is what lets one schema validate them all and what makes a
+    product's capability a recorded value rather than a special case in code. The
+    value class a document builds is the identity it declares, so an identity
+    nothing models is its own diagnostic instead of a document that loads into
+    the wrong type.
+    """
+    architecture = HARDWARE_SPECS.document(_SM100)
+    device = HARDWARE_SPECS.document(_B200)
+    assert device.compatibility == (_SM100,)
+    assert architecture.schema == HARDWARE_SPECS.document(_SM90).schema
+    assert device.schema == HARDWARE_SPECS.document(_H200).schema
+
+    target = CudaTarget(_B200)
+    assert (target.architecture_id, target.device_id) == (_SM100, _B200)
+    assert target.architecture_digest == architecture.digest
+    assert target.device_digest == device.digest
+    assert isinstance(target.architecture, SM100)
+    assert isinstance(target.device, B200SXM)
+    assert target.arch == "sm_100"
+    assert target.device.sm_count == 148
+
+    unmodelled = _hardware_text("nvidia_sm100.toml").replace(
+        'value = "sm_100"', 'value = "sm_105"'
+    )
+    with pytest.raises(SchemaValidationError, match="no value class for identity"):
+        cuda_spec.build_cuda_architecture(
+            parse_document(unmodelled, origin_label="unmodelled")
+        )
+
+    # A rate a product's tensor cores can reach, and the recorded absence of one
+    # they cannot: the second is a statement about the hardware, so asking for it
+    # fails rather than reading as an unpublished number.
+    assert target.device.peak_for(DType.f4e2m1) == 9_000_000_000_000_000
+    assert HARDWARE_SPECS.document(_H200).fact("throughput.f4e2m1").status == (
+        "unavailable"
+    )
+    with pytest.raises(ValueError, match="no dense compute-throughput entry"):
+        CudaTarget(_H200).device.peak_for(DType.f4e2m1)
+
+
 def test_an_explicitly_loaded_document_stays_out_of_the_installed_namespace(
     tmp_path: Path,
 ) -> None:
@@ -187,7 +236,7 @@ def test_a_schema_rejects_a_fact_it_does_not_model() -> None:
         'source = "test"\nconditions = "test"\n'
     )
     with pytest.raises(SchemaValidationError, match="unknown facts for schema"):
-        cuda_spec.build_sm90(parse_document(stray, origin_label="stray"))
+        cuda_spec.build_cuda_architecture(parse_document(stray, origin_label="stray"))
 
 
 def test_registration_and_resolution_failures_are_each_distinguishable() -> None:
@@ -197,7 +246,7 @@ def test_registration_and_resolution_failures_are_each_distinguishable() -> None
     cuda_spec.install(registry)
 
     with pytest.raises(UnknownDocumentError, match="no installed hardware document"):
-        registry.resolve("nvidia.sm100")
+        registry.resolve("nvidia.sm70")
     with pytest.raises(DuplicateRegistrationError, match="already registered"):
         cuda_spec.install(registry)
     with pytest.raises(DuplicateRegistrationError, match="already installed"):
@@ -223,7 +272,9 @@ def test_no_installed_number_is_repeated_as_a_python_default() -> None:
     constructed without one."""
     for value_type in (
         cuda_spec.SM90_ID,
+        cuda_spec.SM100_ID,
         cuda_spec.H200_SXM_ID,
+        cuda_spec.B200_SXM_ID,
         amx_spec.APPLE_AMX_ID,
         amx_spec.APPLE_M2_PRO_ID,
     ):
@@ -248,18 +299,9 @@ def test_an_unavailable_fact_omits_its_value_and_says_why() -> None:
     assert unavailable.status == "unavailable"
     assert unavailable.conditions
 
-    for spec_id in (_SM90, _H200, "apple.amx", "apple.m2_pro"):
+    for spec_id in (_SM90, _SM100, _H200, _B200, "apple.amx", "apple.m2_pro"):
         document = HARDWARE_SPECS.document(spec_id)
         assert not any("policy" in path for path in document.facts)
         assert not any("topology" in path for path in document.facts)
         for fact in document.facts.values():
             assert (fact.value is None) == (not fact.available)
-
-    # A rate the product's tensor cores have no mode for is recorded as absent
-    # rather than left out, so asking for it fails instead of reading as a number
-    # nobody published.
-    assert HARDWARE_SPECS.document(_H200).fact("throughput.f4e2m1").status == (
-        "unavailable"
-    )
-    with pytest.raises(ValueError, match="no dense compute-throughput entry"):
-        CudaTarget(_H200).device.peak_for(DType.f4e2m1)

--- a/tests/target/test_hardware_resources.py
+++ b/tests/target/test_hardware_resources.py
@@ -122,9 +122,9 @@ def test_a_target_retains_the_identity_and_digest_of_what_it_resolved() -> None:
 
 
 def test_a_second_cuda_product_composes_from_its_own_documents() -> None:
-    """AC-1-1, AC-1-2 and AC-1-4. A CUDA product is a pair of documents and
-    nothing else, so naming one device is enough to compose a target for
-    hardware the compiler has never been pointed at before.
+    """A CUDA product is a pair of documents and nothing else, so naming one
+    device is enough to compose a target for hardware the compiler has never been
+    pointed at before.
 
     Both products go through one document format per kind and build one value
     type per kind: every CUDA architecture document states the same fact paths
@@ -264,9 +264,7 @@ def test_no_installed_number_is_repeated_as_a_python_default() -> None:
     constructed without one."""
     for value_type in (
         cuda_spec.SM90_ID,
-        cuda_spec.SM100_ID,
         cuda_spec.H200_SXM_ID,
-        cuda_spec.B200_SXM_ID,
         amx_spec.APPLE_AMX_ID,
         amx_spec.APPLE_M2_PRO_ID,
     ):

--- a/tests/target/test_hardware_resources.py
+++ b/tests/target/test_hardware_resources.py
@@ -21,7 +21,7 @@ import pytest
 from tilefoundry.ir.types import DType
 from tilefoundry.target.amx import AmxTarget
 from tilefoundry.target.amx import spec as amx_spec
-from tilefoundry.target.cuda import B200SXM, SM100, CudaTarget
+from tilefoundry.target.cuda import CudaArchitecture, CudaDevice, CudaTarget
 from tilefoundry.target.cuda import spec as cuda_spec
 from tilefoundry.target.hardware import (
     HARDWARE_SPECS,
@@ -126,13 +126,11 @@ def test_a_second_cuda_product_composes_from_its_own_documents() -> None:
     nothing else, so naming one device is enough to compose a target for
     hardware the compiler has never been pointed at before.
 
-    Both products go through one document format per kind: every CUDA
-    architecture document states the same fact paths and so does every device
-    document, which is what lets one schema validate them all and what makes a
-    product's capability a recorded value rather than a special case in code. The
-    value class a document builds is the identity it declares, so an identity
-    nothing models is its own diagnostic instead of a document that loads into
-    the wrong type.
+    Both products go through one document format per kind and build one value
+    type per kind: every CUDA architecture document states the same fact paths
+    and so does every device document, which is what lets one schema validate
+    them all. What separates the two products is what their documents record, so
+    a Blackwell target needs no type of its own to be a distinct value.
     """
     architecture = HARDWARE_SPECS.document(_SM100)
     device = HARDWARE_SPECS.document(_B200)
@@ -141,21 +139,15 @@ def test_a_second_cuda_product_composes_from_its_own_documents() -> None:
     assert device.schema == HARDWARE_SPECS.document(_H200).schema
 
     target = CudaTarget(_B200)
+    hopper = CudaTarget(_H200)
     assert (target.architecture_id, target.device_id) == (_SM100, _B200)
     assert target.architecture_digest == architecture.digest
     assert target.device_digest == device.digest
-    assert isinstance(target.architecture, SM100)
-    assert isinstance(target.device, B200SXM)
-    assert target.arch == "sm_100"
+    assert (target.arch, target.device.name) == ("sm_100", "b200_sxm")
     assert target.device.sm_count == 148
-
-    unmodelled = _hardware_text("nvidia_sm100.toml").replace(
-        'value = "sm_100"', 'value = "sm_105"'
-    )
-    with pytest.raises(SchemaValidationError, match="no value class for identity"):
-        cuda_spec.build_cuda_architecture(
-            parse_document(unmodelled, origin_label="unmodelled")
-        )
+    assert type(target.architecture) is type(hopper.architecture) is CudaArchitecture
+    assert type(target.device) is type(hopper.device) is CudaDevice
+    assert target != hopper
 
     # A rate a product's tensor cores can reach, and the recorded absence of one
     # they cannot: the second is a statement about the hardware, so asking for it
@@ -165,7 +157,7 @@ def test_a_second_cuda_product_composes_from_its_own_documents() -> None:
         "unavailable"
     )
     with pytest.raises(ValueError, match="no dense compute-throughput entry"):
-        CudaTarget(_H200).device.peak_for(DType.f4e2m1)
+        hopper.device.peak_for(DType.f4e2m1)
 
 
 def test_an_explicitly_loaded_document_stays_out_of_the_installed_namespace(

--- a/tests/target/test_target.py
+++ b/tests/target/test_target.py
@@ -36,7 +36,7 @@ from tilefoundry.target import (
     registered_targets,
     validate_cuda_topology_levels,
 )
-from tilefoundry.target.cuda.spec import installed_architecture as _installed_sm90
+from tilefoundry.target.cuda.spec import installed_sm90 as _installed_sm90
 from tilefoundry.target.services import CodeGenerator, Scheduler
 
 

--- a/tests/target/test_target.py
+++ b/tests/target/test_target.py
@@ -36,7 +36,7 @@ from tilefoundry.target import (
     registered_targets,
     validate_cuda_topology_levels,
 )
-from tilefoundry.target.cuda.spec import installed_sm90 as _installed_sm90
+from tilefoundry.target.cuda.spec import installed_sm90
 from tilefoundry.target.services import CodeGenerator, Scheduler
 
 
@@ -326,7 +326,7 @@ def test_group_functions_by_target_fact_matching() -> None:
         body=body,
         target=CudaTarget(
             "nvidia.h200_sxm",
-            architecture=replace(_installed_sm90(), name="sm_90_alt"),
+            architecture=replace(installed_sm90(), name="sm_90_alt"),
         ),
     )
     with pytest.raises(ValueError, match="mixes unequal device Targets") as error:
@@ -390,7 +390,7 @@ def test_target_conflict_diagnostics_use_stable_summaries() -> None:
     declared_target = CudaTarget("nvidia.h200_sxm")
     explicit_target = CudaTarget(
         "nvidia.h200_sxm",
-        architecture=replace(_installed_sm90(), name="sm_90_alt"),
+        architecture=replace(installed_sm90(), name="sm_90_alt"),
     )
     module_value = Module(
         name="conflicting_targets",

--- a/tests/target/test_target.py
+++ b/tests/target/test_target.py
@@ -36,7 +36,8 @@ from tilefoundry.target import (
     registered_targets,
     validate_cuda_topology_levels,
 )
-from tilefoundry.target.cuda.spec import installed_sm90
+from tilefoundry.target.cuda.spec import SM90_ID
+from tilefoundry.target.hardware import HARDWARE_SPECS
 from tilefoundry.target.services import CodeGenerator, Scheduler
 
 
@@ -326,7 +327,7 @@ def test_group_functions_by_target_fact_matching() -> None:
         body=body,
         target=CudaTarget(
             "nvidia.h200_sxm",
-            architecture=replace(installed_sm90(), name="sm_90_alt"),
+            architecture=replace(HARDWARE_SPECS.resolve(SM90_ID).value, name="sm_90_alt"),
         ),
     )
     with pytest.raises(ValueError, match="mixes unequal device Targets") as error:
@@ -390,7 +391,7 @@ def test_target_conflict_diagnostics_use_stable_summaries() -> None:
     declared_target = CudaTarget("nvidia.h200_sxm")
     explicit_target = CudaTarget(
         "nvidia.h200_sxm",
-        architecture=replace(installed_sm90(), name="sm_90_alt"),
+        architecture=replace(HARDWARE_SPECS.resolve(SM90_ID).value, name="sm_90_alt"),
     )
     module_value = Module(
         name="conflicting_targets",

--- a/tests/target/test_target_facts.py
+++ b/tests/target/test_target_facts.py
@@ -29,6 +29,10 @@ def test_builtin_targets_own_their_facts_projections() -> None:
 
     assert throughput.memory_bandwidth_bytes_per_second == 4_800_000_000_000
     assert memory.explicit("gmem").capacity_bytes == cuda.device.hbm_capacity_bytes
+    # A tensor-memory level with no capacity is how an architecture that
+    # accumulates in registers says it has no such store.
+    assert cuda.architecture.tensor_memory_per_cta_bytes is None
+    assert memory.explicit("tmem").capacity_bytes is None
     assert AmxTarget().get_facts(ThroughputFacts).bandwidth_level == "gmem"
 
 

--- a/tests/target/test_target_facts.py
+++ b/tests/target/test_target_facts.py
@@ -38,8 +38,8 @@ def test_builtin_targets_own_their_facts_projections() -> None:
 
 
 def test_two_cuda_products_project_the_hardware_each_one_is() -> None:
-    """AC-1-3 and AC-1-4. One projection serves both products, so what separates
-    them is what their documents record rather than a branch per architecture.
+    """One projection serves both products, so what separates them is what their
+    documents record rather than a branch per architecture.
 
     Tensor memory is the case that matters: a level with no capacity says the
     architecture has no such store, and a capacity says a CTA's accumulators live

--- a/tests/target/test_target_facts.py
+++ b/tests/target/test_target_facts.py
@@ -9,7 +9,12 @@ from typing import ClassVar
 
 import pytest
 
-from tilefoundry.analysis.facts import MemoryHierarchyFacts, ThroughputFacts
+from tilefoundry.analysis.facts import (
+    MemoryHierarchyFacts,
+    ParallelCapacityFacts,
+    ThroughputFacts,
+)
+from tilefoundry.ir.types import DType
 from tilefoundry.ir.types.shard import Topology
 from tilefoundry.target import (
     AmxTarget,
@@ -29,11 +34,33 @@ def test_builtin_targets_own_their_facts_projections() -> None:
 
     assert throughput.memory_bandwidth_bytes_per_second == 4_800_000_000_000
     assert memory.explicit("gmem").capacity_bytes == cuda.device.hbm_capacity_bytes
-    # A tensor-memory level with no capacity is how an architecture that
-    # accumulates in registers says it has no such store.
-    assert cuda.architecture.tensor_memory_per_cta_bytes is None
-    assert memory.explicit("tmem").capacity_bytes is None
     assert AmxTarget().get_facts(ThroughputFacts).bandwidth_level == "gmem"
+
+
+def test_two_cuda_products_project_the_hardware_each_one_is() -> None:
+    """AC-1-3 and AC-1-4. One projection serves both products, so what separates
+    them is what their documents record rather than a branch per architecture.
+
+    Tensor memory is the case that matters: a level with no capacity says the
+    architecture has no such store, and a capacity says a CTA's accumulators live
+    in one. A projection that reported the same for both would price a Blackwell
+    kernel against Hopper's registers.
+    """
+    hopper = CudaTarget("nvidia.h200_sxm")
+    blackwell = CudaTarget("nvidia.b200_sxm")
+
+    assert hopper.get_facts(MemoryHierarchyFacts).explicit("tmem").capacity_bytes is None
+    tmem = blackwell.get_facts(MemoryHierarchyFacts).explicit("tmem")
+    assert (tmem.capacity_bytes, tmem.scope) == (262_144, "cta")
+
+    throughput = blackwell.get_facts(ThroughputFacts)
+    peaks = dict(throughput.peak_flops_per_second)
+    assert throughput.memory_bandwidth_bytes_per_second == 7_672_320_000_000
+    assert peaks[DType.f4e2m1] == 9_000_000_000_000_000
+    assert DType.f4e2m1 not in dict(
+        hopper.get_facts(ThroughputFacts).peak_flops_per_second
+    )
+    assert blackwell.get_facts(ParallelCapacityFacts).parallel_units == 148
 
 
 def test_a_target_without_a_requested_projection_fails_closed() -> None:


### PR DESCRIPTION
Closes #77.

## Why

- The CUDA target describes exactly one product, so external target support has no
  second NVIDIA part to be exercised on.
- A B200 has two facts no CUDA value could hold: SM100 accumulates its MMA in a
  tensor-memory store that SM90 does not have, and its tensor cores have an FP4
  mode with a published dense peak.

## What

- `CudaArchitecture` and `CudaDevice` are the whole code side: one value type per
  kind, one schema per kind building it. A CUDA product is its architecture
  document and its device document and nothing else — no `Target` subclass, and no
  architecture or device type of its own, because such a type would carry no
  number and only restate an identity the value already holds.
- An architecture states its tensor-memory capacity or records that it has none,
  which the CUDA memory-hierarchy projection reports as the `tmem` level's
  capacity. A device states a dense peak per compute DType or records the
  absence, so `peak_for` raises for a mode the product does not have.
- `nvidia.sm100` and `nvidia.b200_sxm` install alongside the Hopper pair, so
  `CudaTarget("nvidia.b200_sxm")` composes them, reaches codegen as `sm_100`, and
  projects 148 SMs, its own HBM bandwidth, a 256 KiB tensor-memory level, and a
  dense FP4 peak the H200 has no entry for. Adding a further CUDA product is
  adding two TOML files.
- A provider that needs a fact this shape does not model still subclasses the
  value type and states it from a document of its own; the printer workflow covers
  that path.

Hardware evidence follows the existing rules. The Blackwell tuning guide covers
the per-SM limits; the tensor-core peaks are the published HGX B200 rates divided
by eight and, where the figure is sparse, by two, with the division stated as the
leaf's `conditions`. NVIDIA publishes no SM count and no L2 capacity for this
part, so those are recorded as measured through the CUDA runtime on a B200 SXM
rather than borrowed from a related die.

## Contract

- `docs/spec/target.md` follows the same narrative as the code: `CudaArchitecture`
  is §4.1 and `CudaDevice` is §4.2 under `CudaTarget`, and the four products are
  the documents recorded under them (§4.1.1 SM90, §4.1.2 SM100, §4.2.1 H200SXM,
  §4.2.2 B200SXM). The old §2 and §3 are gone; §4 also states that a further CUDA
  product is two documents rather than a subclass, and §10.2 that a document's
  recorded identity is what it is, not a key into a class table.
- Removed from the public surface: `SM90`, `SM100`, `H200SXM`, `B200SXM`. A caller
  holding one of those types now holds `CudaArchitecture` or `CudaDevice`;
  `CudaTarget("nvidia.h200_sxm")` and every projection are unchanged.
- Renamed: `build_sm90` / `build_h200_sxm` → `build_cuda_architecture` /
  `build_cuda_device`, since one builder now serves every value of its kind.
  Removed: `installed_architecture` / `installed_device`, which named one product
  each once a second was installed; both call sites resolve by ID.
- Both CUDA schemas are `/v2`. They require two leaves a `/v1` document does not
  carry — `memory.tensor.per_cta` and `throughput.f4e2m1` — and
  `SchemaReader.optional_integer` requires the key even when the value is
  recorded unavailable, so an old document would stop loading with a
  missing-fact error rather than a signal that the contract moved.
- Every CUDA architecture value states `tensor_memory_per_cta_bytes`; the external
  `Volta70` provider example gains it as `None`.
- `nvidia.sm100` was standing in as an unknown-document example in the
  resolution-diagnostics workflow; that case now uses an ID that stays unknown.
- One reference in an edited constraint rendered as a link to the Target section
  followed by a literal `0.2`; it now points at the registry subsection it meant.

## Evidence

Run on an eight-GPU B200 SXM host, driver 590.48.01, CUDA 13.1, nvcc 13.1. Every
figure below is from the current tip.

- `pre-commit run --all-files` — all nine hooks pass, no file rewritten.
- `pytest tests/` — 680 passed (on the branch with `main` merged in).
- **The whole real-hardware suite against the new target.** Pointing
  `tests/integration` at `nvidia.b200_sxm` instead of `nvidia.h200_sxm` gives 42
  passed: MMA runtime, handwritten TIR MMA, dynamic CTA launch, dynamic shape
  dispatch, rmsnorm + FP8 quant, and the host-launch group including its
  external-target and negative cases.
- **It is real `sm_100` SASS, not PTX compatibility.** `cuobjdump -lelf` on the
  linked module reports `libmain.1.sm_100.cubin` and `cuobjdump -sass` reports
  `arch = sm_100`.
- Wheel: `python -m pip wheel .` ships `nvidia_sm100.toml` and
  `nvidia_b200_sxm.toml`; installed into a clean environment,
  `CudaTarget("nvidia.b200_sxm")` answers `sm_100 / 148 SMs / tmem 262144`.
- `pytest tests/installed -o python_files='smoke_*.py'` against that wheel — 159
  passed, including the external-V100-provider smoke that reads the architecture
  field this change adds.

## Risk

- No test in the suite requires B200 hardware: the documents and projections are
  checked as values, so a CI host without a Blackwell device is unaffected. The
  runs above are the hardware evidence.
- `arch` is `sm_100`, not `sm_100a`. Nothing emitted today needs the
  architecture-specific variant, but a kernel using the tensor-memory MMA family
  would; selecting it is a codegen concern and not part of this change.
- The B200 SM count and L2 capacity are what the CUDA runtime reports, because
  NVIDIA publishes neither for this part; each leaf names the host and the query
  it came from. The HBM capacity is the published per-GPU figure rather than the
  larger number the part under test reports, so a plan is never sized against
  memory a differently provisioned B200 does not have.
