### PR TITLE
refactor(analysis): settle Analyze contracts

### DIFF
--- a/docs/spec/analysis.md
+++ b/docs/spec/analysis.md
@@ -312,10 +312,14 @@ requested analysis and renders the results together
     presentation, and two families would then disagree about it.
   - A rendering MUST report what the caller *requested*. A requested analysis
     pulls its dependencies in, so records reach the IR that nobody asked to see;
-    those records MUST stay on the IR and MUST NOT be reported. Which records an
-    analysis owns MUST be read from its Target-selected descriptor
-    ([§3.1](#31-target-selected-analyzers)) rather than from a
-    second table.
+    by default those records MUST stay on the IR and MUST NOT be reported. A
+    requested `roofline` view is the bounded exception: alongside its verdict it
+    MUST carry the exact summed work and traffic and the per-level peak footprint
+    its declared dependencies wrote, while `requested` still names only
+    `roofline`. It MUST NOT promote persistent bytes, capacities, advisories,
+    lifetimes, or the per-operand split. Which records an analysis owns MUST be
+    read from its Target-selected descriptor ([§3.1](#31-target-selected-analyzers))
+    rather than from a second table.
   - Every rendering of one run MUST make that selection through one shared
     decision. A summary and an annotated program are two views of the same run,
     and choosing separately is how one of them comes to show a dependency the
@@ -328,6 +332,12 @@ requested analysis and renders the results together
     renderer.
   - Two formats over one report MUST carry the same conclusions. They MUST be
     built from one intermediate structure rather than formatted independently.
+  - A compact text report header MUST contain whole-function facts only. A
+    per-value fact belongs on that value's annotated equation; in particular,
+    `ComputeCostMetadata.operands` MUST render there by its positional argument
+    labels plus `result`, and MUST NOT add one header line per Call. The equation
+    supplies the names those positions refer to, while JSON MAY retain those
+    names and operand types in its structured projection.
 
 ### 2.1 Metadata records
 
@@ -664,6 +674,11 @@ class ParallelCapacityFacts:
 `tilefoundry.analysis.api.analyze` is the dependency-composed measurement
 operation. One call selects one root analysis by name; the operation resolves
 what that root transitively needs, runs each member once, and reports what ran.
+Its subject is one `Module` and one HIR `Function` that Module owns. Reachable
+HIR callees are part of that selected invocation and do not become separate
+launches because of Module ownership; the invocation rule is owned by
+[hir §1.1](./hir.md#11-function). Analyze does not select, interpret, trace, or
+dummy-run a plain Python orchestration method.
 
 ```python
 class AnalysisResult:

--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -257,9 +257,10 @@ whole; a reader who asked what a rule says is not asking for every rule.
 comments, regardless of analysis flags. It never performs candidate search,
 layout enumeration, or automatic resharding.
 
-Each flag names one root analysis. With no flag, `analyze` runs all of them. The
-selected Module's resolved Target determines the hardware specification; there is
-no ordinary `--target` option.
+Each flag names one root analysis. With no analysis flag, `analyze` requests no
+family: it type-checks the selection and prints its complete inferred HIR. The
+selected Module's resolved Target determines the hardware specification for an
+explicit analysis; there is no ordinary `--target` option.
 
 - constraints:
   - `analyze` MUST invoke the public operation once per requested root, because
@@ -269,13 +270,17 @@ no ordinary `--target` option.
   - A selection MUST resolve to a Module. A bare Function MUST be rejected
     naming the reason: it declares neither the Target its numbers are measured
     against nor the topology hierarchy they divide over.
-  - `--json` MUST print the report as JSON instead of text. Both formats MUST
-    carry the same conclusions ([analysis §2](./analysis.md#2-authored-hir-metrics)).
+  - `--json` MUST print the report as JSON instead of text. It MUST be refused as
+    an argument-combination error when no analysis flag was supplied, naming that
+    a report needs a requested root and printing the `analyze` usage. Both
+    formats MUST carry the same conclusions
+    ([analysis §2](./analysis.md#2-authored-hir-metrics)).
   - `--topology LEVEL` MUST be optional, passed through as the public analysis
     operation's `level`, and name the unit for per-unit figures. Its help MUST
     state the default and, for every family, which figure changes with the level
     and when to pass it, together with the global-traffic and observed-peak
     assumptions.
+    With no analysis flag it MUST be accepted and inert.
   - `--dim NAME=EXTENT` MUST bind one dimension the selection leaves open, and
     MUST be repeatable to bind several. One dimension MUST receive one extent;
     a comma-separated list of extents for one dimension MUST be rejected because
@@ -289,10 +294,13 @@ no ordinary `--target` option.
     be rejected naming that dimension, whether or not the two extents agree; the
     later occurrence MUST NOT win, because both came from the caller and choosing
     between them silently answers a request that has no answer.
-  - With no `--dim`, the selection MUST be analysed as authored. A selection that
-    leaves a dimension open MUST then fail naming the dimension, its declared
-    `[lo, hi)` interval, and concrete extents inside that interval the caller can
-    use: counting elements requires an extent, and a range is not one.
+  - With no `--dim`, the selection MUST be analysed or type-checked as authored.
+    A selection that leaves a dimension open MUST then fail naming the dimension,
+    its declared `[lo, hi)` interval, and concrete extents inside that interval
+    the caller can use: inferring its concrete program requires an extent, and a
+    range is not one. The bare form MUST apply stated dimensions before running
+    the same type inference and authored validation preflight used by analysis;
+    this is an internal CLI path, not a public typecheck operation.
   - Every requested analysis MUST be reported together even when each was run at
     the stated extents, which builds one program per analysis. The report MUST
     accept those as one program when they were rebuilt from the same function at
@@ -301,14 +309,17 @@ no ordinary `--target` option.
     resulting signature: a dimension occurring only in a loop bound or a body
     operation's attribute leaves the signature identical at every extent.
   - Output MUST report the analyses that were requested. A dependency that ran
-    because a requested root needed it MUST appear in the executed list and MUST
-    NOT have its own measurements reported.
+    because a requested root needed it MUST appear in the executed list and, other
+    than the bounded roofline support view defined by
+    [analysis §2](./analysis.md#2-authored-hir-metrics), MUST NOT have its own
+    measurements reported.
   - The report's `target` field MUST be the concrete Target value's `identity`,
     so two products served by one Target class remain distinguishable.
-  - On success, text output begins with the `#`-headed report followed by
-    annotated HIR. On inference, verification, or analysis failure, stdout MUST
-    be empty and stderr MUST report the source location, binding where
-    available, and reason.
+  - On success with at least one requested root, text output begins with the
+    `#`-headed report followed by annotated HIR. With no analysis flag, output is
+    the typed HIR alone, with no report header and no analysis Metadata comment.
+    On inference, verification, or analysis failure, stdout MUST be empty and
+    stderr MUST report the source location, binding where available, and reason.
 
 ## Schedule
 

--- a/docs/spec/core-ir.md
+++ b/docs/spec/core-ir.md
@@ -83,6 +83,12 @@ class Module:
     a derived function's recorded specialization origin; equal copies and
     same-name functions from another Module MUST remain unowned.
 
+A `Module` is a static ownership and execution-context container, not a dynamic
+invocation. Owning a `Function`, attaching a child `Module`, or declaring a
+`Target` or `Topology` hierarchy never itself begins or counts an invocation;
+Python-to-HIR entry and HIR-to-HIR device calls are governed by
+[hir §1.1](./hir.md#11-function).
+
 - `parse_module` (see [parser §1](./parser.md#1-dsl-syntax)) returns a `Module`.
 - A bare `@func` / `@prim_func` becomes an implicit single-function
   `Module` whose `entry` is set to that function. A function that declares

--- a/docs/spec/hir.md
+++ b/docs/spec/hir.md
@@ -62,6 +62,26 @@ class Function(Expr):
     that owns it declares the `Target` and the ordered `Topology` hierarchy its
     body runs against ([core-ir §1](./core-ir.md#1-module)).
 
+**Kernel invocation.** Entering an HIR `Function` from Python begins one kernel
+invocation. A `Call` from one HIR `Function` to another is a device call inside
+the current kernel invocation and never begins another one, regardless of which
+`Module` owns the callee. A `Module` is a static container and an invocation is
+a dynamic event: Python entering one root twice is two invocations, and a Python
+loop entering it N times is N. Module ownership, topology equality, call-graph
+depth, and source nesting take no part in this rule.
+
+| Caller | Callee | Meaning |
+|---|---|---|
+| Python | HIR `Function`, directly or through a `Module` entry | Begin one kernel invocation |
+| HIR `Function` | HIR `Function` with the same owner | Same-kernel device call |
+| HIR `Function` | HIR `Function` with a different owner | Same-kernel device call |
+| Python | Plain Python `Module` method | Ordinary host orchestration |
+| HIR `Function` | Plain Python method | Invalid |
+
+A plain Python `Module` method stays on the host. Each HIR `Function` it enters
+therefore begins its own invocation; the method itself is not interpreted,
+traced, or dummy-run as HIR.
+
 `Function.body` is a **single Expr** (usually a Call DAG, possibly
 nested inside a `GridRegionExpr`). HIR has no Stmt sequence; name
 reuse lives in the parser's lexical environment, not the IR. The one

--- a/docs/spec/parser.md
+++ b/docs/spec/parser.md
@@ -704,8 +704,9 @@ is.
   delegates to; any other name is reached only by naming it. A class-body
   `__call__` MUST be rejected: Python resolves a dunder on the type, so one
   attached to the built Module instance would never run.
-- A member MAY call a sibling **defined above it** (the call resolves to the
-  sibling function / launches a sibling device kernel); a forward reference to a
+- An HIR member MAY call a sibling HIR function **defined above it**. The call
+  resolves to a `Call` targeting that Function and remains inside the current
+  kernel invocation ([hir §1.1](./hir.md#11-function)); a forward reference to a
   sibling defined below stays unresolved and MUST fail.
 - The `topologies=(Topology(...), ...)` decorator argument declares the
   domain's complete ordered hierarchy. Omitting it inherits the owning class's

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -260,6 +260,13 @@ class LoadedModule:
     left to fail as a shape error inside the evaluator. `check` compares the
     semantic and runtime forwards ([§1.6](#16-check)). A multi-node composition is chained
     by the caller, one `forward` (or one named function call) per node.
+  - Python entry into an HIR `Function`, whether through `forward`'s entry
+    fallback or a named function runner, is the runtime event governed by
+    [hir §1.1](./hir.md#11-function). A registered plain Python orchestration
+    method stays on the host; every function runner it calls is a separate
+    Python-to-HIR entry. An HIR-to-HIR `Call` remains inside the invocation and
+    MUST NOT be surfaced as another runtime launch merely because its callee has
+    a different Module owner.
   - a causal-LM root MAY define `init_caches`,
     `prepare_inputs_for_generation`, and `append_cache` orchestration methods.
     `prepare_inputs_for_generation(input_ids, step, caches, *, device)` receives

--- a/src/tilefoundry/analysis/metadata.py
+++ b/src/tilefoundry/analysis/metadata.py
@@ -48,7 +48,16 @@ class ComputeCostMetadata(IRMetadata):
             )
             or "0"
         )
-        return f"compute-cost flops={flop_text} per-unit={local_text} bytes={traffic_text}"
+        operand_text = ",".join(
+            f"{'result' if index == len(self.operands) - 1 else index}:"
+            f"r{value.read}/w{value.write}"
+            for index, value in enumerate(self.operands)
+        )
+        operands = f" operands={operand_text}" if operand_text else ""
+        return (
+            f"compute-cost flops={flop_text} per-unit={local_text} "
+            f"bytes={traffic_text}{operands}"
+        )
 
 
 @dataclass(frozen=True)

--- a/src/tilefoundry/cli/__init__.py
+++ b/src/tilefoundry/cli/__init__.py
@@ -203,6 +203,7 @@ def build_parser() -> argparse.ArgumentParser:
     analyze.add_argument(
         "--json", action="store_true", help="print the report as JSON instead of text"
     )
+    analyze.set_defaults(_command_parser=analyze)
 
     schedule = commands.add_parser(
         "schedule",
@@ -270,6 +271,16 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.command is None:
         sys.stdout.write(overview())
         return 0
+    analyses: tuple[str, ...] = ()
+    if args.command == "analyze":
+        analyses = tuple(
+            name for name in _ANALYSES if getattr(args, name.replace("-", "_"))
+        )
+        if args.json and not analyses:
+            args._command_parser.error(
+                "--json requires at least one analysis flag: "
+                + ", ".join(f"--{name}" for name in _ANALYSES)
+            )
     try:
         registrations = load_registrations(registry_path(args.registry))
     except (OSError, TypeError, ValueError) as error:
@@ -339,9 +350,6 @@ def main(argv: Sequence[str] | None = None) -> int:
             print(f"tilefoundry: error: {error}", file=sys.stderr)
             return 1
 
-    analyses = tuple(name for name in _ANALYSES if getattr(args, name.replace("-", "_")))
-    if not analyses:
-        analyses = _ANALYSES
     try:
         return run_authored_analysis(
             args.source,

--- a/src/tilefoundry/cli/analyze.py
+++ b/src/tilefoundry/cli/analyze.py
@@ -7,6 +7,8 @@ import textwrap
 from typing import Mapping
 
 from tilefoundry.analysis.api import analyze
+from tilefoundry.analysis.preflight import infer_authored_types, validate_authored
+from tilefoundry.analysis.walk import reachable_functions
 from tilefoundry.cli.source import load_authored_ir, suggested_extents
 from tilefoundry.inspection import PythonPrintOptions, as_script
 from tilefoundry.inspection.analysis_report import (
@@ -15,7 +17,7 @@ from tilefoundry.inspection.analysis_report import (
     report,
     selected_types,
 )
-from tilefoundry.ir.hir.specialize import dim_vars_reached
+from tilefoundry.ir.hir.specialize import dim_vars_reached, specialize_concretely
 
 EVIDENCE: dict[str, str] = {
     "compute-cost": "the logical work and traffic of every value: flops by dtype, bytes moved",
@@ -40,8 +42,10 @@ def guidance() -> str:
         searches nothing, rewrites nothing, and picks no optimization: what to do
         about a number is yours.
 
-        Complete inferred types are printed whatever the flags are; each flag above
-        adds one root analysis, and with no flag every one of them runs.
+        Complete inferred types are printed whatever the flags are, and with no flag
+        that is the whole answer: analyze type-checks the selection and prints it.
+        Each flag above adds one root analysis, and every analysis is asked for by
+        name.
 
         It reads the authored program, so it answers before any implementation of it
         exists -- and its numbers are the floor an implementation is read against,
@@ -106,6 +110,15 @@ def run_authored_analysis(
             for name, dim_var in unbound
         )
         raise ValueError(f"analyze needs one EXTENT for every open dimension: {guidance}")
+    if not analyses:
+        checked = specialize_concretely(function, dims) if dims is not None else function
+        functions = reachable_functions(checked)
+        infer_authored_types(functions, module)
+        validate_authored(functions)
+        annotated = as_script(module, options=PythonPrintOptions(show_types=True))
+        sys.stdout.write(annotated)
+        return 0
+
     results = [
         analyze(module, function, analysis=name, level=topology, dims=dims)
         for name in analyses

--- a/src/tilefoundry/inspection/analysis_report.py
+++ b/src/tilefoundry/inspection/analysis_report.py
@@ -220,6 +220,11 @@ def report(results: Sequence[AnalysisResult]) -> dict[str, object]:
             if selector not in executed:
                 executed.append(selector)
     target = first.module.resolve_target()
+    function_records = _merged_function_records(results, selected)
+    if "roofline" in {item.analysis for item in results} and "memory" not in function_records:
+        support = _roofline_memory_support(results)
+        if support is not None:
+            function_records["memory"] = support
     data = {
         "target": target.identity,
         "module": first.module.name,
@@ -227,12 +232,38 @@ def report(results: Sequence[AnalysisResult]) -> dict[str, object]:
         "topology": first.level,
         "requested": [item.analysis for item in results],
         "executed": executed,
-        "function_records": _merged_function_records(results, selected),
+        "function_records": function_records,
         "calls": _merged_call_records(results, selected),
     }
-    if ComputeCostMetadata in selected:
+    available = {
+        metadata_type
+        for item in results
+        for metadata_type in item.metadata_types
+    }
+    if ComputeCostMetadata in selected or (
+        "roofline" in data["requested"] and ComputeCostMetadata in available
+    ):
         data["totals"] = _work_totals(_costed_function(results))
     return data
+
+
+def _roofline_memory_support(
+    results: Sequence[AnalysisResult],
+) -> dict[str, object] | None:
+    """The bounded memory fact that explains a requested roofline verdict."""
+    for item in results:
+        if item.analysis != "roofline":
+            continue
+        record = get_metadata(item.function, MemoryMetadata)
+        if record is None:
+            continue
+        return {
+            "footprint": [
+                {"level": value.level, "peak_bytes": value.peak_bytes}
+                for value in record.footprint
+            ]
+        }
+    return None
 
 
 def _merged_function_records(
@@ -335,13 +366,6 @@ def _traffic_text(traffic: dict[str, dict[str, int]]) -> str:
     )
 
 
-def _operand_text(operand: dict[str, object]) -> str:
-    return (
-        f"{operand['arg']}:{operand['name']}="
-        f"r{operand['read']}/w{operand['write']}"
-    )
-
-
 def render_text(data: dict[str, object]) -> str:
     """The report as one stable line per conclusion, each prefixed with ``#``.
 
@@ -370,7 +394,7 @@ def render_text(data: dict[str, object]) -> str:
                 or "0"
             )
         )
-        lines.extend(f"advisory {note}" for note in memory["advisories"])
+        lines.extend(f"advisory {note}" for note in memory.get("advisories", ()))
     if "roofline" in records:
         bound = records["roofline"]
         lines.append(
@@ -378,16 +402,6 @@ def render_text(data: dict[str, object]) -> str:
         )
     if "timeline" in records:
         lines.append(f"theoretical-makespan={records['timeline']['end_ns']}ns")
-    for call in data["calls"]:
-
-
-        operands = call.get("compute-cost", {}).get("operands")
-        if operands is None:
-            continue
-        lines.append(
-            f"value={call['value']} operands "
-            + ", ".join(_operand_text(operand) for operand in operands)
-        )
     return "\n".join(f"# {line}" for line in lines)
 
 

--- a/tests/analysis/test_analysis_families.py
+++ b/tests/analysis/test_analysis_families.py
@@ -726,11 +726,12 @@ def test_the_gpu_memory_graph_is_not_a_tree() -> None:
 
 
 def test_a_report_shows_the_requested_analyses_and_reads_the_same_either_way() -> None:
-    """A requested root pulls its dependencies in.
+    """Promote only bounded dependency evidence into a roofline report.
 
     A requested root pulls its dependencies in, so their records land on the
-    IR without having been asked for. A report shows what was requested; the
-    dependency's records stay on the IR for whoever does ask.
+    IR without having been asked for. Roofline promotes only the bounded
+    whole-program evidence that explains its verdict; dependency details stay on
+    the IR for whoever does ask.
 
     Two formats over one structure cannot disagree about a conclusion, so the
     text is checked to carry the verdict the JSON states.
@@ -740,10 +741,25 @@ def test_a_report_shows_the_requested_analyses_and_reads_the_same_either_way() -
 
     data = report([result])
 
+    assert data["requested"] == ["roofline"]
     assert data["executed"] == ["compute-cost", "memory", "roofline"]
-    assert set(data["function_records"]) == {"roofline"}
+    assert set(data["function_records"]) == {"memory", "roofline"}
+    memory = data["function_records"]["memory"]
+    assert set(memory) == {"footprint"}
+    assert all(set(item) == {"level", "peak_bytes"} for item in memory["footprint"])
+    assert data["totals"]["flops"] == {"f32": 256}
+    assert all(set(call) == {"value", "roofline"} for call in data["calls"])
     assert get_metadata(entry, MemoryMetadata) is not None
+    cost = get_metadata(_calls(entry)[-1], ComputeCostMetadata)
+    assert cost is not None
+    assert " operands=0:r" in cost.format_comment()
+    assert ",result:r" in cost.format_comment()
 
     payload = json.loads(render_json(data))
     assert payload == data
-    assert f"by={payload['function_records']['roofline']['bound_by']}" in render_text(data)
+    text = render_text(data)
+    assert f"by={payload['function_records']['roofline']['bound_by']}" in text
+    assert "# flops " in text
+    assert "# traffic " in text
+    assert "# peak-footprint " in text
+    assert "operands" not in text

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -144,6 +144,20 @@ def test_analyze_help_explains_topology_effects_and_assumptions(capsys) -> None:
     assert "is an observation, not a bound" in help_text
 
 
+def test_analyze_json_without_a_requested_root_is_a_usage_error(capsys) -> None:
+    with pytest.raises(SystemExit) as stopped:
+        cli.main(["analyze", "missing.py", "--json"])
+
+    assert stopped.value.code == 2
+    refused = capsys.readouterr()
+    assert refused.out == ""
+    assert refused.err.startswith(
+        "tilefoundry analyze: error: --json requires at least one analysis flag:"
+    )
+    assert "usage: tilefoundry analyze" in refused.err
+    assert "source file not found" not in refused.err
+
+
 def test_target_list_expressions_execute_and_show_accepts_their_identities(
     capsys, monkeypatch
 ) -> None:

--- a/tests/installed/smoke_analyze.py
+++ b/tests/installed/smoke_analyze.py
@@ -17,6 +17,20 @@ class Bad:
         return wrong
 """
 
+_OPEN_MODULE = '''
+from tilefoundry import module
+from tilefoundry.dsl import DimVar, Tensor, Topology, func, tf
+from tilefoundry.target import CudaTarget
+
+N = DimVar("N", 1, 9)
+
+@module(entry="main", target=CudaTarget("nvidia.h200_sxm"), topologies=(Topology("cta", 1),))
+class Open:
+    @func
+    def main(x: Tensor[(N,), "f32"]):
+        return tf.add(x, x)
+'''
+
 
 def test_every_analysis_the_command_offers_runs(tf, cmine) -> None:
     done = tf(
@@ -45,13 +59,51 @@ def test_usage_errors_include_the_command_help(tf) -> None:
     assert "model.py[:Module[.child_module...][.function]]" in done.stderr
 
 
+def test_a_bare_analyze_typechecks_and_prints_only_typed_hir(tf, cmine) -> None:
+    done = tf("analyze", f"{cmine}:CMine.root", "--topology", "not-a-level")
+    assert done.returncode == 0, done.stderr
+    assert done.stderr == ""
+    assert "# Tensor[" in done.stdout
+    assert "# analysis " not in done.stdout
+    assert "compute-cost " not in done.stdout
+    assert "memory peak=" not in done.stdout
+    assert "roofline bound=" not in done.stdout
+    assert "timeline units=" not in done.stdout
+
+
+def test_analyze_json_needs_an_explicit_analysis(tf, cmine) -> None:
+    done = tf("analyze", f"{cmine}:CMine.root", "--json")
+    assert done.returncode == 2
+    assert done.stdout == ""
+    assert done.stderr.startswith(
+        "tilefoundry analyze: error: --json requires at least one analysis flag:"
+    )
+    assert "usage: tilefoundry analyze" in done.stderr
+
+
+def test_a_bare_analyze_binds_every_open_dimension(tf, tmp_path) -> None:
+    source = tmp_path / "open.py"
+    source.write_text(_OPEN_MODULE, encoding="utf-8")
+
+    unbound = tf("analyze", f"{source}:Open")
+    assert unbound.returncode == 1
+    assert unbound.stdout == ""
+    assert "N is declared as [1, 9)" in unbound.stderr
+
+    bound = tf("analyze", f"{source}:Open", "--dim", "N=4")
+    assert bound.returncode == 0, bound.stderr
+    assert "# analysis " not in bound.stdout
+
+
 def test_analyze_reports_only_the_analyses_that_were_requested(tf, cwide) -> None:
     done = tf("analyze", f"{cwide}:Model", "--roofline")
     assert done.returncode == 0, done.stderr
 
     assert "# analyses=roofline executed=compute-cost,memory,roofline" in done.stdout
+    assert "# flops " in done.stdout
+    assert "# traffic " in done.stdout
     assert "# ideal-bound=" in done.stdout
-    assert "# peak-footprint" not in done.stdout
+    assert "# peak-footprint" in done.stdout
     assert "# theoretical-makespan" not in done.stdout
     assert "roofline bound=" in done.stdout
     assert "memory peak=" not in done.stdout
@@ -60,11 +112,12 @@ def test_analyze_reports_only_the_analyses_that_were_requested(tf, cwide) -> Non
 
 
 def test_analyze_json_and_text_report_the_same_conclusions(tf, cwide) -> None:
-    as_json = tf("analyze", f"{cwide}:Model", "--json")
+    analyses = ("--compute-cost", "--memory", "--roofline", "--timeline")
+    as_json = tf("analyze", f"{cwide}:Model", *analyses, "--json")
     assert as_json.returncode == 0, as_json.stderr
     payload = json.loads(as_json.stdout)
 
-    as_text = tf("analyze", f"{cwide}:Model")
+    as_text = tf("analyze", f"{cwide}:Model", *analyses)
     assert as_text.returncode == 0, as_text.stderr
     text = as_text.stdout
     assert as_text.stderr == ""
@@ -83,6 +136,9 @@ def test_analyze_json_and_text_report_the_same_conclusions(tf, cwide) -> None:
     )
     assert "# Tensor[" in text
     assert "compute-cost flops=f32:" in text
+    header, annotated = text.split("\n\n", 1)
+    assert "operands" not in header
+    assert " operands=" in annotated
     assert "roofline bound=" in text
     assert "timeline units=168 waves=2" in text
 


### PR DESCRIPTION
## Why
- Settle kernel invocation and make Analyze output actionable.

## What
- Make bare Analyze type-check HIR and require explicit roots for reports.
- Add bounded roofline facts and move operand traffic beside equations.
- Make HIR the invocation-rule specification owner.

## Contract
- Python-to-HIR starts an invocation; HIR-to-HIR stays inside it. Bare Analyze runs no family. Roofline keeps `requested=roofline` while adding totals and peak footprint.

## Risk
- None.
