### PR TITLE
docs(policies,plan): settle test acceptance while the plan is written

### DIFF
--- a/docs/develop.md
+++ b/docs/develop.md
@@ -86,11 +86,8 @@ short bullet list — keep it that way.
   `convention = "google"`.
 - Describe local logic only.
 - The spec is the only durable document a docstring may reference
-  (`docs/spec/... §...`). Never reference `docs/plans/...` — plans are
-  working-process docs, not a stable contract.
-- A constraint that must guide code long-term belongs in the spec
-  first; the comment then cites the spec, never the plan that proposed
-  it.
+  (`docs/spec/... §...`). Never reference `docs/plans/...`.
+- A constraint that must guide code long-term belongs in the spec first.
 - No milestone / version references.
 - No PR / task / commit / issue / msg / thread coordinates.
 - No agent or human names; no discussion / review narration.
@@ -124,24 +121,20 @@ short bullet list — keep it that way.
 
 ### Tests
 
-- Write meaningful positive tests that exercise the intended path.
+- How a milestone is accepted is settled with the author while the plan is
+  written, in its `##### Accepted by`; `scripts/finalize_plan_context.py`
+  refuses to finalize a plan that leaves that choice open, and prints the
+  contract from `docs/policies/project-policy.json`.
 - Each milestone defines its own Target State Design before implementation.
   Show every part the milestone settles in its delivered form as code or compact
-  pseudocode. Implementation and review match that design; tests exercise its
-  externally observable behavior.
+  pseudocode. Implementation and review match that design.
 - A Target State Design covers every step its milestone lists. A step with no
   delivered shape is a reviewer's finding before implementation begins.
-- Start with the smallest existing workflow that reaches the changed behaviour;
-  extend it before creating another test file or harness.
 - One workflow may evidence several acceptance criteria. An acceptance criterion
   describes behaviour, not a one-test obligation.
-- Add a new test only when no existing workflow can reach a public behaviour;
-  state that missing reachability when you ask for the gate.
 - Lock contracts, not implementation detail. Do not test source text, AST shape,
   private calls, object identity, counts, or names merely to prevent a future
   refactor.
-- Add a negative test only for an externally reachable invalid input or error
-  contract; do not add catch-all defensive cases for hypothetical rewrites.
 
 ### DSL / HIR authoring
 

--- a/docs/plans/TEMPLATE.md
+++ b/docs/plans/TEMPLATE.md
@@ -25,11 +25,21 @@ target_repo: tilefoundry
 - None
 
 #### Target State Design
-<!-- Show every part this milestone designs in its delivered form. Use code or
-     compact pseudocode. -->
+
+##### Delivered
+<!-- The surface this milestone designs, the behaviour it executes, and its
+     output, in delivered form. Use code or compact pseudocode. -->
 ```python
 # <delivered code shape>
 ```
