### PR TITLE
feat(parser): move a tile window by a compile-time offset

### DIFF
--- a/docs/spec/evaluator.md
+++ b/docs/spec/evaluator.md
@@ -186,6 +186,10 @@ class Evaluator(ExprVisitor):
 - `Slice` consumes its evaluated `starts` tuple and resolves `sizes/strides`
   through `dim_bindings`. A window exceeding a runtime axis MUST raise
   `EvalError` rather than return a value whose data disagrees with its full-window type.
+- A dim-arithmetic `Call` reached as an operand — a `Slice` start moved off a
+  loop's induction variable is one — folds the values its operands evaluated to.
+  It performs the arithmetic `resolve_dim` performs in a shape position; only the
+  leaves differ, being operands rather than `DimVar` sizes.
 - A `Call` whose `target` is a `Function` ([hir §1.1](./hir.md#11-function)) binds the
   evaluated arguments to the callee's parameters in a fresh environment
   and evaluates the callee `body` — the same value semantics a call site

--- a/docs/spec/hir.md
+++ b/docs/spec/hir.md
@@ -620,7 +620,10 @@ their input when it states one. An input with `layout=None` produces a view with
 - `Slice` is normalized as `Slice(x, starts, sizes=..., strides=...)`.
   `starts` is a tuple of rank-0 integer operands; `sizes` and `strides` are
   `ShapeDim` attributes. Its result shape is exactly `sizes` and MUST NOT contain
-  an induction `Var`.
+  an induction `Var`. A start MAY be dim arithmetic over an induction `Var` — a
+  window moved off that loop's window by a compile-time offset. That start is an
+  address computed where it is read, not a value some op produces, so a walk over
+  compute ops MUST leave it alone.
 - A plain-layout `Slice` with static starts MUST produce a `ComposedLayout`: its
   offset is the source offset plus the starts multiplied by the source strides,
   and its outer layout carries the sliced shape and retained strides (multiplied

--- a/docs/spec/parser.md
+++ b/docs/spec/parser.md
@@ -385,7 +385,22 @@ value is carried verbatim into `GridRegionExpr.start` / `.extent` / `.step`
 and resolved at evaluate time ([hir §1.2](./hir.md#12-gridregionexpr)).
 
 A tensor subscript `x[slice0, …]` inside a loop body lifts to a
-`hir.tensor.Slice` Op call. An `ast.Assign` whose single Name target is
+`hir.tensor.Slice` Op call.
+
+A subscript axis MAY **move** a tile window by a compile-time integer: `x[:, i + C]`
+reads `[lo + C, lo + C + step)`, the window `i` alone reads translated by `C`. The
+base is compile-time either way, so the moved start is a dim expression over `iv`
+and the axis keeps the static extent `i` alone gives it. Offsets accumulate, so
+`i + A + B` and `A + B + i` name one move by one sum, and each term is a
+compile-time integer on its own. `C - i` MUST be refused: it reverses the window
+rather than moving it. The loop domain, the window length, the offset and the axis
+extent are all compile-time, so a move whose first window would start before the
+axis, or whose last window would end past a static extent, MUST be refused where it
+is written — unlike an unmoved window's own tail, which the axis extent catches at
+evaluate time. In an Expr position `i + C` is ordinary scalar arithmetic over
+`slice.start` and carries none of this.
+
+An `ast.Assign` whose single Name target is
 bound in *outer* scope is a loop-carried rebinding (see [§5](#5-hir-parser) for the carry-out
 lift). A **nested** `for ... in tile/range(...)` is allowed and lifts to a
 nested `GridRegionExpr`; the carry scan recurses into nested loops, so an

--- a/docs/spec/parser.md
+++ b/docs/spec/parser.md
@@ -482,7 +482,8 @@ For a tensor slice, a run-time rank-0 integer is permitted as an endpoint only
 when the resulting window size is a compile-time dimension. The canonical
 spelling is `start:start + K`; the parser MUST reject an unrelated stop
 endpoint because `Slice.sizes` is a static attribute. The slice stride remains
-compile-time.
+compile-time. A tile window keeps its own length and MAY be **moved** by a
+compile-time offset instead ([§1.7](#17-for-i-in-tile--for-i-in-range-hir-only)).
 
 ## 2. DSL namespace surface
 

--- a/docs/spec/passes.md
+++ b/docs/spec/passes.md
@@ -278,9 +278,12 @@ reshard cross-CTA sync fence, tuple-carry field lookup) MAY call other
 
 A unit-stride HIR `Slice` lowers to a `TensorView` at the per-axis absolute
 element starts; `InsertSlice` uses the same coordinate convention. Neither
-multiplies an already-absolute coordinate by a window extent. A non-divisible
-tile loop whose body consumes such a fixed-shape window MUST raise until a
-handwritten residual-tail lowering is supplied.
+multiplies an already-absolute coordinate by a window extent. A start that is dim
+arithmetic over literals and scalar Vars is an address the emitter computes, so
+lowering MUST carry it to the coordinate site rather than lower it as a value. A
+non-divisible tile loop whose body consumes such a fixed-shape window MUST raise
+until a handwritten residual-tail lowering is supplied; a window moved by a
+compile-time offset is still that loop's window for this rule.
 
 #### Mesh structure derivation
 

--- a/docs/spec/passes.md
+++ b/docs/spec/passes.md
@@ -281,6 +281,8 @@ element starts; `InsertSlice` uses the same coordinate convention. Neither
 multiplies an already-absolute coordinate by a window extent. A start that is dim
 arithmetic over literals and scalar Vars is an address the emitter computes, so
 lowering MUST carry it to the coordinate site rather than lower it as a value. A
+coordinate that an **op** computes MUST be refused: materializing it produces a
+buffer, and a buffer is not a scalar index. A
 non-divisible tile loop whose body consumes such a fixed-shape window MUST raise
 until a handwritten residual-tail lowering is supplied; a window moved by a
 compile-time offset is still that loop's window for this rule.

--- a/src/tilefoundry/analysis/poly.py
+++ b/src/tilefoundry/analysis/poly.py
@@ -15,18 +15,18 @@ from dataclasses import dataclass, field
 
 import isl
 
-from tilefoundry.ir.core import Call, Constant, Tuple, TypeInferContext, Var, binding_name
+from tilefoundry.ir.core import Call, Tuple, TypeInferContext, Var, binding_name
 from tilefoundry.ir.hir.function import Function
 from tilefoundry.ir.hir.grid_region import GridRegionExpr
 from tilefoundry.ir.hir.nn.rope import RoPE
 from tilefoundry.ir.hir.tensor.full_like import FullLike
 from tilefoundry.ir.hir.tensor.index_select import IndexSelect
 from tilefoundry.ir.hir.tensor.reshape import Reshape, flat_reshape_map
-from tilefoundry.ir.hir.tensor.slice import Slice
+from tilefoundry.ir.hir.tensor.slice import Slice, window_base
 from tilefoundry.ir.hir.tensor.tuple_get_item import TupleGetItem
 from tilefoundry.ir.hir.tensor.zeros import Zeros
 from tilefoundry.ir.types import TensorType, TupleType
-from tilefoundry.ir.types.dim import DimVar
+from tilefoundry.ir.types.dim import DimVar, is_dim_op_call
 from tilefoundry.ir.types.shard.shard_layout import shard_layout_of, split_target_axes
 from tilefoundry.visitor_registry.access_relation import AccessRelationResult, build_relation
 
@@ -227,18 +227,22 @@ def _index_select_loop_dim(
 
 
 def _slice_start(start, loops: tuple[GridRegionExpr, ...]) -> tuple[int | None, int]:
-    """Resolve an affine Slice start to an optional loop dimension plus offset."""
-    if isinstance(start, Constant):
-        value = start.value
-        if isinstance(value, int) and not isinstance(value, bool):
-            return None, value
-    if isinstance(start, Var):
+    """Resolve an affine Slice start to an optional loop dimension plus offset.
+
+    A window moved by a compile-time offset (``i + C``) is that same loop
+    dimension carrying the offset, so both halves of the pair are used.
+    """
+    base, offset = window_base(start)
+    if base is None:
+        return None, offset
+    if isinstance(base, Var):
         for pos, loop in enumerate(loops):
-            if loop.induction_var is start:
-                return pos, 0
+            if loop.induction_var is base:
+                return pos, offset
     raise ExtractError(
-        "extract: Slice starts must be integer constants or enclosing loop "
-        f"induction variables, got {start!r}"
+        "extract: Slice starts must be integer constants, enclosing loop "
+        "induction variables, or one of those moved by a compile-time offset, "
+        f"got {start!r}"
     )
 
 
@@ -394,7 +398,7 @@ def _full_slice_domain(
                 for axis, (start, size, stride) in enumerate(
                     zip(starts.elements, expr.target.sizes, expr.target.strides)
                 ):
-                    loop_pos, _ = _slice_start(start, loops)
+                    loop_pos, offset = _slice_start(start, loops)
                     if loop_pos is None:
                         continue
                     if not all(
@@ -407,13 +411,17 @@ def _full_slice_domain(
                         )
                     extent = expr.args[0].type.shape[axis]
                     local = isl.local_space.from_space(result.get_space())
+
+
+
+                    span = size * stride + offset
                     constraint = (
                         isl.constraint.alloc_inequality(local)
                         .set_coefficient_si(isl.dim_type.SET, loop_pos, -1)
-                        .set_constant_si(-(size * stride))
+                        .set_constant_si(-span)
                     )
                     if isinstance(extent, int) and not isinstance(extent, bool):
-                        constraint = constraint.set_constant_si(extent - size * stride)
+                        constraint = constraint.set_constant_si(extent - span)
                     elif isinstance(extent, DimVar):
                         param = result.find_dim_by_name(isl.dim_type.PARAM, extent.name)
                         if param < 0:
@@ -911,6 +919,13 @@ def _walk_calls(
             continue
 
         if isinstance(target, (TupleGetItem, Reshape, IndexSelect, Slice)):
+            table[id(e)] = _maybe_replace_args(e, resolved_args)
+            continue
+
+        if is_dim_op_call(e):
+
+
+
             table[id(e)] = _maybe_replace_args(e, resolved_args)
             continue
 

--- a/src/tilefoundry/codegen/cuda/tir/memory/tensor_view.py
+++ b/src/tilefoundry/codegen/cuda/tir/memory/tensor_view.py
@@ -17,7 +17,7 @@ from tilefoundry.codegen.cuda.context import (
 from tilefoundry.ir.core import Call, Constant
 from tilefoundry.ir.tir.memory.tensor_view import TensorView
 from tilefoundry.ir.tir.stmts import LetStmt
-from tilefoundry.ir.types.dim import DimMul, DimVar
+from tilefoundry.ir.types.dim import DimAdd, DimMul, DimSub, DimVar
 from tilefoundry.ir.types.shape_helpers import shape_numel_upper_bound, upper_bound
 from tilefoundry.ir.types.shard import c_order_strides
 from tilefoundry.ir.types.shard.shard_layout import (
@@ -194,19 +194,25 @@ def render_shard_layout_value(var_name: str, sl: SL, dim_var_runtime=None):
     return preamble, value_expr
 
 
+_COORD_OPERATORS = {DimAdd: "+", DimSub: "-", DimMul: "*"}
+
+
 def _coord_ref(index_var, ctx: CodegenContext) -> str:
     """Render a compile-time, scalar, or one-element absolute coordinate.
 
     Integer literals become static coordinates; rank-zero scalars use their
-    native names; one-element offset tensors read element zero. A multiplication
-    preserves grid output placement after an ordinal is converted to an element
-    start. Other forms fail closed.
+    native names; one-element offset tensors read element zero. Dim arithmetic
+    renders as the arithmetic itself: a multiplication preserves grid output
+    placement after an ordinal is converted to an element start, and an addition
+    moves a window's base by a compile-time offset. Other forms fail closed.
     """
     if isinstance(index_var, Constant):
         return str(int(index_var.value))
-    if isinstance(index_var, Call) and isinstance(index_var.target, DimMul):
-        lhs, rhs = (_coord_ref(arg, ctx) for arg in index_var.args)
-        return f"({lhs} * {rhs})"
+    if isinstance(index_var, Call):
+        operator = _COORD_OPERATORS.get(type(index_var.target))
+        if operator is not None:
+            lhs, rhs = (_coord_ref(arg, ctx) for arg in index_var.args)
+            return f"({lhs} {operator} {rhs})"
     name = ctx.name_for(index_var)
     shape = getattr(getattr(index_var, "type", None), "shape", ()) or ()
     dims = tuple(getattr(d, "value", d) for d in shape)

--- a/src/tilefoundry/evaluator/dim.py
+++ b/src/tilefoundry/evaluator/dim.py
@@ -3,9 +3,18 @@
 This is an evaluation-time utility (it substitutes runtime ``DimVar`` sizes and
 folds the dim expression), distinct from the IR-construction / folding in
 ``tilefoundry.ir.types.dim``.
+
+A dim expression also reaches the interpreter as an operand rather than as a
+shape -- a ``Slice`` start moved off a loop's induction variable is one -- so the
+same folding is registered per dim op. There it folds the values its arguments
+already evaluated to instead of substituting ``DimVar`` sizes.
 """
 from __future__ import annotations
 
+from typing import Callable
+
+from tilefoundry.evaluator.registry import register_eval
+from tilefoundry.evaluator.value import EvalError, TensorValue
 from tilefoundry.ir.core import Call, Constant
 from tilefoundry.ir.types.dim import (
     DimAdd,
@@ -18,7 +27,7 @@ from tilefoundry.ir.types.dim import (
     DimVar,
 )
 
-_FOLDERS = {
+_FOLDERS: dict[type, Callable[[int, int], int]] = {
     DimAdd: lambda a, b: a + b,
     DimSub: lambda a, b: a - b,
     DimMul: lambda a, b: a * b,
@@ -63,6 +72,37 @@ def resolve_dim(dim, bindings: dict[str, int]) -> int:
             raise ValueError("resolve_dim: division/modulo by zero")
         return int(fold(a, b))
     raise ValueError(f"resolve_dim: unrecognised Dim {type(dim).__name__}")
+
+
+def _dim_op_eval(op_cls: type, fold: Callable[[int, int], int]):
+    """The evaluator for one dim op in operand position.
+
+    An operand-position dim expression is a compile-time coordinate, so its
+    leaves are ``Constant`` / induction ``Var`` rather than ``DimVar`` sizes:
+    the operands arrive already evaluated and only the arithmetic is left.
+    """
+
+    def _eval(ctx):
+        name = op_cls.__name__
+        if len(ctx.args) != 2:
+            raise EvalError(f"evaluator: {name} takes 2 operands, got {len(ctx.args)}")
+        operands = []
+        for arg in ctx.args:
+            if not isinstance(arg, TensorValue) or arg.data.numel() != 1:
+                raise EvalError(f"evaluator: {name} operands are single integers")
+            operands.append(int(arg.data.reshape(-1)[0].item()))
+        if op_cls in (DimFloorDiv, DimMod) and operands[1] == 0:
+            raise EvalError(f"evaluator: {name} by zero")
+        return TensorValue(
+            data=ctx.args[0].data.new_tensor(int(fold(*operands))),
+            type=ctx.result_type,
+        )
+
+    return _eval
+
+
+for _op_cls, _fold in _FOLDERS.items():
+    register_eval(_op_cls)(_dim_op_eval(_op_cls, _fold))
 
 
 __all__ = ["resolve_dim"]

--- a/src/tilefoundry/inspection/python_printer.py
+++ b/src/tilefoundry/inspection/python_printer.py
@@ -41,7 +41,7 @@ from tilefoundry.ir.hir.math.unary import Unary
 from tilefoundry.ir.hir.sharding.reshard import Reshard
 from tilefoundry.ir.hir.specialize import dim_vars_reached, display_name, origin_of
 from tilefoundry.ir.hir.tensor.reshape import Reshape
-from tilefoundry.ir.hir.tensor.slice import Slice
+from tilefoundry.ir.hir.tensor.slice import Slice, window_base
 from tilefoundry.ir.hir.tensor.tuple_get_item import TupleGetItem
 from tilefoundry.ir.types import DType, TensorType, TupleType
 from tilefoundry.ir.types.dim import (
@@ -347,6 +347,13 @@ def _shape_tuple(shape: tuple) -> str:
     if len(rendered) == 1:
         return f"({rendered[0]},)"
     return "(" + ", ".join(rendered) + ")"
+
+
+def _moved_window_ref(name: str, offset: int) -> str:
+    """A tile-window indexer, carrying the compile-time offset that moves it."""
+    if offset == 0:
+        return name
+    return f"{name} + {offset}" if offset > 0 else f"{name} - {-offset}"
 
 
 def _attr_tuple_str(value: tuple) -> str:
@@ -809,7 +816,7 @@ def _emit_def(
                 and len(candidate.args) == 2
                 and isinstance(candidate.args[1], Tuple)
                 and any(
-                    start is expr.induction_var
+                    window_base(start)[0] is expr.induction_var
                     and size == expr.step
                     and stride == 1
                     for start, size, stride in zip(
@@ -848,6 +855,31 @@ def _emit_def(
             for _ in iter_exprs(init, _root_grid_init_ids):
                 pass
     _grid_internal_ids.difference_update(_root_grid_init_ids)
+
+    def _moved_window(start, size, stride):
+        """The tile window and offset *start* moves it by, else ``None``."""
+        window, offset = window_base(start)
+        if (
+            isinstance(window, Var)
+            and stride == 1
+            and _tile_window_steps.get(id(window)) == size
+        ):
+            return window, offset
+        return None
+
+
+    _inlined_start_ids = {
+        id(start)
+        for expr in _order
+        if isinstance(expr, Call)
+        and isinstance(expr.target, Slice)
+        and len(expr.args) == 2
+        and isinstance(expr.args[1], Tuple)
+        for start, size, stride in zip(
+            expr.args[1].elements, expr.target.sizes, expr.target.strides
+        )
+        if _moved_window(start, size, stride) is not None
+    }
 
     def _assign_name(expr: Expr) -> str:
         key = id(expr)
@@ -917,6 +949,19 @@ def _emit_def(
 
 
         return _tuple_literal(a.elements) if isinstance(a, Tuple) else _expr_ref(a)
+
+    def _start_ref(start, size, stride) -> str:
+        """One Slice start as source.
+
+        A moved tile window prints as the move itself -- the offset is a
+        compile-time constant, so it belongs in the indexer rather than in a
+        statement of its own.
+        """
+        moved = _moved_window(start, size, stride)
+        if moved is None:
+            return repr(start.value) if isinstance(start, Constant) else _expr_ref(start)
+        window, offset = moved
+        return _moved_window_ref(_expr_ref(window), offset)
 
 
 
@@ -1001,12 +1046,8 @@ def _emit_def(
             for axis, (start, size, stride) in enumerate(
                 zip(starts.elements, target.sizes, target.strides)
             ):
-                if (
-                    isinstance(start, Var)
-                    and stride == 1
-                    and _tile_window_steps.get(id(start)) == size
-                ):
-                    indexers.append(_expr_ref(start))
+                if _moved_window(start, size, stride) is not None:
+                    indexers.append(_start_ref(start, size, stride))
                     continue
                 dim = expr.args[0].type.shape[axis]
                 if (
@@ -1031,8 +1072,16 @@ def _emit_def(
                     f"{begin}:{stop}" if stride == 1 else f"{begin}:{stop}:{stride}"
                 )
             if runtime_starts:
+                start_refs = ", ".join(
+                    _start_ref(start, size, stride)
+                    for start, size, stride in zip(
+                        starts.elements, target.sizes, target.strides
+                    )
+                )
+                if len(starts.elements) == 1:
+                    start_refs += ","
                 return (
-                    f"slice({_arg_ref(expr.args[0])}, {_tuple_literal(starts.elements)}, "
+                    f"slice({_arg_ref(expr.args[0])}, ({start_refs}), "
                     f"sizes={_attr_tuple_str(target.sizes)}, "
                     f"strides={_attr_tuple_str(target.strides)})"
                 )
@@ -1091,6 +1140,9 @@ def _emit_def(
         key = id(expr)
         if key in printed:
             return
+        if key in _inlined_start_ids:
+            printed.add(key)
+            return
         if isinstance(expr, Var):
             printed.add(key)
             return
@@ -1148,6 +1200,9 @@ def _emit_def(
 
     for expr in _order:
         if isinstance(expr, Var) or id(expr) in _grid_internal_ids:
+            continue
+        if id(expr) in _inlined_start_ids:
+            printed.add(id(expr))
             continue
         if isinstance(expr, GridRegionExpr):
             _emit_grid(expr, indent)

--- a/src/tilefoundry/ir/hir/tensor/slice.py
+++ b/src/tilefoundry/ir/hir/tensor/slice.py
@@ -92,6 +92,32 @@ def _constant_int(expr: Expr) -> int | None:
     return None
 
 
+def window_base(start: Expr) -> "tuple[Expr | None, int]":
+    """Split a window start into the base it moves off and its constant offset.
+
+    A start moved by a compile-time offset (``i + C``) reports ``(i, C)``, a
+    plain start reports itself at offset ``0``, and an integer constant reports
+    ``(None, value)``. A start whose offset is not compile-time has no constant
+    to take out, so it reports itself unmoved and its reader decides whether it
+    models anything.
+    """
+    value = _constant_int(start)
+    if value is not None:
+        return None, value
+    if isinstance(start, Call) and isinstance(start.target, (DimAdd, DimSub)):
+        sign = 1 if isinstance(start.target, DimAdd) else -1
+        left, right = start.args
+        right_offset = _constant_int(right)
+        if right_offset is not None:
+            base, offset = window_base(left)
+            return base, offset + sign * right_offset
+        left_offset = _constant_int(left)
+        if left_offset is not None and sign == 1:
+            base, offset = window_base(right)
+            return base, offset + left_offset
+    return start, 0
+
+
 def _dim_mul(left, right):
     if isinstance(left, int) and isinstance(right, int):
         return left * right
@@ -271,4 +297,4 @@ def _eval_slice(ctx):
     return TensorValue(data=ctx.args[0].data[tuple(key)], type=ctx.result_type)
 
 
-__all__ = ["Slice", "slice_size"]
+__all__ = ["Slice", "slice_size", "window_base"]

--- a/src/tilefoundry/ir/types/dim.py
+++ b/src/tilefoundry/ir/types/dim.py
@@ -215,6 +215,18 @@ def is_dim_expr(value) -> bool:
     return False
 
 
+def is_dim_op_call(value) -> bool:
+    """True iff *value* is a ``Call`` over one of this module's dim ops.
+
+    Unlike :func:`is_dim_expr` this asks only what the call computes, not what
+    it computes over, so it also holds for a coordinate built on a scalar ``Var``
+    that only the surrounding walk can resolve. Dim arithmetic is an address
+    rather than a value some kernel produces, so a walk over compute ops uses
+    this to leave it alone.
+    """
+    return isinstance(value, Call) and isinstance(value.target, _DIM_OP_TYPES)
+
+
 def dim_min(a, b) -> Expr:
     """Symbolic ``min`` dim expression, folded to a ``Constant`` when both operands are static.
 
@@ -265,6 +277,7 @@ __all__ = [
     "DimMax",
     "simplify_dim",
     "is_dim_expr",
+    "is_dim_op_call",
     "dim_min",
     "dim_max",
     "ceildiv",

--- a/src/tilefoundry/parser/base.py
+++ b/src/tilefoundry/parser/base.py
@@ -33,7 +33,7 @@ from tilefoundry.ir.hir.tensor.reshape import Reshape
 from tilefoundry.ir.hir.tensor.slice import Slice
 from tilefoundry.ir.hir.tensor.tuple_get_item import TupleGetItem
 from tilefoundry.ir.types import DType, TensorType, TupleType
-from tilefoundry.ir.types.dim import is_dim_expr
+from tilefoundry.ir.types.dim import DimAdd, is_dim_expr, simplify_dim
 from tilefoundry.ir.types.dtype import FloatDType
 from tilefoundry.ir.types.shape_helpers import i64_const
 from tilefoundry.ir.types.shard.layout import Layout
@@ -310,6 +310,10 @@ class BaseExprVisitor:
 
         self._call_dsl_names: dict[int, str] = {}
         self._scalar_index_ids: set[int] = set()
+
+
+
+        self._tile_windows: dict[int, tuple[Any, Any]] = {}
         self._active_source_node: ast.AST | None = None
         self._active_binding_hint: str | None = None
         self.source_filename = "<string>"
@@ -731,9 +735,13 @@ class BaseExprVisitor:
             val = self.env.lookup(el.id)
             if isinstance(val, slice):
                 return val.start, val.stop, val.step
+        moved = self._moved_tile_window(el, dim, axis)
+        if moved is not None:
+            return moved.start, moved.stop, moved.step
         raise VerifyError(
             f"tensor subscript axis {axis}: unsupported indexer "
-            f"{ast.dump(el)} (expected `:`, `a:b`, or a tile-window slice)"
+            f"{ast.dump(el)} (expected `:`, `a:b`, a tile-window slice, or a "
+            f"tile window moved by a compile-time integer)"
         )
 
     def _slicer_endpoint(self, node: ast.AST):
@@ -742,6 +750,102 @@ class BaseExprVisitor:
             return self._eval_static(node, allow_runtime_scalar=True)
         except VerifyError:
             return self.expr(node)
+
+    def _tile_window(self, node: ast.AST) -> "slice | None":
+        """The tile window *node* names, else ``None``."""
+        if not isinstance(node, ast.Name):
+            return None
+        value = self.env.lookup(node.id)
+        if isinstance(value, slice) and id(value.start) in self._tile_windows:
+            return value
+        return None
+
+    def _window_move(self, el: ast.AST) -> "tuple[slice, int] | None":
+        """The tile window *el* reads and the offset that moves it.
+
+        ``None`` when *el* names no window. Offsets accumulate, so
+        ``i + QN + KN`` and ``QN + KN + i`` name one move by one sum, and each
+        term is a compile-time integer on its own.
+        """
+        window = self._tile_window(el)
+        if window is not None:
+            return window, 0
+        if not isinstance(el, ast.BinOp) or not isinstance(el.op, (ast.Add, ast.Sub)):
+            return None
+        sign = -1 if isinstance(el.op, ast.Sub) else 1
+        moved = self._window_move(el.left)
+        offset_node = el.right
+        if moved is None:
+            moved = self._window_move(el.right)
+            if moved is None:
+                return None
+            if sign == -1:
+                raise VerifyError(
+                    f"{ast.unparse(el)!r}: an offset moves a window, so the window "
+                    f"is what the offset is added to -- subtracting it from "
+                    f"{ast.unparse(el.left)!r} reverses the window rather than "
+                    f"moving it"
+                )
+            offset_node = el.left
+        offset = self._static_number(offset_node)
+        if isinstance(offset, bool) or not isinstance(offset, int):
+            raise VerifyError(
+                f"{ast.unparse(el)!r}: a tile window moves by a compile-time "
+                f"integer, and {ast.unparse(offset_node)!r} is not one"
+            )
+        window, carried = moved
+        return window, carried + sign * offset
+
+    def _moved_tile_window(self, el: ast.AST, dim: Any, axis: int) -> "slice | None":
+        """The window ``i + C`` reads, or ``None`` when *el* names no window.
+
+        A tile window is a length bound to a moving base, so a compile-time
+        offset moves the base and leaves the length alone: ``i + C`` reads
+        ``[lo + C, lo + C + step)``. The base was already computed at compile
+        time, so this axis keeps the static extent ``i`` alone gives it.
+        """
+        move = self._window_move(el)
+        if move is None:
+            return None
+        window, offset = move
+        if offset == 0:
+            return window
+        extent, length = self._tile_windows[id(window.start)]
+        self._check_moved_window(el, axis, offset, extent, length, dim)
+        base = simplify_dim(DimAdd, (window.start, offset))
+        return slice(base, simplify_dim(DimAdd, (base, length)), window.step)
+
+    @staticmethod
+    def _check_moved_window(
+        el: ast.AST, axis: int, offset: int, extent: Any, length: Any, dim: Any
+    ) -> None:
+        """Refuse a move that reads off the axis.
+
+        The loop domain, the window length, the offset and the axis extent are
+        all compile-time, so the last window a moved read touches is too. A
+        symbolic extent leaves the bound to evaluate time, which is where an
+        unmoved window's own tail is caught.
+        """
+        if offset < 0:
+            raise VerifyError(
+                f"tensor subscript axis {axis}: {ast.unparse(el)!r} moves the "
+                f"window back by {-offset}, and this loop's first window starts "
+                f"at 0, so it would begin before the axis"
+            )
+        if not all(
+            isinstance(value, int) and not isinstance(value, bool)
+            for value in (extent, length, dim)
+        ):
+            return
+        if extent <= 0 or length <= 0:
+            return
+        last = (extent - 1) // length * length
+        if last + offset + length > dim:
+            raise VerifyError(
+                f"tensor subscript axis {axis}: {ast.unparse(el)!r} reads "
+                f"[{last + offset}, {last + offset + length}) on its last "
+                f"iteration, and the axis is {dim} long"
+            )
 
 
 

--- a/src/tilefoundry/parser/hir_parser.py
+++ b/src/tilefoundry/parser/hir_parser.py
@@ -761,6 +761,11 @@ class _HirBodyVisitor(BaseExprVisitor):
         self.env.push_frame()
         if loop_kind == "range":
             self._scalar_index_ids.add(id(iv))
+        else:
+
+
+
+            self._tile_windows[id(iv)] = (extent, step)
         try:
             self.env.define(node.target.id, iv_binding)
             for cname, phi in zip(carry_names, phi_vars):
@@ -779,6 +784,7 @@ class _HirBodyVisitor(BaseExprVisitor):
                 yield_exprs.append(v)
         finally:
             self._scalar_index_ids.discard(id(iv))
+            self._tile_windows.pop(id(iv), None)
             self.env.pop_frame()
 
         if not carry_names:

--- a/src/tilefoundry/passes/transforms/hir_to_tir.py
+++ b/src/tilefoundry/passes/transforms/hir_to_tir.py
@@ -36,6 +36,7 @@ from tilefoundry.ir.hir.tensor.insert_slice import InsertSlice as HirInsertSlice
 from tilefoundry.ir.hir.tensor.reduce import Reduce as HirReduce
 from tilefoundry.ir.hir.tensor.reshape import Reshape as HirReshape
 from tilefoundry.ir.hir.tensor.slice import Slice as HirSlice
+from tilefoundry.ir.hir.tensor.slice import window_base
 from tilefoundry.ir.hir.tensor.tuple_get_item import TupleGetItem as HirTupleGetItem
 from tilefoundry.ir.tir.arith import (
     Binary as TirBinary,
@@ -76,7 +77,7 @@ from tilefoundry.ir.types import (
     TupleType,
     callable_type_for_prim_function,
 )
-from tilefoundry.ir.types.dim import DimMul, simplify_dim
+from tilefoundry.ir.types.dim import DimMul, is_dim_op_call, simplify_dim
 from tilefoundry.ir.types.shape_helpers import shape_numel_upper_bound
 from tilefoundry.ir.types.shard import c_order_strides
 from tilefoundry.ir.types.shard.layout import Layout as _Layout
@@ -100,7 +101,11 @@ from tilefoundry.visitor_registry.registries import (
 
 
 def _has_induction_slice(root: Expr, induction_var: Var) -> bool:
-    """Whether ``root`` contains a Slice starting at ``induction_var``."""
+    """Whether ``root`` contains a Slice starting at ``induction_var``.
+
+    A window moved by a compile-time offset is still that loop's window, so a
+    tail it cannot read is still that loop's tail.
+    """
     seen: set[int] = set()
 
     def visit(expr: Expr) -> bool:
@@ -110,7 +115,7 @@ def _has_induction_slice(root: Expr, induction_var: Var) -> bool:
         if isinstance(expr, Call) and isinstance(expr.target, HirSlice):
             starts = expr.args[1]
             if isinstance(starts, Tuple) and any(
-                start is induction_var for start in starts.elements
+                window_base(start)[0] is induction_var for start in starts.elements
             ):
                 return True
         return any(visit(child) for child in child_exprs(expr))
@@ -1189,7 +1194,9 @@ def _insert_slice_coord(ctx: "_Lowerer", off_expr):
     The scalar window index for an in-place ``insert_slice`` is the absolute
     element coordinate where the update window starts. A
     compile-time offset folds to a ``Constant`` scalar (emitted as a
-    literal coordinate); a runtime scalar offset lowers to its scalar Var
+    literal coordinate); dim arithmetic over the induction variable is a
+    coordinate the emitter computes, so it is carried through rather than
+    lowered to a tensor op; a runtime scalar offset lowers to its scalar Var
     (its single element is read at the coordinate site).
     """
     i32 = TensorType.scalar(dtype=DType.i32, storage=StorageKind.RMEM)
@@ -1197,9 +1204,25 @@ def _insert_slice_coord(ctx: "_Lowerer", off_expr):
         val = off_expr.value
         elem = int(val[0]) if isinstance(val, (list, tuple)) else int(val)
         return Constant(value=elem, type=i32)
+    if _is_coordinate_arithmetic(off_expr):
+        return off_expr
 
 
     return ctx.lower(off_expr)
+
+
+def _is_coordinate_arithmetic(expr) -> bool:
+    """Whether *expr* is dim arithmetic over literals and scalar Vars.
+
+    Such an offset is an address the emitter computes, not a value a tensor op
+    produces, so lowering carries it through to the coordinate site.
+    """
+    if not is_dim_op_call(expr):
+        return False
+    return all(
+        isinstance(arg, (Constant, Var)) or _is_coordinate_arithmetic(arg)
+        for arg in expr.args
+    )
 
 
 @register_hir_lowering(HirSlice)

--- a/src/tilefoundry/passes/transforms/hir_to_tir.py
+++ b/src/tilefoundry/passes/transforms/hir_to_tir.py
@@ -1191,13 +1191,12 @@ def _lower_cache_update(ctx: "_Lowerer", target, expr) -> Var:
 def _insert_slice_coord(ctx: "_Lowerer", off_expr):
     """The scalar window index for an in-place ``insert_slice``.
 
-    The scalar window index for an in-place ``insert_slice`` is the absolute
-    element coordinate where the update window starts. A
-    compile-time offset folds to a ``Constant`` scalar (emitted as a
-    literal coordinate); dim arithmetic over the induction variable is a
-    coordinate the emitter computes, so it is carried through rather than
-    lowered to a tensor op; a runtime scalar offset lowers to its scalar Var
-    (its single element is read at the coordinate site).
+    The absolute element coordinate where the update window starts. A
+    compile-time offset folds to a ``Constant`` literal; dim arithmetic over the
+    induction variable is an address the emitter computes, so it is carried
+    through; a runtime scalar offset lowers to its scalar Var, whose single
+    element is read at the coordinate site. A coordinate an *op* computes is
+    refused: materializing it gives a buffer, and a buffer is not a scalar index.
     """
     i32 = TensorType.scalar(dtype=DType.i32, storage=StorageKind.RMEM)
     if isinstance(off_expr, Constant):
@@ -1206,8 +1205,14 @@ def _insert_slice_coord(ctx: "_Lowerer", off_expr):
         return Constant(value=elem, type=i32)
     if _is_coordinate_arithmetic(off_expr):
         return off_expr
-
-
+    if isinstance(off_expr, Call):
+        raise NotImplementedError(
+            f"hir_to_tir: a window coordinate computed by "
+            f"{type(off_expr.target).__name__} has no lowering -- it would be "
+            f"materialized into a buffer and that buffer used where a scalar "
+            f"index belongs. A coordinate is a literal, a scalar operand, or a "
+            f"compile-time offset off one (`i + C`)"
+        )
     return ctx.lower(off_expr)
 
 

--- a/tests/analysis/test_poly_grid_region.py
+++ b/tests/analysis/test_poly_grid_region.py
@@ -82,6 +82,16 @@ def dynamic_full_windows(
 
 
 @func
+def moved_windows(
+    x: Tensor[(12, 4), "f32"], seed: Tensor[(3, 4), "f32"]
+) -> Tensor[(3, 4), "f32"]:
+    o = add(seed, seed)
+    for i in tile(6, 3):
+        o = add(x[i + 6, :], seed)
+    return o
+
+
+@func
 def unspecialized_window_step(
     x: Tensor[(10, 4), "f32"], seed: Tensor[(TILE, 4), "f32"]
 ) -> Tensor[(TILE, 4), "f32"]:
@@ -231,6 +241,31 @@ def test_windowed_loop_analyzes_only_full_tiles_and_offsets_its_read():
         isl.union_map(
             "{ Binary1[i, r, c] -> x[i + r, c] : "
             "0 <= i <= 4 and i mod 4 = 0 and 0 <= r < 4 and 0 <= c < 4 }"
+        )
+    )
+
+
+def test_a_moved_window_carries_its_offset_into_the_access_map():
+    """A window moved by a compile-time offset reads the same loop dimension.
+
+    A window moved by a compile-time offset reads the same loop dimension shifted
+    by that offset, so the offset belongs in the access map rather than in a
+    separate statement -- the move is an address, not a computation.
+    """
+    tg = extract(moved_windows)
+    domain = _domains(tg)["Binary1"]
+
+    assert domain.is_equal(
+        isl.set("{ Binary1[i, r, c] : 0 <= i <= 3 and i mod 3 = 0 "
+                "and 0 <= r < 3 and 0 <= c < 4 }")
+    )
+    source_reads = tg.reads.intersect_range(
+        isl.union_set("{ x[r, c] : 0 <= r < 12 and 0 <= c < 4 }")
+    )
+    assert source_reads.is_equal(
+        isl.union_map(
+            "{ Binary1[i, r, c] -> x[i + r + 6, c] : "
+            "0 <= i <= 3 and i mod 3 = 0 and 0 <= r < 3 and 0 <= c < 4 }"
         )
     )
 

--- a/tests/ops/test_slice.py
+++ b/tests/ops/test_slice.py
@@ -1,7 +1,8 @@
-"""Slice's sharded-layout preservation and rejection boundary.
+"""Slice's sharded-layout preservation, rejection boundary, and moved windows.
 
 Windows on unsplit logical axes retain distribution. Narrowing a split axis is
-rejected because the window need not align with that mesh division.
+rejected because the window need not align with that mesh division. A window
+moved by a compile-time offset reads a fused ``[gate | up]`` tensor on GPU.
 """
 
 from __future__ import annotations
@@ -276,3 +277,55 @@ def test_runtime_start_slice_does_not_claim_a_static_layout():
         _slice_type(make_tensor_type((1024, 2048), _F), (0, 0), (256, 2048), (1, 1)).layout
         is None
     )
+
+
+import torch  # noqa: E402
+
+from tilefoundry import func, module  # noqa: E402
+from tilefoundry.dsl import Mesh, Tensor, Topology  # noqa: E402
+from tilefoundry.dsl.tf import *  # noqa: E402,F401,F403
+from tilefoundry.evaluator import evaluate  # noqa: E402
+from tilefoundry.target import CudaTarget  # noqa: E402
+
+_HALF, _COLS, _STEP = 4, 4, 2
+
+
+@module(entry="moved_copy", topologies=(Topology("thread", 1),))
+class _MovedWindow:
+    """Read the far half of a fused tensor through a window moved by a constant."""
+
+    @func
+    def moved_copy(gu: Tensor[(2 * _HALF, _COLS), "f32"]):
+        with Mesh(("thread",), (1,), ("t",)) as m:
+            gr = reshard(gu, (2 * _HALF, _COLS @ m.t), "rmem")
+            acc = full_like(gr, 0.0)
+            for r in tile(_HALF, _STEP):
+                acc = insert_slice(acc, gr[r + _HALF, :], (r, 0))
+            return reshard(acc, (2 * _HALF, _COLS @ m.t), "gmem")
+
+
+def _moved_reference(gu):
+    return torch.cat([gu[_HALF:, :], torch.zeros_like(gu[_HALF:, :])])
+
+
+def test_a_moved_window_reads_the_far_half_of_one_tensor():
+    gu = torch.arange(2 * _HALF * _COLS, dtype=torch.float32).reshape(2 * _HALF, _COLS)
+
+    actual = evaluate(_MovedWindow.lookup("moved_copy"), gu, device="cpu")
+
+    torch.testing.assert_close(actual, _moved_reference(gu))
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_moved_window_gpu_oracle():
+    """The offset reaches the emitted address, not just the evaluator's arithmetic."""
+    import tilefoundry  # noqa: PLC0415
+
+    rm = tilefoundry.compile(_MovedWindow, target=CudaTarget("nvidia.h200_sxm"))
+    gu = torch.randn(2 * _HALF, _COLS, device="cuda")
+    out = torch.zeros(2 * _HALF, _COLS, device="cuda")
+    rm(gu, out)
+    torch.cuda.synchronize()
+
+    expected = _moved_reference(gu)
+    assert torch.allclose(out, expected, rtol=1e-4, atol=1e-4), (out - expected).abs().max()

--- a/tests/parser/hir/test_parse_subscript.py
+++ b/tests/parser/hir/test_parse_subscript.py
@@ -271,6 +271,33 @@ def test_a_compile_time_offset_moves_a_tile_window_without_resizing_it():
     torch.testing.assert_close(evaluate(_summed_offsets, gu, seed, device="cpu"), expected)
 
 
+def test_a_run_time_endpoint_and_a_moved_window_share_one_subscript():
+    """One axis takes its start at run time while another moves its window.
+
+    Both keep ``Slice.sizes`` static, by different routes: a run-time endpoint
+    pairs with a compile-time window, and a move keeps the window it was given.
+    """
+    mixed = import_dsl(_src(
+        'x: Tensor[(8, 8), "f32"], e: Tensor[(), "i64"], '
+        f'seed: Tensor[(2, {_STEP}), "f32"]) -> Tensor[(2, {_STEP}), "f32"]',
+        "out = add(seed, seed)",
+        f"for n in tile({_HALF}, {_STEP}):",
+        f"    out = add(out, x[e:e + 2, n + {_HALF}])",
+        "return out",
+    ))
+
+    x = torch.arange(64, dtype=torch.float32).reshape(8, 8)
+    seed = torch.ones((2, _STEP), dtype=torch.float32)
+    expected = seed * 2
+    for lo in range(0, _HALF, _STEP):
+        expected = expected + x[3:5, lo + _HALF:lo + _HALF + _STEP]
+
+    torch.testing.assert_close(
+        evaluate(mixed, x, torch.tensor(3, dtype=torch.int64), seed, device="cpu"),
+        expected,
+    )
+
+
 def test_a_moved_window_round_trips_as_the_move_it_was_written_as():
     script = as_script(_fused_halves)
     assert f"gu[:, n + {_HALF}]" in script, script

--- a/tests/parser/hir/test_parse_subscript.py
+++ b/tests/parser/hir/test_parse_subscript.py
@@ -229,6 +229,111 @@ def test_tile_window_canonical_roundtrip_preserves_evaluation():
     torch.testing.assert_close(evaluate(restored, x, seed, device="cpu"), expected)
 
 
+_HALF, _STEP, _ROWS = 4, 2, 3
+
+
+@func
+def _fused_halves(gu: Tensor[(_ROWS, 2 * _HALF), "f32"], seed: Tensor[(_ROWS, _STEP), "f32"]):
+    out = add(seed, seed)
+    for n in tile(_HALF, _STEP):
+        out = add(out, mul(gu[:, n], gu[:, n + _HALF]))
+    return out
+
+
+@func
+def _summed_offsets(gu: Tensor[(_ROWS, 2 * _HALF), "f32"], seed: Tensor[(_ROWS, _STEP), "f32"]):
+    out = add(seed, seed)
+    for n in tile(_HALF, _STEP):
+        out = add(out, mul(gu[:, n], gu[:, _HALF + 1 + n - 1]))
+    return out
+
+
+def _fused_reference(gu, seed):
+    out = seed * 2
+    for lo in range(0, _HALF, _STEP):
+        out = out + gu[:, lo:lo + _STEP] * gu[:, lo + _HALF:lo + _HALF + _STEP]
+    return out
+
+
+def test_a_compile_time_offset_moves_a_tile_window_without_resizing_it():
+    """Two windows a fixed distance apart, read in one loop over one tensor.
+
+    The fused ``[gate | up]`` read: the offset moves the base and leaves the
+    length, so both reads have the same static shape and land ``_HALF`` columns
+    apart. Offsets accumulate, so a sum of terms names the same move.
+    """
+    gu = torch.arange(_ROWS * 2 * _HALF, dtype=torch.float32).reshape(_ROWS, 2 * _HALF)
+    seed = torch.ones((_ROWS, _STEP), dtype=torch.float32)
+    expected = _fused_reference(gu, seed)
+
+    assert _fused_halves.return_type.shape == (_ROWS, _STEP)
+    torch.testing.assert_close(evaluate(_fused_halves, gu, seed, device="cpu"), expected)
+    torch.testing.assert_close(evaluate(_summed_offsets, gu, seed, device="cpu"), expected)
+
+
+def test_a_moved_window_round_trips_as_the_move_it_was_written_as():
+    script = as_script(_fused_halves)
+    assert f"gu[:, n + {_HALF}]" in script, script
+
+    gu = torch.arange(_ROWS * 2 * _HALF, dtype=torch.float32).reshape(_ROWS, 2 * _HALF)
+    seed = torch.ones((_ROWS, _STEP), dtype=torch.float32)
+    torch.testing.assert_close(
+        evaluate(import_dsl(script), gu, seed, device="cpu"),
+        _fused_reference(gu, seed),
+    )
+
+
+def test_a_move_a_window_cannot_make_is_rejected():
+    """Each way a move stops describing a window of the same length on the axis.
+
+    Each way a move stops describing a window of the same length inside the
+    axis: an offset that is not compile-time, a subtraction that reverses the
+    window instead of moving it, a move that walks the last window off the end,
+    and a move that starts the first window before the front. The extent, the
+    window length and the offset are all compile-time, so the last two are
+    answered here rather than at evaluate time.
+    """
+    runtime_offset = _src(
+        'x: Tensor[(1, 8), "f32"], k: Tensor[(), "i64"]) -> Tensor[(1, 2), "f32"]',
+        "o = relu(x[:, 0:2])",
+        "for n in tile(4, 2):",
+        "    o = relu(x[:, n + k])",
+        "return o",
+    )
+    with pytest.raises(VerifyError, match="moves by a compile-time integer"):
+        import_dsl(runtime_offset)
+
+    reversed_window = _src(
+        'x: Tensor[(1, 8), "f32"]) -> Tensor[(1, 2), "f32"]',
+        "o = relu(x[:, 0:2])",
+        "for n in tile(4, 2):",
+        "    o = relu(x[:, 4 - n])",
+        "return o",
+    )
+    with pytest.raises(VerifyError, match="reverses the window"):
+        import_dsl(reversed_window)
+
+    off_the_end = _src(
+        'x: Tensor[(1, 8), "f32"]) -> Tensor[(1, 2), "f32"]',
+        "o = relu(x[:, 0:2])",
+        "for n in tile(4, 2):",
+        "    o = relu(x[:, n + 5])",
+        "return o",
+    )
+    with pytest.raises(VerifyError, match=r"reads \[7, 9\).*axis is 8 long"):
+        import_dsl(off_the_end)
+
+    before_the_front = _src(
+        'x: Tensor[(1, 8), "f32"]) -> Tensor[(1, 2), "f32"]',
+        "o = relu(x[:, 0:2])",
+        "for n in tile(4, 2):",
+        "    o = relu(x[:, n - 2])",
+        "return o",
+    )
+    with pytest.raises(VerifyError, match="begin before the axis"):
+        import_dsl(before_the_front)
+
+
 def test_unsupported_subscripts_are_rejected():
     """Two shapes of illegal indexer, each named by its own diagnostic.
 
@@ -253,3 +358,13 @@ def test_unsupported_subscripts_are_rejected():
     )
     with pytest.raises(VerifyError, match="integer constant index"):
         import_dsl(runtime_tuple_index)
+
+    scaled_window = _src(
+        'x: Tensor[(1, 8), "f32"]) -> Tensor[(1, 2), "f32"]',
+        "o = relu(x[:, 0:2])",
+        "for n in tile(4, 2):",
+        "    o = relu(x[:, n * 2])",
+        "return o",
+    )
+    with pytest.raises(VerifyError, match="unsupported indexer"):
+        import_dsl(scaled_window)

--- a/tests/passes/test_hir_to_tir.py
+++ b/tests/passes/test_hir_to_tir.py
@@ -29,7 +29,7 @@ from tilefoundry.ir.tir.memory.tensor_view import TensorView
 from tilefoundry.ir.tir.reduce import Reduce as TirReduce
 from tilefoundry.ir.tir.stmts import Evaluate, LetStmt
 from tilefoundry.ir.types import DType, TensorType
-from tilefoundry.ir.types.dim import DimMul
+from tilefoundry.ir.types.dim import DimAdd, DimMul
 from tilefoundry.ir.types.shard.layout import Layout
 from tilefoundry.ir.types.shard.shard_layout import ShardLayout as SL
 from tilefoundry.ir.types.shard.shard_layout import Split
@@ -252,6 +252,66 @@ def test_grid_output_ordinal_lowers_to_an_absolute_element_start() -> None:
     assert isinstance(coordinate, Call) and isinstance(coordinate.target, DimMul)
     assert coordinate.args[0] is iv
     assert isinstance(coordinate.args[1], Constant) and coordinate.args[1].value == 2
+
+
+def test_a_moved_window_lowers_to_the_moved_address() -> None:
+    """A read window moved by a compile-time offset is an address, not a value.
+
+    The offset reaches the coordinate as arithmetic over the induction variable,
+    so nothing is materialized to hold it.
+    """
+
+    @func
+    def f(x: Tensor[(12, 4), "f32"], seed: Tensor[(3, 4), "f32"]):
+        out = tf.add(seed, seed)
+        for row in tile(6, 3):
+            out = tf.add(x[row + 6, :], seed)
+        return out
+
+    pf = HirToTirPass().run(Module(name="t", functions=(f,), entry=f.name)).lookup("f")
+    coordinates = []
+
+    def walk(stmt):
+        if (
+            isinstance(stmt, LetStmt)
+            and isinstance(stmt.value, Call)
+            and isinstance(stmt.value.target, TensorView)
+            and len(stmt.value.args) == 3
+        ):
+            coordinates.append(stmt.value.args[1])
+        for attr in ("body", "stmts"):
+            child = getattr(stmt, attr, None)
+            if isinstance(child, (list, tuple)):
+                for item in child:
+                    walk(item)
+            elif child is not None and hasattr(child, "__dict__"):
+                walk(child)
+
+    walk(pf.body)
+    moved = [c for c in coordinates if isinstance(c, Call) and isinstance(c.target, DimAdd)]
+    assert len(moved) == 1, coordinates
+    assert isinstance(moved[0].args[0], Var)
+    assert isinstance(moved[0].args[1], Constant) and moved[0].args[1].value == 6
+
+
+def test_a_computed_window_coordinate_fails_closed() -> None:
+    """An offset an op computes is refused, not materialized into a buffer.
+
+    A write coordinate spelled as `i + C` reaches lowering as an ordinary scalar
+    add rather than as an address, and a buffer holding its value is not a scalar
+    index. Lowering says so instead of emitting code that does not compile.
+    """
+
+    @func
+    def f(x: Tensor[(8, 4), "f32"], seed: Tensor[(2, 4), "f32"]):
+        acc = tf.add(seed, seed)
+        out = x
+        for row in tile(4, 2):
+            out = tf.insert_slice(out, acc, (row + 4, 0))
+        return out
+
+    with pytest.raises(NotImplementedError, match="coordinate computed by Binary"):
+        HirToTirPass().run(Module(name="t", functions=(f,), entry=f.name))
 
 
 def test_non_divisible_tile_window_lowering_fails_closed() -> None:


### PR DESCRIPTION
## Why
- Reading two windows a fixed distance apart in one loop had no spelling: a tile
  window binds a length to a base, and the base could not move. That is exactly
  the blocked access of every `[a | b]` fused layout — QKV, gate/up, MoE experts.
- The workaround, making the fused axis its own axis (`(SEQ, 2, FFN)`), is free in
  bytes but only holds when the parts are equally wide; fused QKV is not.

## What
- `x[:, i + C]` reads `[lo + C, lo + C + step)` — the window `i` alone reads,
  translated. The moved base is a `DimAdd` over the induction variable, so the
  axis keeps the static extent `i` gives it. Offsets accumulate (`i + QN + KN`);
  `C - i` is refused, since that reverses the window.
- `iv + C` is a new `Slice.starts` shape, so each reader of starts learns it:
  `window_base()` (new, in `hir/tensor/slice.py`) splits a start into base plus
  constant offset for the access map, the non-divisible-tail check and the
  printer; lowering carries the address to the coordinate site instead of
  lowering it as a value; the CUDA emitter renders the arithmetic; the evaluator
  folds a dim op reached as an operand.

## Contract
- New parser surface (parser §1.7): a subscript axis may move a tile window by a
  compile-time integer. `Slice.starts` may be dim arithmetic over an induction
  `Var` (hir §1.5), which a walk over compute ops leaves alone (analysis,
  lowering). A dim-arithmetic Call in operand position now evaluates
  (evaluator §4).
- A move that reads off the axis is refused at parse time — the loop domain,
  window length, offset and axis extent are all static. An **unmoved** window's
  own tail is unchanged: still an evaluate-time axis check, still rejected at
  lowering.

## Risk
- The symmetric **write** coordinate, `insert_slice(dst, upd, (m, n + FFN))`,
  reaches lowering as an ordinary scalar add, not as an address: it was
  materialized into a one-element buffer and that buffer emitted where a scalar
  index belongs, which does not compile. Pre-existing. Lowering now refuses it by
  name instead -- a literal, a scalar operand, and dim arithmetic over one still
  lower. Writing a fused *output* through a moved coordinate stays unsupported;
  giving it the same `DimAdd` treatment is a separate change.
- Verified on top of #95: full suite 1012 passed / 0 failed (source mode, GPU),
  installed mode 175 passed. Includes a GPU oracle reading the far half of a fused
  tensor through a moved window, and a subscript that takes one axis' start at run
  time (#95) while moving another axis' window.