+
+##### Accepted by
+<!-- How this target state is accepted. Two answers are legal, and the first is
+     not an exception:
+       - nothing new; name the existing suites that must still pass unchanged
+       - the test that earns its place; say which bar it clears and what breaks it
+     Settled with the author while the plan is written. -->
+- <existing suite by path, unchanged>
 
 #### Related Files
 <!-- Files this milestone touches. List owning docs/spec/*.md files when it
@@ -47,7 +57,7 @@ target_repo: tilefoundry
 - [ ] AC-0-1: <author-written, milestone-specific observable behaviour>
 - [ ] AC-0-2: <author-written, milestone-specific observable behaviour>
 <!-- policy_ac:start -->
-- [ ] Touched tests and comments MUST be reviewed for redundancy: remove ones superseded by the retained workflow, and do not add source-shape or hypothetical-refactor guards unless that form is a public contract. <!-- policy_ac: milestone_review-0 -->
+- [ ] Touched tests MUST be reviewed for redundancy: remove ones superseded by the retained workflow, and do not add source-shape or hypothetical-refactor guards unless that form is a public contract. <!-- policy_ac: milestone_review-0 -->
 <!-- policy_ac:end -->
 
 ### Milestone M1: <name>
@@ -56,11 +66,21 @@ target_repo: tilefoundry
 - M0
 
 #### Target State Design
-<!-- Show every part this milestone designs in its delivered form. Use code or
-     compact pseudocode. -->
+
+##### Delivered
+<!-- The surface this milestone designs, the behaviour it executes, and its
+     output, in delivered form. Use code or compact pseudocode. -->
 ```python
 # <delivered code shape>
 ```
+
+##### Accepted by
+<!-- How this target state is accepted. Two answers are legal, and the first is
+     not an exception:
+       - nothing new; name the existing suites that must still pass unchanged
+       - the test that earns its place; say which bar it clears and what breaks it
+     Settled with the author while the plan is written. -->
+- <existing suite by path, unchanged>
 
 #### Related Files
 - <path>
@@ -72,13 +92,11 @@ target_repo: tilefoundry
 #### Acceptance Criteria
 - [ ] AC-1-1: <author-written observable behaviour>
 <!-- policy_ac:start -->
-- [ ] Touched tests and comments MUST be reviewed for redundancy: remove ones superseded by the retained workflow, and do not add source-shape or hypothetical-refactor guards unless that form is a public contract. <!-- policy_ac: milestone_review-0 -->
+- [ ] Touched tests MUST be reviewed for redundancy: remove ones superseded by the retained workflow, and do not add source-shape or hypothetical-refactor guards unless that form is a public contract. <!-- policy_ac: milestone_review-0 -->
 <!-- policy_ac:end -->
 
 ## Final Gate
 
 <!-- Auto-filled repository-wide gates. -->
 <!-- final_gate:start -->
-- [ ] Spec section MUST NOT enumerate test names; the pre-commit `spec-rules-lint` and `english-only` hooks already reject forbidden section headers, plan / milestone / task / PR / commit references, agent names, and non-English text. <!-- policy_final: spec_discipline-0 -->
-- [ ] No touched C++/CUDA files in this plan — clang-format gate N/A <!-- policy_final: clang_format-na -->
 <!-- final_gate:end -->

--- a/docs/policies/project-policy.json
+++ b/docs/policies/project-policy.json
@@ -2,39 +2,29 @@
   "version": 1,
   "policies": [
     {
-      "id": "scope_discipline",
-      "name": "Scope discipline",
-      "description": "One commit touches only what the current task requires; unrelated edits / submodule bumps / autoformat go in separate commits or are called out explicitly.",
-      "when": {
-        "path_glob": ["**"]
-      },
-      "rules": {
-        "implementer": [
-          {"path": "docs/develop.md", "section": "Scope"}
-        ],
-        "reviewer": [
-          {"path": "docs/develop.md", "section": "Scope"}
-        ]
-      }
-    },
-    {
       "id": "milestone_review",
       "name": "Milestone review",
-      "description": "Touched tests and comments retain only meaningful contract coverage after each milestone.",
+      "description": "Touched tests retain only meaningful contract coverage after each milestone.",
       "when": {
-        "path_glob": ["**"]
+        "path_glob": [
+          "**"
+        ]
       },
       "ac": [
-        "Touched tests and comments MUST be reviewed for redundancy: remove ones superseded by the retained workflow, and do not add source-shape or hypothetical-refactor guards unless that form is a public contract."
+        "Touched tests MUST be reviewed for redundancy: remove ones superseded by the retained workflow, and do not add source-shape or hypothetical-refactor guards unless that form is a public contract."
       ],
       "rules": {
         "implementer": [
-          {"path": "docs/develop.md", "section": "Tests"},
-          {"path": "docs/develop.md", "section": "Code comments"}
+          {
+            "path": "docs/develop.md",
+            "section": "Tests"
+          }
         ],
         "reviewer": [
-          {"path": "docs/develop.md", "section": "Tests"},
-          {"path": "docs/develop.md", "section": "Code comments"}
+          {
+            "path": "docs/develop.md",
+            "section": "Tests"
+          }
         ]
       }
     },
@@ -43,103 +33,52 @@
       "name": "Spec impact",
       "description": "Every source milestone names the specifications it changes among its Related Files, so the public-contract surface is declared once.",
       "when": {
-        "path_glob": ["src/**", "include/**"]
+        "path_glob": [
+          "src/**",
+          "include/**"
+        ]
       },
       "ac": [
         "A milestone that changes a public contract MUST list the owning `docs/spec/*.md` path in its `#### Related Files`; one that changes none lists no spec path."
       ],
       "rules": {
         "implementer": [
-          {"path": "docs/develop.md", "section": "Spec impact"}
+          {
+            "path": "docs/develop.md",
+            "section": "Spec impact"
+          }
         ],
         "reviewer": [
-          {"path": "docs/develop.md", "section": "Spec impact"}
-        ]
-      }
-    },
-    {
-      "id": "clang_format",
-      "name": "C++ formatting",
-      "description": "C++/CUDA sources follow the repo .clang-format; touched files are formatted by the versioned pre-commit clang-format hook (touched-files scope, no tree-wide pass).",
-      "when": {
-        "path_glob": [
-          "include/**",
-          "**/*.cu",
-          "**/*.cuh",
-          "**/*.h",
-          "**/*.hpp",
-          "**/*.cpp",
-          "**/*.cc"
-        ]
-      },
-      "final_ac": [
-        "Touched C++/CUDA files (`*.h`/`*.hpp`/`*.cuh`/`*.cu`/`*.cpp`/`*.cc`) MUST be formatted by the pre-commit `clang-format` hook (or an equivalent `clang-format --dry-run -Werror` check)."
-      ],
-      "rules": {
-        "implementer": [
-          {"path": "docs/develop.md", "section": "C++ formatting"}
-        ],
-        "reviewer": [
-          {"path": "docs/develop.md", "section": "C++ formatting"}
+          {
+            "path": "docs/develop.md",
+            "section": "Spec impact"
+          }
         ]
       }
     },
     {
       "id": "test_discipline",
       "name": "Test discipline",
-      "description": "Tests prove observable behaviour through existing workflows when possible; no defensive checks that lock implementation detail.",
-      "when": {
-        "path_glob": ["tests/**"]
-      },
-      "rules": {
-        "implementer": [
-          {"path": "docs/develop.md", "section": "Tests"}
-        ],
-        "reviewer": [
-          {"path": "docs/develop.md", "section": "Tests"}
-        ]
-      }
-    },
-    {
-      "id": "spec_discipline",
-      "name": "Spec discipline",
-      "description": "Spec sections follow the spec-writing contract: principle-first, RFC 2119 style, no cross-layer leakage.",
-      "when": {
-        "path_glob": ["docs/spec/**"]
-      },
-      "final_ac": [
-        "Spec section MUST NOT enumerate test names; the pre-commit `spec-rules-lint` and `english-only` hooks already reject forbidden section headers, plan / milestone / task / PR / commit references, agent names, and non-English text."
-      ],
-      "rules": {
-        "implementer": [
-          {"path": "docs/SPEC-RULES.md", "section": "Principle"},
-          {"path": "docs/SPEC-RULES.md", "section": "Constraints"}
-        ],
-        "reviewer": [
-          {"path": "docs/SPEC-RULES.md", "section": "Principle"},
-          {"path": "docs/SPEC-RULES.md", "section": "Constraints"}
-        ]
-      }
-    },
-    {
-      "id": "dsl_hir_authoring",
-      "name": "DSL/HIR authoring",
-      "description": "Conventions for @func DSL fixtures: no docstring in @func body, tf.<op> attribute path, variadic op call surface, SSA reachability.",
+      "description": "A test is committed only when it earns its place; how a milestone is accepted is settled with the author, not chosen during implementation.",
       "when": {
         "path_glob": [
-          "tests/models/**",
-          "tests/dsl/**",
-          "src/tilefoundry/dsl/**"
+          "tests/**"
         ]
       },
-      "knowledge": {
-        "implementer": [
-          {"path": "docs/develop.md", "section": "DSL / HIR authoring"}
-        ],
-        "reviewer": [
-          {"path": "docs/develop.md", "section": "DSL / HIR authoring"}
-        ]
-      }
+      "guidance": [
+        "Tests are evidence. One is committed only when it is",
+        "  necessary    -- no existing workflow reaches the behaviour",
+        "  reusable     -- more than this one change will depend on it",
+        "  fragile      -- a plausible future change breaks it",
+        "  non-trivial  -- what it asserts cannot be read off a signature",
+        "A negative case is committed only for an invalid input reachable from outside;",
+        "a hypothetical rewrite is not a plausible future change.",
+        "Anything else is run once and not committed.",
+        "",
+        "`##### Accepted by` states which of the two answers this milestone takes:",
+        "  - nothing new; name the existing suites that must still pass unchanged",
+        "  - the test that earns its place; say which bar it clears and what breaks it"
+      ]
     }
   ]
 }

--- a/scripts/finalize_plan_context.py
+++ b/scripts/finalize_plan_context.py
@@ -297,6 +297,7 @@ class PlanModel:
         return {
             "name": name,
             "related_files": effective_paths,
+            "target_state_section": sections["Target State Design"],
             "ac_section": ac_section,
             "policy_ac_start_idx": ac_start,
             "policy_ac_end_idx": ac_end,
@@ -347,6 +348,36 @@ def _replace_range(lines: list[str], start_idx: int, end_idx: int, body: list[st
     return lines[: start_idx + 1] + body + lines[end_idx:]
 
 
+def _require_acceptance(plan: "PlanModel", policies: list[dict[str, Any]]) -> None:
+    """Every milestone states how its target state is accepted.
+
+    The delivered shape and the way it is accepted are settled together while the
+    plan is written. A milestone that omits the second half would leave that
+    choice to whoever implements it, so finalizing fails and prints the contract
+    the author needs in order to make the call.
+    """
+    guidance = next(
+        (p["guidance"] for p in policies if p.get("guidance")),
+        [],
+    )
+    for milestone in plan.milestones:
+        start, end = milestone["target_state_section"]
+        for required in ("Delivered", "Accepted by"):
+            span = _find_section(plan.scan, 5, required, start + 1, end)
+            body = (
+                [ln for ln in plan.lines[span[0] + 1 : span[1]] if ln.strip()]
+                if span is not None
+                else []
+            )
+            if not body:
+                detail = "\n".join(guidance)
+                raise FinalizeError(
+                    f"{plan.path}: milestone {milestone['name']!r} has no "
+                    f"`##### {required}` under `#### Target State Design`."
+                    + (f"\n\n{detail}" if detail else "")
+                )
+
+
 def finalize_plan(
     plan_path: Path,
     *,
@@ -363,6 +394,7 @@ def finalize_plan(
     """
     plan = PlanModel(plan_path)
     policies = load_policies(policy_path)
+    _require_acceptance(plan, policies)
 
     plan_matched = filter_policies(policies, plan.plan_related_files)
 

--- a/tests/scripts/test_finalize_plan_context.py
+++ b/tests/scripts/test_finalize_plan_context.py
@@ -17,14 +17,12 @@ def test_template_finalizer_keeps_milestone_and_final_gate_scoped(
     before, after = finalize_plan(plan, write=False)
     assert before != after
     assert after.count("#### Target State Design") == 2
-    assert after.count("Touched tests and comments MUST be reviewed") == 2
+    assert after.count("Touched tests MUST be reviewed") == 2
     assert after.count("MUST list the owning `docs/spec/*.md` path") == 2
-    assert after.count("Spec section MUST NOT reference plans") == 0
-    assert after.count("No touched C++/CUDA files in this plan") == 1
 
     legacy = after.replace(
-        "- [ ] Touched tests and comments MUST be reviewed",
-        "- [x] Touched tests and comments MUST be reviewed",
+        "- [ ] Touched tests MUST be reviewed",
+        "- [x] Touched tests MUST be reviewed",
         1,
     ).replace(
         "<!-- policy_ac: milestone_review-0 -->",
@@ -35,7 +33,7 @@ def test_template_finalizer_keeps_milestone_and_final_gate_scoped(
     )
     plan.write_text(legacy)
     _, normalized = finalize_plan(plan, write=False)
-    assert "- [x] Touched tests and comments MUST be reviewed" in normalized
+    assert "- [x] Touched tests MUST be reviewed" in normalized
     assert "milestone_review-1" not in normalized
     assert "milestone_review-2" not in normalized
 


### PR DESCRIPTION
## Why

- How a milestone is accepted was settled nowhere. `test_discipline` held the
  rules and pointed at `docs/develop.md §Tests`, but a policy's `rules` field has
  no consumer — nothing carries that text to an implementer. It has been that way
  since the initial import, so the choice of what to leave in the repository fell
  to whoever wrote the code.
- Four policies restated what a hook or the parser already rejects.
  `spec_discipline`'s own acceptance text said the pre-commit hooks "already
  reject" the thing it was asking for.

## What

- `#### Target State Design` gains two halves: `##### Delivered` (surface,
  behaviour, output, as before) and `##### Accepted by`. The second takes one of
  two answers — nothing new beyond the suites that must still pass, or the test
  that earns its place. The first is listed first and is not an exception.
- `finalize_plan_context.py` refuses to finalize a plan whose milestone omits
  either half, and prints the contract from the policy file, so a plan that
  leaves the question open cannot reach a reviewer.
- `test_discipline` moves from an unread `rules` pointer to `guidance` that the
  finalizer prints.
- Policies removed: `clang_format` and `spec_discipline` (pre-commit hooks),
  `dsl_hir_authoring` (the parser refuses it), `scope_discipline` (commit rules
  are kept locally). `milestone_review` drops its comment half, enforced by
  `comment_hygiene_lint.py`. Seven policies become three.
- `docs/develop.md §Tests` drops from 21 lines to 17 and stops carrying the rules
  itself; its opening imperative is replaced by a pointer to `##### Accepted by`.

## Contract

- Every milestone in a finalized plan states both halves of its target state.
  Finalizing fails otherwise, naming the milestone and the missing half.
- The bar for a committed test lives in `docs/policies/project-policy.json` as
  `test_discipline.guidance`, and is printed at the point of failure rather than
  filed in a document.
- `docs/plans/TEMPLATE.md` remains the canonical finalizer output; the two new
  subsections are part of it.

## Risk

- `develop.md`'s `### C++ formatting` and `### DSL / HIR authoring` no longer have
  a policy pointing at them. Neither should be deleted wholesale — the C++ naming
  and header conventions are not checkable by any hook — so they are left as
  human documentation pending a per-rule pass.
- `final_gate` now renders empty: both `final_ac` policies were the removed ones.
  The mechanism stands unused until a repository-wide gate needs it.
- `tests/scripts/test_finalize_plan_context.py` asserts policy text as string
  literals, so it fails whenever a policy's wording changes. It was updated here
  rather than reworked; the scope behaviour it protects (milestone AC per
  milestone, final AC once per plan) deserves a probe that is not the wording.
