### PR TITLE
refactor(inspection): render a record by walking its declared fields

### DIFF
--- a/docs/spec/analysis.md
+++ b/docs/spec/analysis.md
@@ -678,11 +678,13 @@ Requesting memory adds one summary line and one line per advisory:
 
 ```text
 peak-footprint=<level>:<int>[,<level>:<int>...]
-advisory=<text>
+advisory="<text>"
 ```
 
 An empty footprint states the family name alone; each advisory is its own line, so
-a program with none adds none.
+a program with none adds none. An advisory is a sentence, so it is quoted and
+escaped ([inspection §2.8](./inspection.md#28-record-comment-forms)); JSON carries
+the same text raw.
 
 The record's single-line comment form projects the footprint it holds; `traffic`
 and `lifetimes` are read from JSON, not from a line:

--- a/docs/spec/analysis.md
+++ b/docs/spec/analysis.md
@@ -327,18 +327,24 @@ Each owns its record types and declares its dependencies and output additions.
 
 | Selector | Requires | Owns | Rests on | Text summary adds | Annotates equations |
 |---|---|---|---|---|---|
-| `compute-cost` | - | `ComputeCostMetadata` | the authored program | `flops`, `traffic` | every measured Call |
+| `compute-cost` | - | `ComputeCostMetadata` | the authored program | `compute-cost` | every measured Call |
 | `memory` | `compute-cost` | `MemoryMetadata` | `MemoryHierarchyFacts` | `peak-footprint`, `advisory` | none |
-| `roofline` | `memory`, `compute-cost` | `RooflineMetadata` | `ThroughputFacts` | bounded dependency evidence, `ideal-bound` | every measured Call |
-| `timeline` | `compute-cost` | `TimelineMetadata`, `TimelineSummaryMetadata` | `ThroughputFacts`, `ParallelCapacityFacts` | local makespan, waves, estimated kernel time | every measured Call |
+| `roofline` | `memory`, `compute-cost` | `RooflineMetadata` | `ThroughputFacts` | bounded dependency evidence, `roofline` | every measured Call |
+| `timeline` | `compute-cost` | `TimelineMetadata`, `TimelineSummaryMetadata` | `ThroughputFacts`, `ParallelCapacityFacts` | `timeline` | every measured Call |
 
 Every compact text summary begins with these two lines:
 
 ```text
 # example
-# analysis target=<target> module=<module> function=<function> topology=<level|none>
-# analyses=<selector>[,<selector>...] executed=<selector>[,<selector>...]
+# analysis target=<target> module=<module> function=<function> topology=<level>
+# selection requested=<selector>[,<selector>...] executed=<selector>[,<selector>...]
 ```
+
+Every summary line is one record walked exactly as an annotated equation is
+([inspection §2.8](./inspection.md#28-record-comment-forms)), so the two surfaces
+cannot spell one value two ways. What the report is about and what was asked of it
+are records of the report rather than of the IR; every other summary line is a
+record of the selected Function.
 
 The JSON report carries the same identity and selection in `target`, `module`,
 `function`, `topology`, `requested`, and `executed`. Whole-function
@@ -470,14 +476,13 @@ class ComputeCostMetadata(IRMetadata):
 | `traffic` | Multiply the evaluator's per-operand movement by the same factor, charge concrete tensor leaves to their storage levels, and group by level. A Type with leaves at several levels keeps those leaf bytes separate. A `UMAT` leaf has no residency of its own: when it appears in `Call.args`, charge its own bytes at the target's established `rmem` materialization level; when it appears only in an Op attribute, charge nothing. A Function Call takes the callee's grouped total. | No |
 | `operands` | Multiply each evaluator entry by the same factor and keep order `(*call.args, call)`. A Function Call has no operand split. | No |
 
-Requesting this family adds these summary lines, each prefixed by `# `:
+Requesting this family adds one summary line, prefixed by `# `: the Function's own
+record, stated exactly as a Call's is. The whole program's work is not a second
+record.
 
 ```text
-flops <dtype>=<int>[, <dtype>=<int>...]
-traffic <level>=r<int>/w<int>[, <level>=r<int>/w<int>...]
+compute-cost flops=<dtype>:<int>@<int>[,...] traffic=<level>:r<int>/w<int>@r<int>/w<int>[,...]
 ```
-
-An empty flop or traffic set prints as `0` after its label.
 
 Every measured Call receives this annotation. Each key pairs the whole quantity
 with one unit's share, so the two `*_per_unit` fields are not separate keys.
@@ -672,12 +677,12 @@ class MemoryHierarchyFacts:
 Requesting memory adds one summary line and one line per advisory:
 
 ```text
-peak-footprint <level>=<int>[, <level>=<int>...]
-advisory <text>
+peak-footprint=<level>:<int>[,<level>:<int>...]
+advisory=<text>
 ```
 
-An empty footprint prints as `peak-footprint 0`; no advisory line is emitted
-when there is no advisory.
+An empty footprint states the family name alone; each advisory is its own line, so
+a program with none adds none.
 
 The record's single-line comment form projects the footprint it holds; `traffic`
 and `lifetimes` are read from JSON, not from a line:
@@ -782,7 +787,7 @@ Requesting roofline adds the exact summed compute-cost `flops` and `traffic`,
 the memory record's per-level peak, and this verdict to the summary:
 
 ```text
-ideal-bound=<int>ns by=<resource>
+roofline ideal-ns=<int> bound-by=<resource>
 ```
 
 Every measured Call receives this annotation. `compute_ns` and `memory_ns` are
@@ -910,9 +915,14 @@ class ParallelCapacityFacts:
 Requesting timeline adds this Function verdict to the summary:
 
 ```text
-timeline root=<Module>::<Function> local-makespan=<int>ns waves=<int>
-estimated-kernel=<int>ns
+timeline root=<Module>::<Function> local-makespan-ns=<int> waves=<int> estimated-kernel-ns=<int>
 ```
+
+`root` is the report's own identity, composed by inspection from the module and
+function it already states; it is not a field of `TimelineSummaryMetadata` and does
+not appear in that record's JSON projection. `waves` is stated even when it is one,
+because how many passes over the machine a plan takes is a conclusion and one wave
+is an answer.
 
 Every measured Call receives this annotation, one interval whether or not it
 repeats: a single trip states its own bounds, and a repeated occurrence states

--- a/docs/spec/analysis.md
+++ b/docs/spec/analysis.md
@@ -383,22 +383,16 @@ def render_analysis(result: AnalysisResult) -> AnalysisRendering:
   is a share of, and JSON MUST expose all four quantities without reconstructing
   any of them from the others.
 
-The output forms below are the values a record's fields hold, rendered by their
-own type ([inspection §2.8](./inspection.md#28-record-comment-forms)). A field
-whose plain `int`, `str`, or mapping already reads correctly has no type of its
-own:
+A value renders by the type its field holds, and those forms and their separators
+are owned by [inspection §2.8](./inspection.md#28-record-comment-forms). What this
+layer settles is which type a field holds and what its keys name:
 
-| Type | Form |
-|---|---|
-| `int` | `<int>` |
-| `str` | the bare token, `<resource>` being `compute`, `memory`, `balanced`, `unrated`, or `none` |
-| a mapping | `<key>:<value>[,<key>:<value>...]`, where a key is a dtype, a storage level, or an operand position (an argument integer or `result`) |
-| `TrafficBytes` | `r<int>/w<int>` |
-| `TotalAndPerUnit` | `<whole>@<one unit's share>` |
-| `TripInterval` | `[<int>,<int>)` for one trip; `[<int>t+<int>,<int>t+<int>)*<int>` for a repeated one, the coefficient being the stride and the suffix the trip count |
-
-A key that measured nothing is left out, so a record that measured nothing is
-its family name alone.
+- A mapping's key is a dtype, a storage level, or an operand position -- an
+  argument integer, or `result` for the value the Call produces.
+- `<resource>` is `compute`, `memory`, `balanced`, `unrated`, or `none`.
+- Bytes moved are `TrafficBytes`; a whole quantity paired with one unit's share
+  is `TotalAndPerUnit`; a Call's occurrence on the timeline is one
+  `TripInterval`.
 
 - constraints:
   - A family MUST obtain hardware only through a Facts aggregate it declares

--- a/docs/spec/analysis.md
+++ b/docs/spec/analysis.md
@@ -373,22 +373,26 @@ def render_analysis(result: AnalysisResult) -> AnalysisRendering:
   receives neither a comment nor a report row.
 - A parameterized loop occurrence MUST stay one record. Neither surface expands
   it into one entry per trip.
-- A compute-cost comment MUST place `per-unit-bytes` immediately after global
-  `bytes`, and JSON MUST expose all four quantities without reconstructing any
-  of them from the others.
+- A compute-cost comment MUST state one unit's share beside the whole quantity it
+  is a share of, and JSON MUST expose all four quantities without reconstructing
+  any of them from the others.
 
-The output forms below share these placeholders:
+The output forms below are the values a record's fields hold, rendered by their
+own type ([inspection §2.8](./inspection.md#28-record-comment-forms)). A field
+whose plain `int`, `str`, or mapping already reads correctly has no type of its
+own:
 
-| Placeholder | Form | Empty value |
-|---|---|---|
-| `<flopset>` | `<dtype>:<int>[,<dtype>:<int>...]` | `0` |
-| `<levelset>` | `<level>:r<int>/w<int>[,<level>:r<int>/w<int>...]` | `0` |
-| `<peakset>` | `<level>:<int>[,<level>:<int>...]` | `0` |
-| `<operandset>` | `<position>:r<int>/w<int>[,<position>:r<int>/w<int>...]`, where position is an argument integer or `result` | omitted |
-| `<resource>` | `compute`, `memory`, `balanced`, `unrated`, or `none` | `none` |
+| Type | Form |
+|---|---|
+| `int` | `<int>` |
+| `str` | the bare token, `<resource>` being `compute`, `memory`, `balanced`, `unrated`, or `none` |
+| a mapping | `<key>:<value>[,<key>:<value>...]`, where a key is a dtype, a storage level, or an operand position (an argument integer or `result`) |
+| `TrafficBytes` | `r<int>/w<int>` |
+| `TotalAndPerUnit` | `<whole>@<one unit's share>` |
+| `TripInterval` | `[<int>,<int>)` for one trip; `[<int>t+<int>,<int>t+<int>)*<int>` for a repeated one, the coefficient being the stride and the suffix the trip count |
 
-Summary sets use `=` and comma-space separators; annotation sets use `:` and
-comma separators. This difference is intentional.
+A key that measured nothing is left out, so a record that measured nothing is
+its family name alone.
 
 - constraints:
   - A family MUST obtain hardware only through a Facts aggregate it declares
@@ -465,11 +469,14 @@ traffic <level>=r<int>/w<int>[, <level>=r<int>/w<int>...]
 
 An empty flop or traffic set prints as `0` after its label.
 
-Every measured Call receives this annotation; `operands` is omitted for a
-Function Call:
+Every measured Call receives this annotation. Each key pairs the whole quantity
+with one unit's share, so the two `*_per_unit` fields are not separate keys.
+`operands` is the same traffic split by operand, one layer finer, so it is
+emitted only when asked for ([cli Analyze](./cli.md#analyze)) and is absent from a
+Function Call, which has no split:
 
 ```text
-compute-cost flops=<flopset> per-unit=<flopset> bytes=<levelset> per-unit-bytes=<levelset>[ operands=<operandset>]
+compute-cost flops=<dtype>:<int>@<int>[,...] traffic=<level>:r<int>/w<int>@r<int>/w<int>[,...][ operands=<position>:r<int>/w<int>[,...]]
 ```
 
 Each reported Call's JSON projection is under its `compute-cost` key. `operands`
@@ -662,10 +669,11 @@ advisory <text>
 An empty footprint prints as `peak-footprint 0`; no advisory line is emitted
 when there is no advisory.
 
-The record's single-line comment form is:
+The record's single-line comment form projects the footprint it holds; `traffic`
+and `lifetimes` are read from JSON, not from a line:
 
 ```text
-memory peak=<peakset> persistent=<int> advisories=<int>
+memory peak=<level>:<int>[,...] persistent=<int> advisories=<int>
 ```
 
 The `analyze` equation printer emits no memory annotation because the record is
@@ -767,10 +775,12 @@ the memory record's per-level peak, and this verdict to the summary:
 ideal-bound=<int>ns by=<resource>
 ```
 
-Every measured Call receives this annotation:
+Every measured Call receives this annotation. `compute_ns` and `memory_ns` are
+the two numbers the verdict was read off, so they are in JSON rather than on the
+line:
 
 ```text
-roofline bound=<int>ns by=<resource> compute=<int>ns memory=<int>ns
+roofline ideal-ns=<int> bound-by=<resource>
 ```
 
 Reported Call and Function records use the same projection under their
@@ -894,10 +904,15 @@ timeline root=<Module>::<Function> local-makespan=<int>ns waves=<int>
 estimated-kernel=<int>ns
 ```
 
-Every measured Call receives this annotation:
+Every measured Call receives this annotation, one interval whether or not it
+repeats: a single trip states its own bounds, and a repeated occurrence states
+them offset by the trip index, with the trip count as a suffix. The trip count is
+not a second key, because a reader deriving the later intervals reads it off the
+interval it is a coefficient in:
 
 ```text
-timeline start=<int>ns end=<int>ns
+timeline=[<int>,<int>)
+timeline=[<int>t+<int>,<int>t+<int>)*<int>
 ```
 
 Reported Call and Function records use distinct projections under their

--- a/docs/spec/analysis.md
+++ b/docs/spec/analysis.md
@@ -423,6 +423,16 @@ its family name alone.
     recorded by the analysis that computed it.
   - Text and JSON MUST be built from one intermediate report and MUST carry the
     same conclusions.
+  - A family's JSON projection MUST be its record's fields under their own names,
+    with nothing left out: a default, a `null`, and an empty mapping are each a
+    fact a program branches on, and a key spelled by hand is a key that can drift
+    from the field it reports. A field whose projection needs the expression the
+    record is attached to MUST be declared as one, and MAY be absent where the
+    program offers no such reading -- `operands` on a Function Call, which charges
+    a callee total no operand position names. A comment over the same record MAY
+    state fewer keys, or projected ones
+    ([inspection §2.8](./inspection.md#28-record-comment-forms)), and what it
+    leaves out MUST stay in the JSON projection.
   - A compact text summary MUST contain whole-function facts only. Per-value
     facts MUST stay on their annotated equations; JSON MAY retain operand names
     and types in its structured projection.

--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -276,6 +276,11 @@ explicit analysis; there is no ordinary `--target` option.
     a report needs a requested root and printing the `analyze` usage. Both
     formats MUST carry the same conclusions
     ([analysis §2](./analysis.md#2-authored-hir-metrics)).
+  - `--operands` MUST add each operand's share of a call's traffic to that call's
+    annotation, and MUST NOT change the JSON report, which carries that split
+    either way. It is the traffic the annotation already states, one layer finer,
+    so a reader who did not ask is not made to read it.
+    With no analysis flag it MUST be accepted and inert.
   - `--topology LEVEL` MUST be optional, passed through as the public analysis
     operation's `level`, and name the unit for per-unit figures. Its help MUST
     state the default and, for every family, which figure changes with the level

--- a/docs/spec/core-ir.md
+++ b/docs/spec/core-ir.md
@@ -255,8 +255,6 @@ is not a thing a cost can be stated about.
 class IRMetadata:
     """Describe one immutable expression annotation."""
 
-    def format_comment(self) -> str | None: ...
-
 class BindingMetadata(IRMetadata):
     """Describe an authored SSA binding name.
 
@@ -285,9 +283,11 @@ class SourceSpanMetadata(IRMetadata):
 ```
 
 - constraints:
-  - the immutable base of every typed annotation stored on an `Expr`;
-    `format_comment()` returns `None` unless a concrete metadata class provides
-    a printable comment.
+  - the immutable base of every typed annotation stored on an `Expr`: typed
+    fields and nothing about how they are read. What a record looks like as text
+    or as JSON is decided by inspection
+    ([inspection §2.8](./inspection.md#28-record-comment-forms)), so a record
+    MUST NOT carry a rendering, a key name, or a family name of its own.
   - `BindingMetadata` is the authored SSA label. The parser maps explicit DSL
     `loc=` syntax and inferred assignment names to this metadata; there is no
     parallel `Expr.loc` field.

--- a/docs/spec/inspection.md
+++ b/docs/spec/inspection.md
@@ -333,6 +333,10 @@ separates unless that value brackets itself:
   - A value MUST be an `int`, a `str`, a mapping of them, or a type with a
     declared rendering. `int` and `str` MUST NOT be wrapped in a type that
     renders identically.
+  - A `str` that is a token renders bare. Text that is a sentence MUST render as
+    a quoted, escaped DSL string literal ([§2.3](#23-dsl-text-forms)), which is
+    what lets it hold a separator the ladder uses; a reader splits a layer
+    outside the quotes.
   - A key whose value equals what it declared it says nothing by MUST be left
     out, so a record that measured nothing collapses to its family name.
   - A record declaring exactly one key MUST use the family name as that key: for

--- a/docs/spec/inspection.md
+++ b/docs/spec/inspection.md
@@ -61,10 +61,12 @@ class PythonPrintOptions:
     Attributes:
         show_types: attribute; Whether to append inferred types.
         comment_metadata_types: attribute; Metadata classes rendered as comments.
+        comment_opt_in: attribute; Declared keys a reader asked a comment for.
     """
 
     show_types: bool = False
     comment_metadata_types: tuple[type[IRMetadata], ...] = ()
+    comment_opt_in: frozenset[str] = frozenset()
 
 
 def hir_function_to_python(
@@ -289,6 +291,52 @@ be imported at all, which is a weaker artifact than display-only is meant to be
 -- the whole point of printing a program is that somebody can be handed the file.
 The bounds are not recoverable from the name, so they are restated rather than
 inferred.
+
+### 2.8 Record comment forms
+
+A record attached to an expression is typed fields and nothing else
+([core-ir §2](./core-ir.md#2-expr)). What one looks like on a printed line is
+decided here, by walking its fields: a family that wrote its own form string
+would be deciding presentation, and every family would then spell one value its
+own way.
+
+A record MUST declare that it renders as a comment, and MAY declare which keys
+it emits: a field by its own name, anything else as a projection carrying its
+key, its type, and where its value comes from. Metadata with no declaration
+renders as nothing, which is how an annotation that is not a report -- a binding
+name, a constraint -- stays off the line. A comment MUST NOT emit a key the
+family's JSON projection cannot state; it MAY emit fewer.
+
+One separator per layer, and a separator MUST NOT appear inside a value it
+separates unless that value brackets itself:
+
+| Layer | Separates | With |
+|---|---|---|
+| value | bytes read from bytes written | `/` |
+| value | a whole quantity from one unit's share | `@` |
+| value | a mapping's key from its value | `:` |
+| value | a mapping's entries | `,` |
+| field | a key from its value | `=` |
+| record | one field from the next | space |
+| line | one record from the next | `; ` |
+
+- constraints:
+  - A key MUST be its declared name with `_` written as `-`. It MUST NOT be
+    derived from the value, and a unit MUST be part of the name -- `ideal-ns=13`,
+    never `ideal=13ns` -- so the unit is stated once, where the field states it.
+  - A value MUST be an `int`, a `str`, a mapping of them, or a type with a
+    declared rendering. `int` and `str` MUST NOT be wrapped in a type that
+    renders identically.
+  - A key whose value equals what it declared it says nothing by MUST be left
+    out, so a record that measured nothing collapses to its family name.
+  - A record declaring exactly one key MUST use the family name as that key: for
+    a record of one thing the family and the key state the same thing.
+  - The family name MUST be the class name without a trailing `Metadata`, in
+    kebab case. A record whose reported name differs MUST state that name where
+    its keys are declared.
+  - Part zero of a line is the value's own type, which carries no key: it is not
+    a measurement of the value, it is the value, and it is DSL text
+    ([§2.3](#23-dsl-text-forms)) that pastes back. Every later part is a record.
 
 ## 3. Viewer
 

--- a/docs/spec/inspection.md
+++ b/docs/spec/inspection.md
@@ -187,6 +187,16 @@ Both modes MUST agree on semantics; only the level of detail differs.
 The meaning of `Split` / `Partial` / `Broadcast` is owned by
 [shard](./shard.md); these forms define only render syntax.
 
+The same-line type annotation `show_types` appends is the `canonical` form on
+one physical line, rendered through the same mesh name map
+([§2.5](#25-mesh-name-map)) as the signature and the prelude: an annotated
+layout MUST name the hoisted mesh rather than restate it, and a `Tuple[...]`
+annotation MUST name it in every field. The verbose `ShardLayout(...)` fallback
+is unchanged — a mesh with no named axes, or a layout the sugar cannot express,
+still renders verbose, so no annotation loses information. The annotation is
+**display-only** ([§2.7](#27-round-trip-contract)); what round-trips is the
+emitted code, not its comments.
+
 Canonical DType text is the descriptor's `name`. Tensor annotations and DType
 op attributes MUST emit that name as a quoted DSL string. Compact labels MAY
 omit the quotes, but MUST NOT use the descriptor's raw `repr()`.

--- a/docs/spec/inspection.md
+++ b/docs/spec/inspection.md
@@ -304,8 +304,14 @@ A record MUST declare that it renders as a comment, and MAY declare which keys
 it emits: a field by its own name, anything else as a projection carrying its
 key, its type, and where its value comes from. Metadata with no declaration
 renders as nothing, which is how an annotation that is not a report -- a binding
-name, a constraint -- stays off the line. A comment MUST NOT emit a key the
-family's JSON projection cannot state; it MAY emit fewer.
+name, a constraint -- stays off the line.
+
+A record an analysis report projects ([analysis §2](./analysis.md#2-authored-hir-metrics))
+MUST NOT emit a key that projection cannot state; it MAY emit fewer, because a
+comment is read on a line and JSON is read by a program. A record no report
+projects is comment-only -- `SourceSpanMetadata` is where an expression was
+authored, which no family measures -- and there is no projection for it to be a
+subset of.
 
 One separator per layer, and a separator MUST NOT appear inside a value it
 separates unless that value brackets itself:

--- a/src/tilefoundry/analysis/metadata.py
+++ b/src/tilefoundry/analysis/metadata.py
@@ -52,37 +52,6 @@ class ComputeCostMetadata(IRMetadata):
             TrafficBytes(),
         )
 
-    def format_comment(self) -> str:
-        flop_text = ",".join(f"{name}:{value}" for name, value in self.flops) or "0"
-        local_text = (
-            ",".join(f"{name}:{value}" for name, value in self.flops_per_unit)
-            or "0"
-        )
-        traffic_text = (
-            ",".join(
-                f"{level}:r{value.read}/w{value.write}"
-                for level, value in self.traffic
-            )
-            or "0"
-        )
-        local_traffic_text = (
-            ",".join(
-                f"{level}:r{value.read}/w{value.write}"
-                for level, value in self.traffic_per_unit
-            )
-            or "0"
-        )
-        operand_text = ",".join(
-            f"{'result' if index == len(self.operands) - 1 else index}:"
-            f"r{value.read}/w{value.write}"
-            for index, value in enumerate(self.operands)
-        )
-        operands = f" operands={operand_text}" if operand_text else ""
-        return (
-            f"compute-cost flops={flop_text} per-unit={local_text} "
-            f"bytes={traffic_text} per-unit-bytes={local_traffic_text}{operands}"
-        )
-
 
 @dataclass(frozen=True)
 class LevelFootprint:
@@ -142,17 +111,6 @@ class MemoryMetadata(IRMetadata):
         """The footprint recorded for *name*, if the function touches it."""
         return next((item for item in self.footprint if item.level == name), None)
 
-    def format_comment(self) -> str:
-        peaks = (
-            ",".join(f"{item.level}:{item.peak_bytes}" for item in self.footprint)
-            or "0"
-        )
-        persistent = sum(item.persistent_bytes for item in self.footprint)
-        return (
-            f"memory peak={peaks} persistent={persistent} "
-            f"advisories={len(self.advisories)}"
-        )
-
 
 @dataclass(frozen=True)
 class RooflineMetadata(IRMetadata):
@@ -173,12 +131,6 @@ class RooflineMetadata(IRMetadata):
     ideal_ns: int = 0
     bound_by: str = "none"
 
-    def format_comment(self) -> str:
-        return (
-            f"roofline bound={self.ideal_ns}ns by={self.bound_by} "
-            f"compute={self.compute_ns}ns memory={self.memory_ns}ns"
-        )
-
 
 @dataclass(frozen=True)
 class TimelineMetadata(IRMetadata):
@@ -193,16 +145,6 @@ class TimelineMetadata(IRMetadata):
     trips: int = 1
     stride_ns: int = 0
 
-    def format_comment(self) -> str:
-        if self.trips > 1:
-            span_end = self.start_ns + self.trips * self.stride_ns
-            return (
-                f"timeline [{self.start_ns}+{self.stride_ns}t, "
-                f"{self.end_ns}+{self.stride_ns}t) trips={self.trips} "
-                f"span=[{self.start_ns},{span_end})"
-            )
-        return f"timeline start={self.start_ns}ns end={self.end_ns}ns"
-
 
 @dataclass(frozen=True)
 class TimelineSummaryMetadata(IRMetadata):
@@ -211,12 +153,6 @@ class TimelineSummaryMetadata(IRMetadata):
     local_makespan_ns: int = 0
     waves: int = 1
     estimated_kernel_ns: int = 0
-
-    def format_comment(self) -> str:
-        return (
-            f"timeline local-makespan={self.local_makespan_ns}ns "
-            f"waves={self.waves} estimated-kernel={self.estimated_kernel_ns}ns"
-        )
 
 
 __all__ = [

--- a/src/tilefoundry/cli/__init__.py
+++ b/src/tilefoundry/cli/__init__.py
@@ -201,6 +201,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="bind one dimension the model left open, for example ctx_len=1024",
     )
     analyze.add_argument(
+        "--operands",
+        action="store_true",
+        help=(
+            "add what each operand of a call moved to its annotation; the JSON "
+            "report carries it either way"
+        ),
+    )
+    analyze.add_argument(
         "--json", action="store_true", help="print the report as JSON instead of text"
     )
     analyze.set_defaults(_command_parser=analyze)
@@ -356,6 +364,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             analyses,
             topology=args.topology,
             as_json=args.json,
+            operands=args.operands,
             dims=one_extent_per_dim(parse_dims(args.dim)),
         )
     except (AnalysisError, VerifyError, OSError, TypeError, ValueError) as error:

--- a/src/tilefoundry/cli/analyze.py
+++ b/src/tilefoundry/cli/analyze.py
@@ -94,6 +94,7 @@ def run_authored_analysis(
     *,
     topology: str | None = None,
     as_json: bool = False,
+    operands: bool = False,
     dims: Mapping[str, int] | None = None,
 ) -> int:
     """Analyse one authored HIR selection and print what was found.
@@ -134,7 +135,7 @@ def run_authored_analysis(
         return 0
 
     result = analyze(module, function, analysis=analyses, level=topology, dims=dims)
-    rendered = render_analysis(result)
+    rendered = render_analysis(result, operands=operands)
     data = rendered.data
     if as_json:
         sys.stdout.write(f"{render_json(data)}\n")

--- a/src/tilefoundry/cli/analyze.py
+++ b/src/tilefoundry/cli/analyze.py
@@ -136,14 +136,13 @@ def run_authored_analysis(
 
     result = analyze(module, function, analysis=analyses, level=topology, dims=dims)
     rendered = render_analysis(result, operands=operands)
-    data = rendered.data
     if as_json:
-        sys.stdout.write(f"{render_json(data)}\n")
+        sys.stdout.write(f"{render_json(rendered.data)}\n")
         return 0
 
 
 
-    sys.stdout.write(f"{render_text(data)}\n\n{rendered.annotated}")
+    sys.stdout.write(f"{render_text(rendered)}\n\n{rendered.annotated}")
     return 0
 
 

--- a/src/tilefoundry/inspection/analysis_report.py
+++ b/src/tilefoundry/inspection/analysis_report.py
@@ -13,11 +13,13 @@ that drift.
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 
 from tilefoundry.analysis import (
     ComputeCostMetadata,
     MemoryMetadata,
+    RooflineMetadata,
+    TimelineSummaryMetadata,
 )
 from tilefoundry.analysis.api import AnalysisResult
 from tilefoundry.analysis.walk import postorder, tensor_types
@@ -27,9 +29,16 @@ from tilefoundry.inspection.python_printer import (
     _render_hir_function,
 )
 from tilefoundry.inspection.values import (
+    AdvisorySummary,
+    MemorySummary,
+    ReportIdentity,
+    ReportSelection,
+    TimelineSummaryView,
     declared_records,
     expr_field,
     family_of,
+    peak_footprint,
+    render_comment,
     render_record,
 )
 from tilefoundry.ir.core import Call, IRMetadata, binding_name, get_metadata
@@ -98,10 +107,16 @@ def _records_of(expr: object, selected: frozenset[type[IRMetadata]]) -> dict[str
 
 @dataclass(frozen=True)
 class AnalysisRendering:
-    """One annotated program and the report projected from that rendering."""
+    """One annotated program and the report projected from that rendering.
+
+    *summary* is one record per summary line, in reading order. They are the same
+    records the equations are annotated from, so a summary line and an equation
+    cannot state one number two ways.
+    """
 
     data: dict[str, object]
     annotated: str
+    summary: tuple[IRMetadata, ...] = ()
 
 
 def selected_types(
@@ -165,7 +180,53 @@ def render_analysis(
         "roofline" in data["requested"] and ComputeCostMetadata in available
     ):
         data["totals"] = _work_totals(function)
-    return AnalysisRendering(data=data, annotated=rendered.source)
+    return AnalysisRendering(
+        data=data,
+        annotated=rendered.source,
+        summary=_summary(function, data, function_records, selected),
+    )
+
+
+def _summary(
+    function: Function,
+    data: dict[str, object],
+    function_records: dict[str, object],
+    selected: frozenset[type[IRMetadata]],
+) -> tuple[IRMetadata, ...]:
+    """One record per summary line: what this report is about, then its findings.
+
+    A conclusion is stated by the record that holds it, on the same terms the
+    equations state theirs. Which lines appear is the same question as which
+    records the report carries, so it is asked of those and not of the text.
+    """
+    views: list[IRMetadata] = [
+        ReportIdentity(
+            target=data["target"],
+            module=data["module"],
+            function=data["function"],
+            topology=data["topology"] or "none",
+        ),
+        ReportSelection(
+            requested=tuple(data["requested"]), executed=tuple(data["executed"])
+        ),
+    ]
+    if "totals" in data:
+        views.append(get_metadata(function, ComputeCostMetadata) or ComputeCostMetadata())
+    if "memory" in function_records:
+        memory = get_metadata(function, MemoryMetadata)
+        views.append(MemorySummary(peak_footprint(memory)))
+        if MemoryMetadata in selected:
+            views.extend(AdvisorySummary(note) for note in memory.advisories)
+    if "roofline" in function_records:
+        views.append(get_metadata(function, RooflineMetadata))
+    if "timeline" in function_records:
+        summary = get_metadata(function, TimelineSummaryMetadata)
+        views.append(
+            TimelineSummaryView(
+                root=f"{data['module']}::{data['function']}", **asdict(summary)
+            )
+        )
+    return tuple(views)
 
 
 def report(result: AnalysisResult) -> dict[str, object]:
@@ -210,63 +271,13 @@ def _work_totals(function: Function) -> dict[str, object]:
     return {"flops": reported["flops"], "traffic": reported["traffic"]}
 
 
-def _flop_text(flops: dict[str, int]) -> str:
-    return ", ".join(f"{name}={value}" for name, value in sorted(flops.items())) or "0"
-
-
-def _traffic_text(traffic: dict[str, dict[str, int]]) -> str:
-    return (
-        ", ".join(
-            f"{level}=r{value['read']}/w{value['write']}"
-            for level, value in sorted(traffic.items())
-        )
-        or "0"
-    )
-
-
-def render_text(data: dict[str, object]) -> str:
+def render_text(rendering: AnalysisRendering) -> str:
     """The report as one stable line per conclusion, each prefixed with ``#``.
 
-    A conclusion appears only when a record states it, or -- for the work totals
-    -- when it is the exact sum of records that do.
+    Every line is one record walked the way an annotated equation is, so nothing
+    here knows what a family has: a conclusion appears when a record states it.
     """
-    lines = [
-        f"analysis target={data['target']} module={data['module']} "
-        f"function={data['function']} topology={data['topology'] or 'none'}",
-        f"analyses={','.join(data['requested'])} executed={','.join(data['executed'])}",
-    ]
-    totals = data.get("totals")
-    if totals is not None:
-        lines.append(f"flops {_flop_text(totals['flops'])}")
-        lines.append(f"traffic {_traffic_text(totals['traffic'])}")
-    records = data["function_records"]
-    if "memory" in records:
-        memory = records["memory"]
-        lines.append(
-            "peak-footprint "
-            + (
-                ", ".join(
-                    f"{item['level']}={item['peak_bytes']}"
-                    for item in memory["footprint"]
-                )
-                or "0"
-            )
-        )
-        lines.extend(f"advisory {note}" for note in memory.get("advisories", ()))
-    if "roofline" in records:
-        bound = records["roofline"]
-        lines.append(
-            f"ideal-bound={bound['ideal_ns']}ns by={bound['bound_by']}"
-        )
-    if "timeline" in records:
-        timeline = records["timeline"]
-        lines.append(
-            f"timeline root={data['module']}::{data['function']} "
-            f"local-makespan={timeline['local_makespan_ns']}ns "
-            f"waves={timeline['waves']} "
-            f"estimated-kernel={timeline['estimated_kernel_ns']}ns"
-        )
-    return "\n".join(f"# {line}" for line in lines)
+    return "\n".join(f"# {render_comment(view)}" for view in rendering.summary)
 
 
 def render_json(data: dict[str, object]) -> str:

--- a/src/tilefoundry/inspection/analysis_report.py
+++ b/src/tilefoundry/inspection/analysis_report.py
@@ -31,6 +31,7 @@ from tilefoundry.inspection.python_printer import (
 from tilefoundry.inspection.values import (
     AdvisorySummary,
     MemorySummary,
+    Prose,
     ReportIdentity,
     ReportSelection,
     TimelineSummaryView,
@@ -216,7 +217,7 @@ def _summary(
         memory = get_metadata(function, MemoryMetadata)
         views.append(MemorySummary(peak_footprint(memory)))
         if MemoryMetadata in selected:
-            views.extend(AdvisorySummary(note) for note in memory.advisories)
+            views.extend(AdvisorySummary(Prose(note)) for note in memory.advisories)
     if "roofline" in function_records:
         views.append(get_metadata(function, RooflineMetadata))
     if "timeline" in function_records:

--- a/src/tilefoundry/inspection/analysis_report.py
+++ b/src/tilefoundry/inspection/analysis_report.py
@@ -199,8 +199,15 @@ def selected_types(
     return tuple(order)
 
 
-def render_analysis(result: AnalysisResult) -> AnalysisRendering:
-    """Render one result once for both annotated source and report data."""
+def render_analysis(
+    result: AnalysisResult, *, operands: bool = False
+) -> AnalysisRendering:
+    """Render one result once for both annotated source and report data.
+
+    *operands* asks the annotation for the per-operand split of the traffic it
+    already states. JSON carries it either way: it is read by programs, and a
+    reader of the text is not looking that closely by default.
+    """
     function = result.function
     selected_types_ = selected_types(result)
     selected = frozenset(selected_types_)
@@ -209,6 +216,7 @@ def render_analysis(result: AnalysisResult) -> AnalysisRendering:
         options=PythonPrintOptions(
             show_types=True,
             comment_metadata_types=selected_types_,
+            comment_opt_in=frozenset({"operands"}) if operands else frozenset(),
         ),
     )
     target = result.module.resolve_target()

--- a/src/tilefoundry/inspection/analysis_report.py
+++ b/src/tilefoundry/inspection/analysis_report.py
@@ -18,10 +18,6 @@ from dataclasses import dataclass
 from tilefoundry.analysis import (
     ComputeCostMetadata,
     MemoryMetadata,
-    RooflineMetadata,
-    TimelineMetadata,
-    TimelineSummaryMetadata,
-    TrafficBytes,
 )
 from tilefoundry.analysis.api import AnalysisResult
 from tilefoundry.analysis.walk import postorder, tensor_types
@@ -30,15 +26,14 @@ from tilefoundry.inspection.python_printer import (
     _PrintedStatement,
     _render_hir_function,
 )
+from tilefoundry.inspection.values import (
+    declared_records,
+    expr_field,
+    family_of,
+    render_record,
+)
 from tilefoundry.ir.core import Call, IRMetadata, binding_name, get_metadata
 from tilefoundry.ir.hir.function import Function
-
-
-def _traffic(traffic: tuple[tuple[str, TrafficBytes], ...]) -> dict[str, dict[str, int]]:
-    return {
-        level: {"read": value.read, "write": value.write}
-        for level, value in traffic
-    }
 
 
 def _type_text(type_: object) -> str:
@@ -63,10 +58,16 @@ def _operand_name(operand: object) -> str:
     return type(operand).__name__.lower()
 
 
-def _operands(record: ComputeCostMetadata, expr: object) -> list[dict[str, object]]:
-    """Each recorded amount, against the operand it was charged to."""
-    if not isinstance(expr, Call):
-        return []
+def _operands(
+    record: ComputeCostMetadata, expr: object
+) -> list[dict[str, object]] | None:
+    """Each recorded amount, against the operand of the program it was charged to.
+
+    ``None`` where there is no such split to report: a Function Call charges its
+    callee's total, and an operand position names nothing there.
+    """
+    if not isinstance(expr, Call) or not record.operands:
+        return None
     operands = (*expr.args, expr)
     return [
         {
@@ -80,94 +81,18 @@ def _operands(record: ComputeCostMetadata, expr: object) -> list[dict[str, objec
     ]
 
 
-def _compute_cost(record: ComputeCostMetadata, expr: object) -> dict[str, object]:
-    projected: dict[str, object] = {
-        "flops": dict(record.flops),
-        "flops_per_unit": dict(record.flops_per_unit),
-        "traffic": _traffic(record.traffic),
-        "traffic_per_unit": _traffic(record.traffic_per_unit),
-    }
-    operands = _operands(record, expr)
-    if operands:
-        projected["operands"] = operands
-    return projected
-
-
-def _roofline(record: RooflineMetadata, expr: object) -> dict[str, object]:
-    return {
-        "compute_ns": record.compute_ns,
-        "memory_ns": record.memory_ns,
-        "ideal_ns": record.ideal_ns,
-        "bound_by": record.bound_by,
-    }
-
-
-def _timeline(record: TimelineMetadata, expr: object) -> dict[str, object]:
-    return {
-        "start_ns": record.start_ns,
-        "end_ns": record.end_ns,
-        "trips": record.trips,
-        "stride_ns": record.stride_ns,
-    }
-
-
-def _timeline_summary(
-    record: TimelineSummaryMetadata, expr: object
-) -> dict[str, object]:
-    return {
-        "local_makespan_ns": record.local_makespan_ns,
-        "waves": record.waves,
-        "estimated_kernel_ns": record.estimated_kernel_ns,
-    }
-
-
-def _memory(record: MemoryMetadata, expr: object) -> dict[str, object]:
-    return {
-        "footprint": [
-            {
-                "level": item.level,
-                "peak_bytes": item.peak_bytes,
-                "persistent_bytes": item.persistent_bytes,
-                "capacity_bytes": item.capacity_bytes,
-            }
-            for item in record.footprint
-        ],
-        "traffic": _traffic(record.traffic),
-        "lifetimes": [
-            {
-                "binding": item.binding,
-                "level": item.level,
-                "bytes": item.bytes,
-                "defined_at": item.defined_at,
-                "last_used_at": item.last_used_at,
-                "persistent": item.persistent,
-            }
-            for item in record.lifetimes
-        ],
-        "advisories": list(record.advisories),
-    }
-
-
-
-
-_RECORDS: tuple[tuple[str, type[IRMetadata], object], ...] = (
-    ("compute-cost", ComputeCostMetadata, _compute_cost),
-    ("memory", MemoryMetadata, _memory),
-    ("roofline", RooflineMetadata, _roofline),
-    ("timeline", TimelineMetadata, _timeline),
-    ("timeline", TimelineSummaryMetadata, _timeline_summary),
-)
+expr_field(ComputeCostMetadata, "operands", _operands)
 
 
 def _records_of(expr: object, selected: frozenset[type[IRMetadata]]) -> dict[str, object]:
     """Every selected record on *expr*, keyed by the family that owns it."""
     result: dict[str, object] = {}
-    for name, metadata_type, project in _RECORDS:
+    for metadata_type in declared_records():
         if metadata_type not in selected:
             continue
         record = get_metadata(expr, metadata_type)
         if record is not None:
-            result[name] = project(record, expr)
+            result[family_of(metadata_type)] = render_record(record, expr)
     return result
 
 
@@ -281,10 +206,8 @@ def _work_totals(function: Function) -> dict[str, object]:
     record = get_metadata(function, ComputeCostMetadata)
     if record is None:
         return {"flops": {}, "traffic": {}}
-    return {
-        "flops": dict(record.flops),
-        "traffic": _traffic(record.traffic),
-    }
+    reported = render_record(record, function)
+    return {"flops": reported["flops"], "traffic": reported["traffic"]}
 
 
 def _flop_text(flops: dict[str, int]) -> str:

--- a/src/tilefoundry/inspection/python_printer.py
+++ b/src/tilefoundry/inspection/python_printer.py
@@ -70,6 +70,8 @@ from tilefoundry.ir.types.substitute import dim_vars_by_name
 from tilefoundry.ir.visitor import _expr_children
 from tilefoundry.utils.python_source import PythonExpr
 
+from .values import PARTS, render_comment
+
 _DIM_INFIX_OPS: dict[type, str] = {
     DimAdd: "+",
     DimSub: "-",
@@ -91,6 +93,7 @@ class PythonPrintOptions:
 
     show_types: bool = False
     comment_metadata_types: tuple[type[IRMetadata], ...] = ()
+    comment_opt_in: frozenset[str] = frozenset()
 
 
 @dataclass(frozen=True)
@@ -134,6 +137,11 @@ def _comments(expr: Expr, options: PythonPrintOptions, mesh_name_map: dict[int, 
     Omit the binding because the left-hand side already carries its emitted name
     and importing recovers it there. Emit types as annotation fragments without
     a redundant ``type=`` key.
+
+    Part zero is the value's own type, which carries no key: it is not a
+    measurement of the value, it is the value, and it is DSL text that can be
+    pasted back. Every later part is what a record measured, and ``PARTS`` is
+    the boundary between those two languages.
     """
     comments: list[str] = []
     if options.show_types:
@@ -142,10 +150,10 @@ def _comments(expr: Expr, options: PythonPrintOptions, mesh_name_map: dict[int, 
         metadata = get_metadata(expr, metadata_type)
         if metadata is None:
             continue
-        comment = metadata.format_comment()
+        comment = render_comment(metadata, opt_in=options.comment_opt_in)
         if comment is not None:
             comments.append(comment)
-    return f"  # {'; '.join(comments)}" if comments else ""
+    return f"  # {PARTS.join(comments)}" if comments else ""
 
 
 def shape_entry_str(entry: object) -> str:

--- a/src/tilefoundry/inspection/python_printer.py
+++ b/src/tilefoundry/inspection/python_printer.py
@@ -55,7 +55,7 @@ from tilefoundry.ir.types.dim import (
     DimSub,
     DimVar,
 )
-from tilefoundry.ir.types.shard import c_order_strides
+from tilefoundry.ir.types.shard import try_c_order_strides
 from tilefoundry.ir.types.shard.layout import ComposedLayout, Layout, LayoutBase
 from tilefoundry.ir.types.shard.mesh import Mesh
 from tilefoundry.ir.types.shard.shard_layout import (
@@ -113,17 +113,22 @@ def _physical_line_count(lines: list[str]) -> int:
     return sum(line.count("\n") + 1 for line in lines)
 
 
-def _compact_type(ty: object) -> str:
-    """One physical-line, DSL-shaped type annotation for inspection output."""
+def _compact_type(ty: object, mesh_name_map: dict[int, str]) -> str:
+    """One physical-line, DSL-shaped type annotation for inspection output.
+
+    Takes the same mesh-name map the signature and mesh prelude are rendered
+    from, so an annotated layout names the hoisted mesh instead of restating it.
+    """
     if isinstance(ty, TensorType):
-        rendered = _tensor_annotation(ty)
+        rendered = _tensor_annotation(ty, mesh_name_map=mesh_name_map)
         return " ".join(rendered.split())
     if isinstance(ty, TupleType):
-        return "Tuple[" + ", ".join(_compact_type(field) for field in ty.fields) + "]"
+        fields = ", ".join(_compact_type(field, mesh_name_map) for field in ty.fields)
+        return f"Tuple[{fields}]"
     return repr(ty)
 
 
-def _comments(expr: Expr, options: PythonPrintOptions) -> str:
+def _comments(expr: Expr, options: PythonPrintOptions, mesh_name_map: dict[int, str]) -> str:
     """Return same-line annotations for one printed statement.
 
     Omit the binding because the left-hand side already carries its emitted name
@@ -132,7 +137,7 @@ def _comments(expr: Expr, options: PythonPrintOptions) -> str:
     """
     comments: list[str] = []
     if options.show_types:
-        comments.append(_compact_type(expr.type))
+        comments.append(_compact_type(expr.type, mesh_name_map))
     for metadata_type in options.comment_metadata_types:
         metadata = get_metadata(expr, metadata_type)
         if metadata is None:
@@ -263,6 +268,9 @@ def _shard_layout_surface_str(
     Inline splits on layout dimensions, emit partial value states as a set, and
     omit broadcasts. Include explicit strides only when present. Return ``None``
     when sugar cannot express the layout so callers use verbose fallback.
+
+    A symbolic shape has no static C-order strides to compare against, so the
+    ones it states are emitted rather than assumed contiguous.
     """
     layout = sl.layout
     if not isinstance(layout, Layout):
@@ -287,7 +295,7 @@ def _shard_layout_surface_str(
         dim_str += ","
     axis_tuple = f"({dim_str})"
 
-    c_strides = c_order_strides(layout.shape)
+    c_strides = try_c_order_strides(layout.shape)
     explicit = layout.strides is not None and layout.strides != c_strides
     stride_str = _shape_tuple(layout.strides) if explicit else None
     value_set = "{" + ", ".join(partials) + "}" if partials else None
@@ -753,7 +761,7 @@ def _module_callee_binding(target: HirFunction, child_entries: dict[int, str]) -
 
 
 def _emit_def(
-    fn: HirFunction, def_name: str, mesh_map: dict, indent: str,
+    fn: HirFunction, def_name: str, mesh_map: dict[int, str], indent: str,
     options: PythonPrintOptions, child_entries: dict[int, str] | None = None,
     *,
     line_offset: int = 0,
@@ -1132,7 +1140,7 @@ def _emit_def(
             )
         lines.append(
             f"{level}{name} = {_format_call(expr, level)}"
-            f"{_comments(expr, options)}"
+            f"{_comments(expr, options, mesh_map)}"
         )
         printed.add(id(expr))
 
@@ -1147,7 +1155,7 @@ def _emit_def(
             printed.add(key)
             return
         if isinstance(expr, Constant):
-            lines.append(f"{level}{_names[key]} = {repr(expr.value)}{_comments(expr, options)}")
+            lines.append(f"{level}{_names[key]} = {repr(expr.value)}{_comments(expr, options, mesh_map)}")
             printed.add(key)
             return
         if isinstance(expr, Tuple):
@@ -1189,7 +1197,7 @@ def _emit_def(
             loop = f"range({extent})"
         else:
             loop = f"range({start}, {extent}, {step})"
-        lines.append(f"{level}for {grid.induction_var.name} in {loop}:{_comments(grid, options)}")
+        lines.append(f"{level}for {grid.induction_var.name} in {loop}:{_comments(grid, options, mesh_map)}")
         printed.add(key)
         inner = level + "    "
         _emit_expr(grid.body, inner)
@@ -1217,7 +1225,7 @@ def _emit_def(
             continue
         if isinstance(expr, Constant):
             name = _names[id(expr)]
-            lines.append(f"{indent}{name} = {repr(expr.value)}{_comments(expr, options)}")
+            lines.append(f"{indent}{name} = {repr(expr.value)}{_comments(expr, options, mesh_map)}")
             line = _constraint_line(expr, indent, name)
             if line is not None:
                 lines.append(line)
@@ -1238,7 +1246,7 @@ def _emit_def(
                 )
             lines.append(
                 f"{indent}{name} = {_format_call(expr, indent)}"
-                f"{_comments(expr, options)}"
+                f"{_comments(expr, options, mesh_map)}"
             )
             line = _constraint_line(expr, indent, name)
             if line is not None:

--- a/src/tilefoundry/inspection/values.py
+++ b/src/tilefoundry/inspection/values.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import re
 from collections.abc import Callable, Mapping
-from dataclasses import dataclass, fields, is_dataclass
+from dataclasses import dataclass, field, fields, is_dataclass
 from typing import get_args, get_origin, get_type_hints
 
 from tilefoundry.analysis.metadata import (
@@ -55,13 +55,15 @@ RENDER: dict[type, Callable[..., str]] = {
 
 
 def render_value(value: object) -> str:
-    """One value, rendered by its own type or as the mapping it is."""
+    """One value, rendered by its own type or as the entries it holds."""
     for value_type, render in RENDER.items():
         if isinstance(value, value_type):
             return render(value, render_value)
     entries = _entries_of(value)
     if entries is not None:
         return ENTRIES.join(f"{key}{ENTRY}{render_value(item)}" for key, item in entries)
+    if isinstance(value, tuple | list):
+        return ENTRIES.join(render_value(item) for item in value)
     return str(value)
 
 
@@ -117,7 +119,7 @@ def _derived_family(record: type) -> str:
 
 def _field_projections(record: type[IRMetadata], names: tuple[str, ...]) -> tuple[Projection, ...]:
     hints = get_type_hints(record)
-    defaults = {field.name: field.default for field in fields(record)}
+    defaults = {item.name: item.default for item in fields(record)}
     return tuple(
         Projection(name, hints[name], _read(name), defaults[name]) for name in names
     )
@@ -142,7 +144,7 @@ def comment(
     *family* is only for a record whose reported name is not the one its class
     name states.
     """
-    declared = emitted or tuple(field.name for field in fields(record))
+    declared = emitted or tuple(item.name for item in fields(record))
     emissions = tuple(
         item
         if isinstance(item, Projection)
@@ -237,15 +239,13 @@ def render_record(record: IRMetadata, expr: object) -> dict[str, object]:
     from_expr = _EXPR_FIELDS.get(type(record), {})
     hints = get_type_hints(type(record))
     reported: dict[str, object] = {}
-    for field in fields(record):
-        if field.name in from_expr:
-            value = from_expr[field.name](record, expr)
+    for name in (item.name for item in fields(record)):
+        if name in from_expr:
+            value = from_expr[name](record, expr)
             if value is not None:
-                reported[field.name] = value
+                reported[name] = value
             continue
-        reported[field.name] = _reported_value(
-            getattr(record, field.name), hints[field.name]
-        )
+        reported[name] = _reported_value(getattr(record, name), hints[name])
     return reported
 
 
@@ -260,8 +260,8 @@ def _reported_value(value: object, declared: object) -> object:
     if is_dataclass(declared) and isinstance(declared, type):
         hints = get_type_hints(declared)
         return {
-            field.name: _reported_value(getattr(value, field.name), hints[field.name])
-            for field in fields(declared)
+            item.name: _reported_value(getattr(value, item.name), hints[item.name])
+            for item in fields(declared)
         }
     origin = get_origin(declared)
     if origin is dict:
@@ -320,7 +320,7 @@ def _by_operand(record: ComputeCostMetadata) -> dict[str, TrafficBytes]:
     }
 
 
-def _peak_bytes(record: MemoryMetadata) -> dict[str, int]:
+def peak_footprint(record: MemoryMetadata) -> dict[str, int]:
     """How much of each level the function holds at its peak."""
     return {item.level: item.peak_bytes for item in record.footprint}
 
@@ -345,6 +345,56 @@ def _source_span(record: SourceSpanMetadata) -> str:
     return f"{record.file}:{record.line}:{record.column}"
 
 
+@dataclass(frozen=True)
+class ReportIdentity(IRMetadata):
+    """Which program, on which machine, this report is about."""
+
+    target: str = ""
+    module: str = ""
+    function: str = ""
+    topology: str = "none"
+
+
+@dataclass(frozen=True)
+class ReportSelection(IRMetadata):
+    """What was asked for, and what running it took."""
+
+    requested: tuple[str, ...] = ()
+    executed: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class MemorySummary(IRMetadata):
+    """What one function holds at its peak, per level."""
+
+    peak_bytes: dict[str, int] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class AdvisorySummary(IRMetadata):
+    """One thing the memory walk observed that a reader should weigh."""
+
+    text: str
+
+
+@dataclass(frozen=True)
+class TimelineSummaryView(IRMetadata):
+    """One function's local plan, under the root the report is about.
+
+    ``root`` is the report's own identity composed for a reader, not something
+    the timeline family measured, which is why it lives here and not on
+    ``TimelineSummaryMetadata``. ``waves`` is stated even when it is one: how
+    many passes over the machine a plan takes is a conclusion, and one wave is an
+    answer rather than nothing to say. It is declared with no value it says
+    nothing by, so the suppression rule itself stays one rule.
+    """
+
+    root: str = ""
+    local_makespan_ns: int = 0
+    waves: int = 1
+    estimated_kernel_ns: int = 0
+
+
 comment(
     ComputeCostMetadata,
     Projection("flops", dict[str, TotalAndPerUnit[int]], _paired_flops),
@@ -353,7 +403,7 @@ comment(
 )
 comment(
     MemoryMetadata,
-    Projection("peak", dict[str, int], _peak_bytes),
+    Projection("peak", dict[str, int], peak_footprint),
     Projection("persistent", int, _persistent_bytes, default=0),
     Projection("advisories", int, _advisory_count, default=0),
 )
@@ -361,9 +411,22 @@ comment(RooflineMetadata, "ideal_ns", "bound_by")
 comment(TimelineMetadata, Projection("interval", TripInterval, _interval))
 comment(TimelineSummaryMetadata, family="timeline")
 comment(SourceSpanMetadata, Projection("span", str, _source_span), family="source")
+comment(ReportIdentity, family="analysis")
+comment(ReportSelection, family="selection")
+comment(MemorySummary, family="peak-footprint")
+comment(AdvisorySummary, family="advisory")
+comment(
+    TimelineSummaryView,
+    "root",
+    "local_makespan_ns",
+    Projection("waves", int, _read("waves")),
+    "estimated_kernel_ns",
+    family="timeline",
+)
 
 
 __all__ = [
+    "AdvisorySummary",
     "ENTRIES",
     "ENTRY",
     "FIELD",
@@ -373,14 +436,19 @@ __all__ = [
     "PER_UNIT",
     "RENDER",
     "TRIPS",
+    "MemorySummary",
     "Projection",
     "RecordComment",
+    "ReportIdentity",
+    "ReportSelection",
+    "TimelineSummaryView",
     "comment",
     "comment_of",
     "declared_records",
     "expr_field",
     "expr_fields",
     "family_of",
+    "peak_footprint",
     "render_comment",
     "render_record",
     "render_value",

--- a/src/tilefoundry/inspection/values.py
+++ b/src/tilefoundry/inspection/values.py
@@ -13,8 +13,8 @@ from __future__ import annotations
 
 import re
 from collections.abc import Callable, Mapping
-from dataclasses import dataclass, fields
-from typing import get_type_hints
+from dataclasses import dataclass, fields, is_dataclass
+from typing import get_args, get_origin, get_type_hints
 
 from tilefoundry.analysis.metadata import (
     ComputeCostMetadata,
@@ -206,6 +206,92 @@ def _says_nothing(value: object, default: object) -> bool:
     return entries is not None and not entries
 
 
+_EXPR_FIELDS: dict[type[IRMetadata], dict[str, Callable[..., object]]] = {}
+
+
+def expr_field(
+    record: type[IRMetadata], key: str, of: Callable[..., object]
+) -> None:
+    """Declare that one field is reported from the expression it is attached to.
+
+    A record states what it measured, not what the program calls the things it
+    measured. A field whose report needs those names is read by *of*, which is
+    given the record and its expression, and returns ``None`` where the program
+    offers no such reading.
+    """
+    _EXPR_FIELDS.setdefault(record, {})[key] = of
+
+
+def expr_fields(record: type[IRMetadata]) -> frozenset[str]:
+    """Which of *record*'s fields are reported from its expression."""
+    return frozenset(_EXPR_FIELDS.get(record, {}))
+
+
+def render_record(record: IRMetadata, expr: object) -> dict[str, object]:
+    """One record as report data, keyed by its own field names.
+
+    Nothing is left out and nothing is folded: a default, a ``None``, and an
+    empty mapping are each a fact a program may branch on, and the key is the
+    field name unchanged so a consumer reading the record reads the same word.
+    """
+    from_expr = _EXPR_FIELDS.get(type(record), {})
+    hints = get_type_hints(type(record))
+    reported: dict[str, object] = {}
+    for field in fields(record):
+        if field.name in from_expr:
+            value = from_expr[field.name](record, expr)
+            if value is not None:
+                reported[field.name] = value
+            continue
+        reported[field.name] = _reported_value(
+            getattr(record, field.name), hints[field.name]
+        )
+    return reported
+
+
+def _reported_value(value: object, declared: object) -> object:
+    """One value as report data, read through the type its field declared.
+
+    The type is what decides, because a value cannot: an empty tuple of pairs and
+    an empty tuple of strings are the same object and different reports.
+    """
+    if value is None:
+        return None
+    if is_dataclass(declared) and isinstance(declared, type):
+        hints = get_type_hints(declared)
+        return {
+            field.name: _reported_value(getattr(value, field.name), hints[field.name])
+            for field in fields(declared)
+        }
+    origin = get_origin(declared)
+    if origin is dict:
+        _, value_type = get_args(declared)
+        return {key: _reported_value(item, value_type) for key, item in value.items()}
+    if origin in (tuple, list):
+        item_type = _item_type(declared)
+        pair = _pair_types(item_type)
+        if pair is not None:
+            return {key: _reported_value(item, pair[1]) for key, item in value}
+        return [_reported_value(item, item_type) for item in value]
+    return value
+
+
+def _item_type(declared: object) -> object:
+    """What one entry of a declared sequence is."""
+    args = [arg for arg in get_args(declared) if arg is not Ellipsis]
+    return args[0] if args else object
+
+
+def _pair_types(declared: object) -> tuple[object, object] | None:
+    """The key and value types of a declared pair, or ``None`` if it is not one."""
+    if get_origin(declared) is not tuple:
+        return None
+    args = get_args(declared)
+    if len(args) != 2 or Ellipsis in args:
+        return None
+    return args[0], args[1]
+
+
 def _paired_flops(record: ComputeCostMetadata) -> dict[str, TotalAndPerUnit[int]]:
     """Each dtype's work, whole and per unit, as one value."""
     per_unit = dict(record.flops_per_unit)
@@ -292,7 +378,10 @@ __all__ = [
     "comment",
     "comment_of",
     "declared_records",
+    "expr_field",
+    "expr_fields",
     "family_of",
     "render_comment",
+    "render_record",
     "render_value",
 ]

--- a/src/tilefoundry/inspection/values.py
+++ b/src/tilefoundry/inspection/values.py
@@ -1,0 +1,298 @@
+"""How a record renders as one line of comment.
+
+A record states typed fields ([core-ir §2](docs/spec/core-ir.md#2-expr)); what
+they look like is decided here, so a family arrives by declaring what it has
+rather than by writing a form string -- which is how five came to spell one value
+five ways. Only a value Python cannot already read needs a rendering: three do,
+and ``int`` / ``str`` / a mapping of them do not. The constants below are the
+ladder of [inspection §2.8](docs/spec/inspection.md#28-record-comment-forms),
+one each, and nothing else in the tree spells one.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, fields
+from typing import get_type_hints
+
+from tilefoundry.analysis.metadata import (
+    ComputeCostMetadata,
+    MemoryMetadata,
+    RooflineMetadata,
+    TimelineMetadata,
+    TimelineSummaryMetadata,
+)
+from tilefoundry.ir.core.metadata import IRMetadata, SourceSpanMetadata
+from tilefoundry.ir.core.values import TotalAndPerUnit, TripInterval
+from tilefoundry.visitor_registry.contexts import TrafficBytes
+
+PAIR = "/"
+PER_UNIT = "@"
+ENTRY = ":"
+ENTRIES = ","
+FIELD = "="
+FIELDS = " "
+PARTS = "; "
+TRIPS = "*"
+
+
+def _trip_interval(value: TripInterval, render: Callable[[object], str]) -> str:
+    """One interval, offset by the trip index when it repeats."""
+    if value.trips <= 1:
+        return f"[{value.start}{ENTRIES}{value.end})"
+    offset = f"{value.stride}t+"
+    return f"[{offset}{value.start}{ENTRIES}{offset}{value.end}){TRIPS}{value.trips}"
+
+
+RENDER: dict[type, Callable[..., str]] = {
+    TrafficBytes: lambda value, render: f"r{value.read}{PAIR}w{value.write}",
+    TotalAndPerUnit: (
+        lambda value, render: f"{render(value.total)}{PER_UNIT}{render(value.per_unit)}"
+    ),
+    TripInterval: _trip_interval,
+}
+
+
+def render_value(value: object) -> str:
+    """One value, rendered by its own type or as the mapping it is."""
+    for value_type, render in RENDER.items():
+        if isinstance(value, value_type):
+            return render(value, render_value)
+    entries = _entries_of(value)
+    if entries is not None:
+        return ENTRIES.join(f"{key}{ENTRY}{render_value(item)}" for key, item in entries)
+    return str(value)
+
+
+def _entries_of(value: object) -> tuple[tuple[object, object], ...] | None:
+    """*value* as key/value pairs, or ``None`` when it is not a mapping."""
+    if isinstance(value, Mapping):
+        return tuple(value.items())
+    if isinstance(value, tuple) and all(
+        isinstance(item, tuple) and len(item) == 2 for item in value
+    ):
+        return value
+    return None
+
+
+_UNSET = object()
+
+
+@dataclass(frozen=True)
+class Projection:
+    """One key a comment emits: its name, its type, and where its value is read.
+
+    A field is the identity projection of itself. Anything else -- a sum, a
+    count, several fields folded into one value -- is declared here, which is
+    what keeps the next one from appearing unannounced.
+
+    *default* is the value this key says nothing by, so it is left out. Without
+    one, an empty mapping says nothing and every other value is emitted.
+    """
+
+    key: str
+    type: object
+    of: Callable[..., object]
+    default: object = _UNSET
+    opt_in: bool = False
+
+
+@dataclass(frozen=True)
+class RecordComment:
+    """What one record type emits, in order, under which family name."""
+
+    family: str
+    emissions: tuple[Projection, ...]
+
+
+_COMMENTS: dict[type[IRMetadata], RecordComment] = {}
+
+
+def _derived_family(record: type) -> str:
+    """The family name the class name already states."""
+    stem = record.__name__.removesuffix("Metadata")
+    return re.sub(r"(?<!^)(?=[A-Z])", "-", stem).lower()
+
+
+def _field_projections(record: type[IRMetadata], names: tuple[str, ...]) -> tuple[Projection, ...]:
+    hints = get_type_hints(record)
+    defaults = {field.name: field.default for field in fields(record)}
+    return tuple(
+        Projection(name, hints[name], _read(name), defaults[name]) for name in names
+    )
+
+
+def _read(name: str) -> Callable[..., object]:
+    return lambda record: getattr(record, name)
+
+
+def comment(
+    record: type[IRMetadata],
+    *emitted: str | Projection,
+    family: str | None = None,
+) -> None:
+    """Declare that *record* renders as a comment, and what it emits.
+
+    A field is named by its own name; anything else is a ``Projection``. Naming
+    nothing emits every field in declaration order. A record with no declaration
+    renders as ``None``, which is how metadata that is not a report stays out of
+    the comment.
+
+    *family* is only for a record whose reported name is not the one its class
+    name states.
+    """
+    declared = emitted or tuple(field.name for field in fields(record))
+    emissions = tuple(
+        item
+        if isinstance(item, Projection)
+        else _field_projections(record, (item,))[0]
+        for item in declared
+    )
+    _COMMENTS[record] = RecordComment(
+        family=family or _derived_family(record), emissions=emissions
+    )
+
+
+def comment_of(record: type[IRMetadata]) -> RecordComment | None:
+    """What *record* declared it emits, if it declared anything."""
+    return _COMMENTS.get(record)
+
+
+def declared_records() -> tuple[type[IRMetadata], ...]:
+    """Every record type that declared it renders as a comment."""
+    return tuple(_COMMENTS)
+
+
+def family_of(record: type[IRMetadata]) -> str:
+    """The family name *record* is reported under."""
+    declared = _COMMENTS.get(record)
+    return declared.family if declared is not None else _derived_family(record)
+
+
+def render_comment(
+    record: IRMetadata, *, opt_in: frozenset[str] = frozenset()
+) -> str | None:
+    """One record as one comment, or ``None`` when it does not report.
+
+    A key is its declared name with ``_`` written as ``-``; a unit belongs in
+    that name, which is where it is said once. A record declaring one key uses
+    the family name as that key, because for a record of one thing the family
+    and the key say the same thing twice.
+    """
+    declared = _COMMENTS.get(type(record))
+    if declared is None:
+        return None
+    alone = len(declared.emissions) == 1
+    emitted: list[str] = []
+    for emission in declared.emissions:
+        if emission.opt_in and emission.key not in opt_in:
+            continue
+        value = emission.of(record)
+        if _says_nothing(value, emission.default):
+            continue
+        key = declared.family if alone else emission.key.replace("_", "-")
+        emitted.append(f"{key}{FIELD}{render_value(value)}")
+    if alone and emitted:
+        return emitted[0]
+    return FIELDS.join([declared.family, *emitted])
+
+
+def _says_nothing(value: object, default: object) -> bool:
+    """Whether this value adds nothing to the comment it would appear in."""
+    if default is not _UNSET:
+        return value == default
+    entries = _entries_of(value)
+    return entries is not None and not entries
+
+
+def _paired_flops(record: ComputeCostMetadata) -> dict[str, TotalAndPerUnit[int]]:
+    """Each dtype's work, whole and per unit, as one value."""
+    per_unit = dict(record.flops_per_unit)
+    return {
+        dtype: TotalAndPerUnit(total, per_unit.get(dtype, 0))
+        for dtype, total in record.flops
+    }
+
+
+def _paired_traffic(
+    record: ComputeCostMetadata,
+) -> dict[str, TotalAndPerUnit[TrafficBytes]]:
+    """Each level's traffic, whole and per unit, as one value."""
+    return {
+        level: TotalAndPerUnit(moved, record.traffic_per_unit_at(level))
+        for level, moved in record.traffic
+    }
+
+
+def _by_operand(record: ComputeCostMetadata) -> dict[str, TrafficBytes]:
+    """What each operand moved, positional against ``(*call.args, call)``."""
+    last = len(record.operands) - 1
+    return {
+        ("result" if index == last else str(index)): moved
+        for index, moved in enumerate(record.operands)
+    }
+
+
+def _peak_bytes(record: MemoryMetadata) -> dict[str, int]:
+    """How much of each level the function holds at its peak."""
+    return {item.level: item.peak_bytes for item in record.footprint}
+
+
+def _persistent_bytes(record: MemoryMetadata) -> int:
+    """The part of the peak the function cannot reclaim, across levels."""
+    return sum(item.persistent_bytes for item in record.footprint)
+
+
+def _advisory_count(record: MemoryMetadata) -> int:
+    """How many advisories there are; the comment is not where they are read."""
+    return len(record.advisories)
+
+
+def _interval(record: TimelineMetadata) -> TripInterval:
+    """The occurrence's interval, with its repetition folded in."""
+    return TripInterval(record.start_ns, record.end_ns, record.stride_ns, record.trips)
+
+
+def _source_span(record: SourceSpanMetadata) -> str:
+    """Where the expression was authored, as one location."""
+    return f"{record.file}:{record.line}:{record.column}"
+
+
+comment(
+    ComputeCostMetadata,
+    Projection("flops", dict[str, TotalAndPerUnit[int]], _paired_flops),
+    Projection("traffic", dict[str, TotalAndPerUnit[TrafficBytes]], _paired_traffic),
+    Projection("operands", dict[str, TrafficBytes], _by_operand, opt_in=True),
+)
+comment(
+    MemoryMetadata,
+    Projection("peak", dict[str, int], _peak_bytes),
+    Projection("persistent", int, _persistent_bytes, default=0),
+    Projection("advisories", int, _advisory_count, default=0),
+)
+comment(RooflineMetadata, "ideal_ns", "bound_by")
+comment(TimelineMetadata, Projection("interval", TripInterval, _interval))
+comment(TimelineSummaryMetadata, family="timeline")
+comment(SourceSpanMetadata, Projection("span", str, _source_span), family="source")
+
+
+__all__ = [
+    "ENTRIES",
+    "ENTRY",
+    "FIELD",
+    "FIELDS",
+    "PAIR",
+    "PARTS",
+    "PER_UNIT",
+    "RENDER",
+    "TRIPS",
+    "Projection",
+    "RecordComment",
+    "comment",
+    "comment_of",
+    "declared_records",
+    "family_of",
+    "render_comment",
+    "render_value",
+]

--- a/src/tilefoundry/inspection/values.py
+++ b/src/tilefoundry/inspection/values.py
@@ -3,9 +3,9 @@
 A record states typed fields ([core-ir §2](docs/spec/core-ir.md#2-expr)); what
 they look like is decided here, so a family arrives by declaring what it has
 rather than by writing a form string -- which is how five came to spell one value
-five ways. Only a value Python cannot already read needs a rendering: three do,
-and ``int`` / ``str`` / a mapping of them do not. The constants below are the
-ladder of [inspection §2.8](docs/spec/inspection.md#28-record-comment-forms),
+five ways. A value earns a rendering of its own only where Python cannot already
+read it: an ``int``, a token, and a mapping of them get none. The constants below
+are the ladder of [inspection §2.8](docs/spec/inspection.md#28-record-comment-forms),
 one each, and nothing else in the tree spells one.
 """
 

--- a/src/tilefoundry/inspection/values.py
+++ b/src/tilefoundry/inspection/values.py
@@ -11,6 +11,7 @@ one each, and nothing else in the tree spells one.
 
 from __future__ import annotations
 
+import json
 import re
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field, fields, is_dataclass
@@ -37,6 +38,16 @@ PARTS = "; "
 TRIPS = "*"
 
 
+class Prose(str):
+    """Text that is a sentence rather than a token.
+
+    A token renders bare, which only works while it holds no separator. A
+    sentence holds several -- spaces, commas, a semicolon -- so it renders as a
+    quoted, escaped string literal, which brackets it: a reader splits a layer
+    outside the quotes ([inspection §2.8](docs/spec/inspection.md#28-record-comment-forms)).
+    """
+
+
 def _trip_interval(value: TripInterval, render: Callable[[object], str]) -> str:
     """One interval, offset by the trip index when it repeats."""
     if value.trips <= 1:
@@ -46,6 +57,7 @@ def _trip_interval(value: TripInterval, render: Callable[[object], str]) -> str:
 
 
 RENDER: dict[type, Callable[..., str]] = {
+    Prose: lambda value, render: json.dumps(str(value)),
     TrafficBytes: lambda value, render: f"r{value.read}{PAIR}w{value.write}",
     TotalAndPerUnit: (
         lambda value, render: f"{render(value.total)}{PER_UNIT}{render(value.per_unit)}"
@@ -374,7 +386,7 @@ class MemorySummary(IRMetadata):
 class AdvisorySummary(IRMetadata):
     """One thing the memory walk observed that a reader should weigh."""
 
-    text: str
+    text: Prose
 
 
 @dataclass(frozen=True)
@@ -434,6 +446,7 @@ __all__ = [
     "PAIR",
     "PARTS",
     "PER_UNIT",
+    "Prose",
     "RENDER",
     "TRIPS",
     "MemorySummary",

--- a/src/tilefoundry/ir/core/__init__.py
+++ b/src/tilefoundry/ir/core/__init__.py
@@ -16,6 +16,7 @@ from .metadata import (
     source_metadata,
 )
 from .op import Op, ParameterInfo
+from .values import TotalAndPerUnit, TripInterval
 from tilefoundry.visitor_registry.registries import (
     AnalysisRegistry,
     cost_evaluator_registry,
@@ -44,6 +45,8 @@ __all__ = [
     "remove_metadata",
     "Op",
     "ParameterInfo",
+    "TotalAndPerUnit",
+    "TripInterval",
     "AnalysisRegistry",
     "typeinfer_registry",
     "verify_stmt_registry",

--- a/src/tilefoundry/ir/core/metadata.py
+++ b/src/tilefoundry/ir/core/metadata.py
@@ -7,10 +7,6 @@ from dataclasses import dataclass, replace
 class IRMetadata:
     """Base class for typed metadata attached to an IR expression."""
 
-    def format_comment(self) -> str | None:
-        """Return an optional source-printer comment for this metadata."""
-        return None
-
 
 @dataclass(frozen=True)
 class BindingMetadata(IRMetadata):
@@ -28,9 +24,6 @@ class SourceSpanMetadata(IRMetadata):
     column: int
     end_line: int | None = None
     end_column: int | None = None
-
-    def format_comment(self) -> str:
-        return f"source={self.file}:{self.line}:{self.column}"
 
 
 def get_metadata[T: IRMetadata](expr: "Expr", cls: type[T]) -> T | None:

--- a/src/tilefoundry/ir/core/values.py
+++ b/src/tilefoundry/ir/core/values.py
@@ -1,0 +1,40 @@
+"""Value types a record states and Python has no shape for.
+
+A field that a plain ``int``, ``str``, or mapping already reads correctly does
+not belong here -- a name that renders exactly like ``int`` says nothing extra.
+These two earn their place: a bare pair cannot say which half is the whole
+machine's, and Python has no half-open interval parameterized by a trip index.
+
+They carry values only. What they look like is decided where the rest of the
+rendering is, in inspection.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class TotalAndPerUnit[V]:
+    """One quantity, stated for the whole machine and for one unit of it."""
+
+    total: V
+    per_unit: V
+
+
+@dataclass(frozen=True)
+class TripInterval:
+    """A half-open interval, parameterized by the trip index of its loop.
+
+    A single trip occurs once, so ``stride`` says nothing about it and the trip
+    index does not appear. Repeated trips state the first interval and the
+    stride every later one is offset by.
+    """
+
+    start: int
+    end: int
+    stride: int = 0
+    trips: int = 1
+
+
+__all__ = ["TotalAndPerUnit", "TripInterval"]

--- a/tests/analysis/test_analysis_families.py
+++ b/tests/analysis/test_analysis_families.py
@@ -915,7 +915,7 @@ def test_a_cache_too_small_is_advisory_and_only_where_the_scopes_agree() -> None
     assert not any("l1 holds" in note for note in record.advisories)
 
     lines = render_text(render_analysis(result)).splitlines()
-    assert [f"# advisory={note}" for note in record.advisories] == [
+    assert [f"# advisory={json.dumps(note)}" for note in record.advisories] == [
         line for line in lines if line.startswith("# advisory")
     ]
 

--- a/tests/analysis/test_analysis_families.py
+++ b/tests/analysis/test_analysis_families.py
@@ -38,7 +38,12 @@ from tilefoundry.analysis.compute_cost import _call_movement
 from tilefoundry.analysis.errors import AnalysisError
 from tilefoundry.analysis.walk import postorder
 from tilefoundry.dsl import ConstTensor, DimVar, Mesh, Tensor, Topology, tf
-from tilefoundry.inspection.analysis_report import render_json, render_text, report
+from tilefoundry.inspection.analysis_report import (
+    render_analysis,
+    render_json,
+    render_text,
+    report,
+)
 from tilefoundry.inspection.values import render_comment
 from tilefoundry.ir.core import Call, Constant, Tuple, Var, get_metadata
 from tilefoundry.ir.hir import Function
@@ -909,6 +914,11 @@ def test_a_cache_too_small_is_advisory_and_only_where_the_scopes_agree() -> None
     assert any("l2 holds" in note for note in record.advisories)
     assert not any("l1 holds" in note for note in record.advisories)
 
+    lines = render_text(render_analysis(result)).splitlines()
+    assert [f"# advisory={note}" for note in record.advisories] == [
+        line for line in lines if line.startswith("# advisory")
+    ]
+
 
 def test_a_shared_block_reports_what_the_program_leaves_the_cache() -> None:
     """The sharing edge makes L1's usable size depend on the program.
@@ -1348,7 +1358,8 @@ def test_a_report_shows_the_requested_analyses_and_reads_the_same_either_way() -
     entry = _entry(_CudaAdd)
     result = analyze(_CudaAdd, entry, analysis="roofline")
 
-    data = report(result)
+    rendered = render_analysis(result)
+    data = rendered.data
 
     assert data["requested"] == ["roofline"]
     assert data["executed"] == ["compute-cost", "memory", "roofline"]
@@ -1368,9 +1379,9 @@ def test_a_report_shows_the_requested_analyses_and_reads_the_same_either_way() -
 
     payload = json.loads(render_json(data))
     assert payload == data
-    text = render_text(data)
-    assert f"by={payload['function_records']['roofline']['bound_by']}" in text
-    assert "# flops " in text
-    assert "# traffic " in text
-    assert "# peak-footprint " in text
+    text = render_text(rendered)
+    bound = payload["function_records"]["roofline"]
+    assert f"# roofline ideal-ns={bound['ideal_ns']} bound-by={bound['bound_by']}" in text
+    assert "# compute-cost flops=f32:256@256 traffic=gmem:r2048/w1024@r2048/w1024" in text
+    assert "# peak-footprint=gmem:2048" in text
     assert "operands" not in text

--- a/tests/analysis/test_analysis_families.py
+++ b/tests/analysis/test_analysis_families.py
@@ -39,6 +39,7 @@ from tilefoundry.analysis.errors import AnalysisError
 from tilefoundry.analysis.walk import postorder
 from tilefoundry.dsl import ConstTensor, DimVar, Mesh, Tensor, Topology, tf
 from tilefoundry.inspection.analysis_report import render_json, render_text, report
+from tilefoundry.inspection.values import render_comment
 from tilefoundry.ir.core import Call, Constant, Tuple, Var, get_metadata
 from tilefoundry.ir.hir import Function
 from tilefoundry.ir.hir.math.binary import Binary
@@ -1091,8 +1092,8 @@ def test_mega_kernel_preserves_placement_costs_and_timeline_order() -> None:
     assert cost.traffic_per_unit == (("gmem", TrafficBytes(read=256, write=256)),)
     assert cost.traffic_per_unit_at("gmem") == TrafficBytes(read=256, write=256)
     assert (
-        "bytes=gmem:r30720/w30720 per-unit-bytes=gmem:r256/w256 operands="
-        in cost.format_comment()
+        "traffic=gmem:r30720/w30720@r256/w256"
+        in render_comment(cost, opt_in=frozenset({"operands"}))
     )
 
     records = tuple(get_metadata(call, TimelineMetadata) for call in calls)
@@ -1360,8 +1361,10 @@ def test_a_report_shows_the_requested_analyses_and_reads_the_same_either_way() -
     assert get_metadata(result.function, MemoryMetadata) is not None
     cost = get_metadata(_calls(result.function)[-1], ComputeCostMetadata)
     assert cost is not None
-    assert " operands=0:r" in cost.format_comment()
-    assert ",result:r" in cost.format_comment()
+    asked = render_comment(cost, opt_in=frozenset({"operands"}))
+    assert " operands=0:r" in asked
+    assert ",result:r" in asked
+    assert "operands" not in render_comment(cost)
 
     payload = json.loads(render_json(data))
     assert payload == data

--- a/tests/analysis/test_analysis_invariants.py
+++ b/tests/analysis/test_analysis_invariants.py
@@ -8,6 +8,11 @@ implementation output, so a formula round-trip cannot validate itself.
 
 from __future__ import annotations
 
+import re
+from dataclasses import MISSING
+from dataclasses import fields as dataclass_fields
+from typing import get_args, get_origin
+
 import isl
 import pytest
 
@@ -15,12 +20,14 @@ import tilefoundry.analysis.api as analysis_api
 import tilefoundry.cli.analyze as cli_analyze
 from tests.fixtures.logical.authored_constraint import AuthoredConstraint
 from tests.fixtures.logical.gqa_static import static_online_attend
+from tests.fixtures.placed.moe_mega_kernel import MoEMegaKernel
 from tests.fixtures.placed.rmsnorm import RmsnormModule
 from tilefoundry import func, module
 from tilefoundry.analysis import (
     AnalysisError,
     OccurrenceProvenance,
     TileGraph,
+    analyze,
     check_program,
     extract,
 )
@@ -28,9 +35,24 @@ from tilefoundry.analysis.preflight import validate_authored
 from tilefoundry.analysis.walk import postorder, values_of
 from tilefoundry.dsl import ConstTensor, Tensor
 from tilefoundry.dsl.tf import *  # noqa: F401,F403 -- op names resolved dynamically
+from tilefoundry.inspection.values import (
+    ENTRIES,
+    ENTRY,
+    FIELD,
+    FIELDS,
+    PAIR,
+    PER_UNIT,
+    TRIPS,
+    comment_of,
+    declared_records,
+    render_comment,
+)
 from tilefoundry.ir.core import (
+    BindingMetadata,
     Call,
     SourceSpanMetadata,
+    TotalAndPerUnit,
+    TripInterval,
     TypeInferContext,
     Var,
     binding_name,
@@ -56,6 +78,7 @@ from tilefoundry.visitor_registry.access_relation import (
     AccessRelations,
     access_relation_registry,
 )
+from tilefoundry.visitor_registry.contexts import TrafficBytes
 
 REPEATS = 4
 B, S, H, D = 1, 5, 2, 3
@@ -536,3 +559,90 @@ def test_a_quantised_scale_is_written_once_per_group() -> None:
     scale = relation.outputs[1]
     assert isinstance(scale, isl.map)
     assert "128" in str(scale)
+
+
+def _emitted(text: str, family: str) -> dict[str, str]:
+    """One comment taken apart by the record and field layers of the ladder."""
+    if text.startswith(f"{family}{FIELD}"):
+        return {family: text[len(family) + len(FIELD) :]}
+    head, _, rest = text.partition(FIELDS)
+    assert head == family, text
+    return dict(part.split(FIELD, 1) for part in rest.split(FIELDS) if part)
+
+
+def _assert_shape(text: str, declared: object) -> None:
+    """One value keeps the shape its declared type renders in.
+
+    Which is also how the separator ladder is checked: an inner value holding an
+    outer separator would not match the shape its own type renders in.
+    """
+    if declared is int:
+        assert re.fullmatch(r"-?\d+", text), (text, declared)
+    elif declared is str:
+        assert FIELD not in text and FIELDS not in text, (text, declared)
+    elif declared is TrafficBytes:
+        assert re.fullmatch(rf"r-?\d+{re.escape(PAIR)}w-?\d+", text), text
+    elif declared is TripInterval:
+        assert re.fullmatch(rf"\[[^{ENTRIES}]+{ENTRIES}[^{ENTRIES}]+\)(\{TRIPS}\d+)?", text), text
+    elif get_origin(declared) is TotalAndPerUnit:
+        (inner,) = get_args(declared)
+        total, separator, per_unit = text.partition(PER_UNIT)
+        assert separator == PER_UNIT, text
+        _assert_shape(total, inner)
+        _assert_shape(per_unit, inner)
+    elif get_origin(declared) is dict:
+        key_type, value_type = get_args(declared)
+        for entry in text.split(ENTRIES):
+            key, separator, value = entry.partition(ENTRY)
+            assert separator == ENTRY, entry
+            _assert_shape(key, key_type)
+            _assert_shape(value, value_type)
+    else:
+        raise AssertionError(f"{declared} has no rendering: {text}")
+
+
+def test_a_record_comment_states_only_what_it_declared() -> None:
+    """Every key on a comment maps back to a field or a declared projection.
+
+    A key spelled by hand drifts from the field it reports -- five did -- and a
+    projection nobody declared can grow a sixth. So the walk is held to the
+    declarations: every key is one of them, every value keeps the shape its
+    declared type renders in, and a record that measured nothing states its
+    family name and stops. Metadata that is not a report states nothing at all.
+    """
+    result = analyze(
+        MoEMegaKernel,
+        MoEMegaKernel.entry_function(),
+        analysis=("compute-cost", "memory", "roofline", "timeline"),
+    )
+    function = result.function
+    found: dict[type, list[object]] = {}
+    for expr in (function, *postorder(function.body)):
+        for value in expr.metadata:
+            found.setdefault(type(value), []).append(value)
+
+    assert set(declared_records()) <= set(found)
+    assert {BindingMetadata, OccurrenceProvenance} <= set(found)
+
+    for record_type, records in found.items():
+        declared = comment_of(record_type)
+        if declared is None:
+            assert all(render_comment(record) is None for record in records)
+            continue
+        keys = {emission.key.replace("_", "-"): emission for emission in declared.emissions}
+        for record in records:
+            emitted = _emitted(render_comment(record), declared.family)
+            for key, value in emitted.items():
+                emission = keys.get(key) or (
+                    declared.emissions[0] if key == declared.family else None
+                )
+                assert emission is not None, (key, declared)
+                assert not emission.opt_in, (key, "asked for nothing")
+                _assert_shape(value, emission.type)
+
+    for record_type in declared_records():
+        if any(field.default is MISSING for field in dataclass_fields(record_type)):
+            continue
+        declared = comment_of(record_type)
+        nothing = render_comment(record_type())
+        assert nothing == declared.family or nothing.startswith(f"{declared.family}{FIELD}")

--- a/tests/analysis/test_analysis_invariants.py
+++ b/tests/analysis/test_analysis_invariants.py
@@ -35,6 +35,7 @@ from tilefoundry.analysis.preflight import validate_authored
 from tilefoundry.analysis.walk import postorder, values_of
 from tilefoundry.dsl import ConstTensor, Tensor
 from tilefoundry.dsl.tf import *  # noqa: F401,F403 -- op names resolved dynamically
+from tilefoundry.inspection.analysis_report import render_analysis
 from tilefoundry.inspection.values import (
     ENTRIES,
     ENTRY,
@@ -43,6 +44,7 @@ from tilefoundry.inspection.values import (
     PAIR,
     PER_UNIT,
     TRIPS,
+    AdvisorySummary,
     comment_of,
     declared_records,
     expr_fields,
@@ -600,25 +602,35 @@ def _assert_shape(text: str, declared: object) -> None:
             assert separator == ENTRY, entry
             _assert_shape(key, key_type)
             _assert_shape(value, value_type)
+    elif get_origin(declared) is tuple:
+        (item_type,) = (arg for arg in get_args(declared) if arg is not Ellipsis)
+        for item in text.split(ENTRIES):
+            _assert_shape(item, item_type)
     else:
         raise AssertionError(f"{declared} has no rendering: {text}")
 
 
-def _every_record() -> dict[type, list[tuple[object, object]]]:
-    """Every record one real analysis leaves, each with the expression it is on."""
+def _analysed_mega() -> tuple[dict[type, list[tuple[object, object]]], tuple[object, ...]]:
+    """What one real analysis leaves on the IR, and the views it reports.
+
+    Between them they cover every declared record but ``AdvisorySummary``, which
+    needs a program that overflows a cache; the memory family test pins that line.
+    """
     result = analyze(
         MoEMegaKernel,
         MoEMegaKernel.entry_function(),
         analysis=("compute-cost", "memory", "roofline", "timeline"),
     )
+    rendered = render_analysis(result)
     function = result.function
     found: dict[type, list[tuple[object, object]]] = {}
     for expr in (function, *postorder(function.body)):
         for value in expr.metadata:
             found.setdefault(type(value), []).append((value, expr))
-    assert set(declared_records()) <= set(found)
-    assert {BindingMetadata, OccurrenceProvenance} <= set(found)
-    return found
+    covered = set(found) | {type(view) for view in rendered.summary}
+    assert set(declared_records()) <= covered | {AdvisorySummary}
+    assert {BindingMetadata, OccurrenceProvenance} <= covered
+    return found, rendered.summary
 
 
 def test_a_record_comment_states_only_what_it_declared() -> None:
@@ -628,15 +640,24 @@ def test_a_record_comment_states_only_what_it_declared() -> None:
     projection nobody declared can grow a sixth. So the walk is held to the
     declarations: every key is one of them, every value keeps the shape its
     declared type renders in, and a record that measured nothing states its
-    family name and stops. Metadata that is not a report states nothing at all.
+    family name and stops. Metadata that is not a report states nothing at all,
+    and a summary line is held to the same rules as an annotated equation.
     """
-    for record_type, records in _every_record().items():
+    found, views = _analysed_mega()
+    stated: dict[type, list[object]] = {
+        record_type: [record for record, _ in records]
+        for record_type, records in found.items()
+    }
+    for view in views:
+        stated.setdefault(type(view), []).append(view)
+
+    for record_type, records in stated.items():
         declared = comment_of(record_type)
         if declared is None:
-            assert all(render_comment(record) is None for record, _ in records)
+            assert all(render_comment(record) is None for record in records)
             continue
         keys = {emission.key.replace("_", "-"): emission for emission in declared.emissions}
-        for record, _ in records:
+        for record in records:
             emitted = _emitted(render_comment(record), declared.family)
             for key, value in emitted.items():
                 emission = keys.get(key) or (
@@ -650,8 +671,9 @@ def test_a_record_comment_states_only_what_it_declared() -> None:
         if any(field.default is MISSING for field in dataclass_fields(record_type)):
             continue
         declared = comment_of(record_type)
-        nothing = render_comment(record_type())
-        assert nothing == declared.family or nothing.startswith(f"{declared.family}{FIELD}")
+        nothing = _emitted(render_comment(record_type()), declared.family)
+        assert set(nothing) <= {declared.family, "waves"}, nothing
+        assert nothing.get("waves", "1") == "1"
 
 
 def test_a_reported_record_keys_every_field_by_its_own_name() -> None:
@@ -664,7 +686,8 @@ def test_a_reported_record_keys_every_field_by_its_own_name() -> None:
     only key it may leave out is one read from the expression, which is where a
     Function Call has no operand split to state.
     """
-    for record_type, records in _every_record().items():
+    found, _ = _analysed_mega()
+    for record_type, records in found.items():
         if comment_of(record_type) is None:
             continue
         names = {field.name for field in dataclass_fields(record_type)}

--- a/tests/analysis/test_analysis_invariants.py
+++ b/tests/analysis/test_analysis_invariants.py
@@ -8,6 +8,7 @@ implementation output, so a formula round-trip cannot validate itself.
 
 from __future__ import annotations
 
+import json
 import re
 from dataclasses import MISSING
 from dataclasses import fields as dataclass_fields
@@ -18,6 +19,7 @@ import pytest
 
 import tilefoundry.analysis.api as analysis_api
 import tilefoundry.cli.analyze as cli_analyze
+from tests.analysis.test_analysis_families import _oversized_working_set
 from tests.fixtures.logical.authored_constraint import AuthoredConstraint
 from tests.fixtures.logical.gqa_static import static_online_attend
 from tests.fixtures.placed.moe_mega_kernel import MoEMegaKernel
@@ -45,6 +47,7 @@ from tilefoundry.inspection.values import (
     PER_UNIT,
     TRIPS,
     AdvisorySummary,
+    Prose,
     comment_of,
     declared_records,
     expr_fields,
@@ -566,13 +569,23 @@ def test_a_quantised_scale_is_written_once_per_group() -> None:
     assert "128" in str(scale)
 
 
+_KEYED = re.compile(rf'(?P<key>[\w-]+){FIELD}(?P<value>"(?:[^"\\]|\\.)*"|\S+)')
+
+
 def _emitted(text: str, family: str) -> dict[str, str]:
-    """One comment taken apart by the record and field layers of the ladder."""
+    """One comment taken apart by the record and field layers of the ladder.
+
+    The record layer splits outside a quoted value, which is the whole reason a
+    value that holds a separator has to bracket itself. That the pairs rejoin to
+    exactly what was read is how the split is held to being one.
+    """
     if text.startswith(f"{family}{FIELD}"):
         return {family: text[len(family) + len(FIELD) :]}
     head, _, rest = text.partition(FIELDS)
     assert head == family, text
-    return dict(part.split(FIELD, 1) for part in rest.split(FIELDS) if part)
+    keyed = list(_KEYED.finditer(rest))
+    assert FIELDS.join(match.group(0) for match in keyed) == rest, rest
+    return {match["key"]: match["value"] for match in keyed}
 
 
 def _assert_shape(text: str, declared: object) -> None:
@@ -583,6 +596,8 @@ def _assert_shape(text: str, declared: object) -> None:
     """
     if declared is int:
         assert re.fullmatch(r"-?\d+", text), (text, declared)
+    elif declared is Prose:
+        assert re.fullmatch(r'"(?:[^"\\]|\\.)*"', text), (text, declared)
     elif declared is str:
         assert FIELD not in text and FIELDS not in text, (text, declared)
     elif declared is TrafficBytes:
@@ -610,12 +625,11 @@ def _assert_shape(text: str, declared: object) -> None:
         raise AssertionError(f"{declared} has no rendering: {text}")
 
 
-def _analysed_mega() -> tuple[dict[type, list[tuple[object, object]]], tuple[object, ...]]:
-    """What one real analysis leaves on the IR, and the views it reports.
+_PROSE_PROBE = 'l2 holds 2 B, spills; says "no" over \\'
 
-    Between them they cover every declared record but ``AdvisorySummary``, which
-    needs a program that overflows a cache; the memory family test pins that line.
-    """
+
+def _analysed_mega() -> tuple[dict[type, list[tuple[object, object]]], tuple[object, ...]]:
+    """What one real analysis leaves on the IR, and the views it reports."""
     result = analyze(
         MoEMegaKernel,
         MoEMegaKernel.entry_function(),
@@ -627,10 +641,35 @@ def _analysed_mega() -> tuple[dict[type, list[tuple[object, object]]], tuple[obj
     for expr in (function, *postorder(function.body)):
         for value in expr.metadata:
             found.setdefault(type(value), []).append((value, expr))
-    covered = set(found) | {type(view) for view in rendered.summary}
-    assert set(declared_records()) <= covered | {AdvisorySummary}
-    assert {BindingMetadata, OccurrenceProvenance} <= covered
     return found, rendered.summary
+
+
+def _every_stated_record() -> dict[type, list[object]]:
+    """Every declared record, from real analyses, plus one prose probe.
+
+    The mega kernel fits its caches, so an advisory needs the second program;
+    the probe then carries every separator the ladder uses, which is what a
+    quoted value has to survive.
+    """
+    found, views = _analysed_mega()
+    stated: dict[type, list[object]] = {
+        record_type: [record for record, _ in records]
+        for record_type, records in found.items()
+    }
+    for view in views:
+        stated.setdefault(type(view), []).append(view)
+    advisory = render_analysis(
+        analyze(_oversized_working_set, _oversized_working_set.entry_function(), analysis="memory")
+    )
+    stated.setdefault(AdvisorySummary, []).extend(
+        view for view in advisory.summary if isinstance(view, AdvisorySummary)
+    )
+    stated[AdvisorySummary].append(AdvisorySummary(Prose(_PROSE_PROBE)))
+
+    assert set(declared_records()) <= set(stated)
+    assert {BindingMetadata, OccurrenceProvenance} <= set(stated)
+    assert len(stated[AdvisorySummary]) > 1
+    return stated
 
 
 def test_a_record_comment_states_only_what_it_declared() -> None:
@@ -643,15 +682,7 @@ def test_a_record_comment_states_only_what_it_declared() -> None:
     family name and stops. Metadata that is not a report states nothing at all,
     and a summary line is held to the same rules as an annotated equation.
     """
-    found, views = _analysed_mega()
-    stated: dict[type, list[object]] = {
-        record_type: [record for record, _ in records]
-        for record_type, records in found.items()
-    }
-    for view in views:
-        stated.setdefault(type(view), []).append(view)
-
-    for record_type, records in stated.items():
+    for record_type, records in _every_stated_record().items():
         declared = comment_of(record_type)
         if declared is None:
             assert all(render_comment(record) is None for record in records)
@@ -666,6 +697,8 @@ def test_a_record_comment_states_only_what_it_declared() -> None:
                 assert emission is not None, (key, declared)
                 assert not emission.opt_in, (key, "asked for nothing")
                 _assert_shape(value, emission.type)
+                if emission.type is Prose:
+                    assert json.loads(value) == str(emission.of(record))
 
     for record_type in declared_records():
         if any(field.default is MISSING for field in dataclass_fields(record_type)):

--- a/tests/analysis/test_analysis_invariants.py
+++ b/tests/analysis/test_analysis_invariants.py
@@ -45,7 +45,10 @@ from tilefoundry.inspection.values import (
     TRIPS,
     comment_of,
     declared_records,
+    expr_fields,
+    family_of,
     render_comment,
+    render_record,
 )
 from tilefoundry.ir.core import (
     BindingMetadata,
@@ -601,6 +604,23 @@ def _assert_shape(text: str, declared: object) -> None:
         raise AssertionError(f"{declared} has no rendering: {text}")
 
 
+def _every_record() -> dict[type, list[tuple[object, object]]]:
+    """Every record one real analysis leaves, each with the expression it is on."""
+    result = analyze(
+        MoEMegaKernel,
+        MoEMegaKernel.entry_function(),
+        analysis=("compute-cost", "memory", "roofline", "timeline"),
+    )
+    function = result.function
+    found: dict[type, list[tuple[object, object]]] = {}
+    for expr in (function, *postorder(function.body)):
+        for value in expr.metadata:
+            found.setdefault(type(value), []).append((value, expr))
+    assert set(declared_records()) <= set(found)
+    assert {BindingMetadata, OccurrenceProvenance} <= set(found)
+    return found
+
+
 def test_a_record_comment_states_only_what_it_declared() -> None:
     """Every key on a comment maps back to a field or a declared projection.
 
@@ -610,27 +630,13 @@ def test_a_record_comment_states_only_what_it_declared() -> None:
     declared type renders in, and a record that measured nothing states its
     family name and stops. Metadata that is not a report states nothing at all.
     """
-    result = analyze(
-        MoEMegaKernel,
-        MoEMegaKernel.entry_function(),
-        analysis=("compute-cost", "memory", "roofline", "timeline"),
-    )
-    function = result.function
-    found: dict[type, list[object]] = {}
-    for expr in (function, *postorder(function.body)):
-        for value in expr.metadata:
-            found.setdefault(type(value), []).append(value)
-
-    assert set(declared_records()) <= set(found)
-    assert {BindingMetadata, OccurrenceProvenance} <= set(found)
-
-    for record_type, records in found.items():
+    for record_type, records in _every_record().items():
         declared = comment_of(record_type)
         if declared is None:
-            assert all(render_comment(record) is None for record in records)
+            assert all(render_comment(record) is None for record, _ in records)
             continue
         keys = {emission.key.replace("_", "-"): emission for emission in declared.emissions}
-        for record in records:
+        for record, _ in records:
             emitted = _emitted(render_comment(record), declared.family)
             for key, value in emitted.items():
                 emission = keys.get(key) or (
@@ -646,3 +652,30 @@ def test_a_record_comment_states_only_what_it_declared() -> None:
         declared = comment_of(record_type)
         nothing = render_comment(record_type())
         assert nothing == declared.family or nothing.startswith(f"{declared.family}{FIELD}")
+
+
+def test_a_reported_record_keys_every_field_by_its_own_name() -> None:
+    """JSON is the record's own field names, and the comment cannot crop it.
+
+    A handwritten projection could rename a key and no output assertion would
+    notice, and a comment leaving a key out must not take it out of what programs
+    read: a default, a zero, and a null are facts a consumer branches on. So the
+    report states every field a record has, under the field's own name, and the
+    only key it may leave out is one read from the expression, which is where a
+    Function Call has no operand split to state.
+    """
+    for record_type, records in _every_record().items():
+        if comment_of(record_type) is None:
+            continue
+        names = {field.name for field in dataclass_fields(record_type)}
+        for record, expr in records:
+            reported = render_record(record, expr)
+
+            assert set(reported) <= names
+            assert names - set(reported) <= expr_fields(record_type)
+            for key, value in _emitted(
+                render_comment(record), family_of(record_type)
+            ).items():
+                stated = reported.get(key.replace("-", "_"))
+                if isinstance(stated, int | str):
+                    assert value == str(stated), (key, value, stated)

--- a/tests/analysis/test_analyze_at_a_size.py
+++ b/tests/analysis/test_analyze_at_a_size.py
@@ -412,9 +412,9 @@ def test_gqa_loop_occurrences_are_costed_once_and_parameterized_over_trips() -> 
     lines = rendered.annotated.splitlines()
     rows = [row for row in rendered.data["calls"] if "timeline" in row]
     comments = [
-        line.split("; timeline ", 1)[1]
+        line.split("; timeline=", 1)[1]
         for line in lines
-        if "; timeline " in line
+        if "; timeline=" in line
     ]
     expected_comments = []
     for row in rows:
@@ -423,26 +423,21 @@ def test_gqa_loop_occurrences_are_costed_once_and_parameterized_over_trips() -> 
         assert lines[line - 1].lstrip().startswith(f"{value} = ")
         timeline = row["timeline"]
         if timeline["trips"] > 1:
-            span_end = (
-                timeline["start_ns"]
-                + timeline["trips"] * timeline["stride_ns"]
-            )
+            offset = f"{timeline['stride_ns']}t+"
             expected_comments.append(
-                f"[{timeline['start_ns']}+{timeline['stride_ns']}t, "
-                f"{timeline['end_ns']}+{timeline['stride_ns']}t) "
-                f"trips={timeline['trips']} "
-                f"span=[{timeline['start_ns']},{span_end})"
+                f"[{offset}{timeline['start_ns']},{offset}{timeline['end_ns']})"
+                f"*{timeline['trips']}"
             )
         else:
             expected_comments.append(
-                f"start={timeline['start_ns']}ns end={timeline['end_ns']}ns"
+                f"[{timeline['start_ns']},{timeline['end_ns']})"
             )
 
     assert comments == expected_comments
     first = next(row for row in rows if row["value"].startswith("v0:"))
     assert first["value"] == "v0:44"
     assert lines[43].lstrip().startswith("v0 = reshard(")
-    assert "; timeline start=0ns end=0ns" in lines[47]
+    assert "; timeline=[0,0)" in lines[47]
     structural = next(row for row in rows if row["value"].startswith("v10:"))
     assert set(structural) == {"value", "compute-cost", "timeline"}
     assert structural["value"] == "v10:59"
@@ -452,7 +447,7 @@ def test_gqa_loop_occurrences_are_costed_once_and_parameterized_over_trips() -> 
         "stride_ns": 920,
         "trips": 8,
     }
-    assert "timeline [652+920t, 652+920t) trips=8 span=[652,8012)" in lines[58]
+    assert "timeline=[920t+652,920t+652)*8" in lines[58]
     assert lines[82].strip() == "m = v16"
     assert "timeline" not in lines[82]
 @pytest.mark.parametrize("ctx_len", (1, 1024))

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -669,12 +669,28 @@ def test_analyze_reports_the_inlined_mega_kernel_from_one_rendering(capsys) -> N
     assert "offset=120" in annotated
 
     summary = payload["function_records"]["timeline"]
-    assert (
+    cost = payload["function_records"]["compute-cost"]
+    whole, unit = cost["traffic"]["gmem"], cost["traffic_per_unit"]["gmem"]
+    peak = payload["function_records"]["memory"]["footprint"]
+    bound = payload["function_records"]["roofline"]
+    assert header.splitlines() == [
+        "# analysis target=nvidia.h200_sxm module=MoEMegaKernel function=experts "
+        f"topology={payload['topology']}",
+        f"# selection requested={','.join(payload['requested'])} "
+        f"executed={','.join(payload['executed'])}",
+        "# compute-cost "
+        f"flops=f32:{cost['flops']['f32']}@{cost['flops_per_unit']['f32']} "
+        f"traffic=gmem:r{whole['read']}/w{whole['write']}"
+        f"@r{unit['read']}/w{unit['write']}",
+        f"# peak-footprint=gmem:{peak[0]['peak_bytes']}",
+        f"# roofline ideal-ns={bound['ideal_ns']} bound-by={bound['bound_by']}",
         "# timeline root=MoEMegaKernel::experts "
-        f"local-makespan={summary['local_makespan_ns']}ns "
+        f"local-makespan-ns={summary['local_makespan_ns']} "
         f"waves={summary['waves']} "
-        f"estimated-kernel={summary['estimated_kernel_ns']}ns"
-    ) in header.splitlines()
+        f"estimated-kernel-ns={summary['estimated_kernel_ns']}",
+    ]
+    assert payload["totals"]["flops"] == cost["flops"]
+    assert payload["totals"]["traffic"] == cost["traffic"]
 
     hoisted = {
         line.split(" = ", 1)[0] for line in lines if " = Mesh((Topology(" in line

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 import sys
 import tomllib
@@ -668,6 +669,16 @@ def test_analyze_reports_the_inlined_mega_kernel_from_one_rendering(capsys) -> N
         f"estimated-kernel={summary['estimated_kernel_ns']}ns"
     ) in header.splitlines()
 
+    hoisted = {
+        line.split(" = ", 1)[0] for line in lines if " = Mesh((Topology(" in line
+    }
+    assert hoisted == {"cta", "cta_2", "cta_3", "cta_4"}
+    annotated_types = [
+        line.split("  # ", 1)[1].split("; ", 1)[0] for line in lines if "  # Tensor[" in line
+    ]
+    assert 'Tensor[(120, 64), "f32", (120 @ cta_2.tile, 64)]' in annotated_types
+    assert 'Tensor[(120, 64), "f32", (12 @ cta_3.tile, 10, 64)]' in annotated_types
+
     rows = payload["calls"]
     assert len(rows) == 7
     assert all(
@@ -689,6 +700,11 @@ def test_analyze_reports_the_inlined_mega_kernel_from_one_rendering(capsys) -> N
             f"timeline start={timeline['start_ns']}ns end={timeline['end_ns']}ns"
             in statement
         )
+        annotated_meshes = set(re.findall(r"@ (\w+)\.", statement.split("  # ", 1)[1]))
+        assert annotated_meshes <= hoisted
+        placed_meshes = set(re.findall(r"mesh=(\w+),", statement))
+        if annotated_meshes and placed_meshes:
+            assert annotated_meshes == placed_meshes
     assert len([line for line in lines if "; timeline " in line]) == len(rows)
     assert len({row["value"] for row in rows}) == len(rows)
     assert "units=" not in annotated

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -639,6 +639,13 @@ def test_analyze_reports_the_inlined_mega_kernel_from_one_rendering(capsys) -> N
     second = capsys.readouterr().out
     assert first == second
 
+    assert cli.main(["analyze", selector, *flags, "--operands"]) == 0
+    asked = capsys.readouterr().out
+    assert "operands=" not in first
+    assert "operands=0:r30720/w0,result:r0/w30720" in asked
+    assert cli.main(["analyze", selector, *flags, "--operands", "--json"]) == 0
+    assert json.loads(capsys.readouterr().out) == payload
+
     header, annotated = first.split("\n\n", 1)
     lines = annotated.splitlines()
     assert payload["requested"] == payload["executed"] == [
@@ -696,15 +703,12 @@ def test_analyze_reports_the_inlined_mega_kernel_from_one_rendering(capsys) -> N
         stop = starts[index + 1] - 1 if index + 1 < len(starts) else len(lines)
         statement = "\n".join(lines[start - 1 : stop])
         timeline = row["timeline"]
-        assert (
-            f"timeline start={timeline['start_ns']}ns end={timeline['end_ns']}ns"
-            in statement
-        )
+        assert f"timeline=[{timeline['start_ns']},{timeline['end_ns']})" in statement
         annotated_meshes = set(re.findall(r"@ (\w+)\.", statement.split("  # ", 1)[1]))
         assert annotated_meshes <= hoisted
         placed_meshes = set(re.findall(r"mesh=(\w+),", statement))
         if annotated_meshes and placed_meshes:
             assert annotated_meshes == placed_meshes
-    assert len([line for line in lines if "; timeline " in line]) == len(rows)
+    assert len([line for line in lines if "; timeline=" in line]) == len(rows)
     assert len({row["value"] for row in rows}) == len(rows)
     assert "units=" not in annotated

--- a/tests/inspection/test_python_printer.py
+++ b/tests/inspection/test_python_printer.py
@@ -6,9 +6,13 @@ left-hand side carries, and the target header, whose value must rebuild the
 *same* Target when the emitted source is executed.
 """
 
+import re
 from dataclasses import dataclass, fields, replace
 
 from tests._source import import_dsl
+from tests.fixtures.placed.gqa_decode import GqaOnline
+from tests.fixtures.placed.moe_mega_kernel import MoEMegaKernel
+from tests.fixtures.placed.prefill_decode_attention import PrefillDecodeAttention
 from tests.fixtures.placed.rmsnorm import RmsnormModule
 from tilefoundry.inspection import PythonPrintOptions, as_script
 from tilefoundry.inspection.analysis_report import _type_text
@@ -45,6 +49,70 @@ def test_inspection_types_are_opt_in_same_line_comments():
     assert all(
         line.split("# Tensor[")[0].strip() for line in annotated.splitlines() if "# Tensor[" in line
     )
+
+
+def _hoisted_meshes(source: str) -> set[str]:
+    return {
+        line.split(" = ", 1)[0] for line in source.splitlines() if " = Mesh((Topology(" in line
+    }
+
+
+def test_annotated_tuple_fields_each_name_the_hoisted_mesh():
+    """Every field of a tuple-typed annotation reaches the prelude's mesh name.
+
+    A loop carrying several tensors annotates a ``Tuple[...]``, so the field
+    walk has to carry the same mesh name map the signature is rendered from. A
+    field that lost it would restate the whole mesh as ``ShardLayout(...)``.
+    """
+    annotated = as_script(
+        PrefillDecodeAttention, options=PythonPrintOptions(show_types=True)
+    )
+    hoisted = _hoisted_meshes(annotated)
+    tuples = [
+        line.split("  # ", 1)[1] for line in annotated.splitlines() if "  # Tuple[" in line
+    ]
+
+    assert len(tuples) == 2
+    for annotation in tuples:
+        assert "ShardLayout(" not in annotation
+        named = set(re.findall(r"@ (\w+)\.", annotation))
+        assert named
+        assert named <= hoisted
+
+
+def test_an_annotated_layout_sugar_cannot_say_stays_verbose():
+    """Both fallbacks keep the whole layout, and they coexist with sugar.
+
+    Sugar names a mesh axis, so a mesh with no named axes has nothing to name;
+    and a layout it cannot express at all (here a broadcast over one of several
+    meshes) also stays verbose. Neither may drop what the verbose form carries.
+    """
+    unnamed_axes = as_script(GqaOnline, options=PythonPrintOptions(show_types=True))
+    verbose = [
+        line for line in unnamed_axes.splitlines() if "  # " in line and "ShardLayout(" in line
+    ]
+
+    assert verbose
+    for line in verbose:
+        assert 'mesh=Mesh((Topology("cta", ' in line
+        assert "names=" not in line
+        assert "@ " not in line.split("  # ", 1)[1]
+
+    several_meshes = as_script(
+        MoEMegaKernel, options=PythonPrintOptions(show_types=True)
+    )
+    annotations = [
+        line.split("  # ", 1)[1].split("; ", 1)[0]
+        for line in several_meshes.splitlines()
+        if "  # Tensor[" in line
+    ]
+
+    restated = "mesh=Mesh((Topology(\"cta\", 132),), Layout((132,), (1,)), names=('tile',))"
+    assert any("@ cta_2.tile" in annotation for annotation in annotations)
+    broadcast = [a for a in annotations if "attrs=(B(),)" in a]
+    assert broadcast
+    for annotation in broadcast:
+        assert restated in annotation
 
 
 def test_binding_metadata_names_the_emitted_binding():

--- a/tests/installed/smoke_analyze.py
+++ b/tests/installed/smoke_analyze.py
@@ -41,7 +41,7 @@ def test_logical_analyses_run_and_timeline_requires_result_placement(tf, cmine) 
         "--roofline",
     )
     assert done.returncode == 0, done.stderr
-    for conclusion in ("flops ", "traffic ", "peak-footprint ", "ideal-bound="):
+    for conclusion in ("# compute-cost flops=", "# peak-footprint=", "# roofline ideal-ns="):
         assert conclusion in done.stdout, conclusion
 
     rejected = tf("analyze", f"{cmine}:CMine.root", "--timeline")
@@ -88,10 +88,11 @@ def test_mega_kernel_reports_four_families_on_one_expanded_program(tf) -> None:
         "# analysis target=nvidia.h200_sxm module=MoEMegaKernel function=experts"
     )
     for conclusion in (
-        "# flops f32=",
-        "# peak-footprint ",
-        "# ideal-bound=",
-        "# timeline root=MoEMegaKernel::experts local-makespan=",
+        "# selection requested=compute-cost,memory,roofline,timeline",
+        "# compute-cost flops=f32:",
+        "# peak-footprint=",
+        "# roofline ideal-ns=",
+        "# timeline root=MoEMegaKernel::experts local-makespan-ns=",
     ):
         assert conclusion in text
 
@@ -177,12 +178,14 @@ def test_analyze_reports_only_the_analyses_that_were_requested(tf, cwide) -> Non
     done = tf("analyze", f"{cwide}:Model", "--roofline")
     assert done.returncode == 0, done.stderr
 
-    assert "# analyses=roofline executed=compute-cost,memory,roofline" in done.stdout
-    assert "# flops " in done.stdout
-    assert "# traffic " in done.stdout
-    assert "# ideal-bound=" in done.stdout
-    assert "# peak-footprint" in done.stdout
-    assert "# timeline local-makespan" not in done.stdout
+    assert (
+        "# selection requested=roofline executed=compute-cost,memory,roofline"
+        in done.stdout
+    )
+    assert "# compute-cost flops=" in done.stdout
+    assert "# roofline ideal-ns=" in done.stdout
+    assert "# peak-footprint=" in done.stdout
+    assert "# timeline " not in done.stdout
     assert "roofline ideal-ns=" in done.stdout
     assert "memory peak=" not in done.stdout
     assert "compute-cost flops=" not in done.stdout

--- a/tests/installed/smoke_analyze.py
+++ b/tests/installed/smoke_analyze.py
@@ -115,10 +115,10 @@ def test_a_bare_analyze_typechecks_and_prints_only_typed_hir(tf, cmine) -> None:
     assert done.stderr == ""
     assert "# Tensor[" in done.stdout
     assert "# analysis " not in done.stdout
-    assert "compute-cost " not in done.stdout
+    assert "compute-cost" not in done.stdout
     assert "memory peak=" not in done.stdout
-    assert "roofline bound=" not in done.stdout
-    assert "timeline start=" not in done.stdout
+    assert "roofline" not in done.stdout
+    assert "timeline=" not in done.stdout
 
 
 def test_analyze_json_needs_an_explicit_analysis(tf, cmine) -> None:
@@ -183,10 +183,10 @@ def test_analyze_reports_only_the_analyses_that_were_requested(tf, cwide) -> Non
     assert "# ideal-bound=" in done.stdout
     assert "# peak-footprint" in done.stdout
     assert "# timeline local-makespan" not in done.stdout
-    assert "roofline bound=" in done.stdout
+    assert "roofline ideal-ns=" in done.stdout
     assert "memory peak=" not in done.stdout
     assert "compute-cost flops=" not in done.stdout
-    assert "timeline start=" not in done.stdout
+    assert "timeline=" not in done.stdout
 
 
 def test_analyze_failure_reports_line_variable_and_reason(tf, tmp_path) -> None:

--- a/tests/installed/smoke_analyze.py
+++ b/tests/installed/smoke_analyze.py
@@ -186,10 +186,10 @@ def test_analyze_reports_only_the_analyses_that_were_requested(tf, cwide) -> Non
     assert "# roofline ideal-ns=" in done.stdout
     assert "# peak-footprint=" in done.stdout
     assert "# timeline " not in done.stdout
-    assert "roofline ideal-ns=" in done.stdout
-    assert "memory peak=" not in done.stdout
-    assert "compute-cost flops=" not in done.stdout
-    assert "timeline=" not in done.stdout
+    assert "; roofline ideal-ns=" in done.stdout
+    assert "; memory peak=" not in done.stdout
+    assert "; compute-cost" not in done.stdout
+    assert "; timeline=" not in done.stdout
 
 
 def test_analyze_failure_reports_line_variable_and_reason(tf, tmp_path) -> None:

--- a/tests/installed/smoke_models.py
+++ b/tests/installed/smoke_models.py
@@ -75,7 +75,8 @@ def test_models_source_names_the_shipped_directory_and_its_files(
     analysed = tf("analyze", static, "--compute-cost")
     assert analysed.returncode == 0, analysed.stderr
     assert "target=nvidia.h200_sxm" in analysed.stdout
-    assert "flops" in analysed.stdout and "traffic gmem=" in analysed.stdout
+    assert "# compute-cost flops=bf16:" in analysed.stdout
+    assert "traffic=gmem:r" in analysed.stdout
 
     targetless = f"{copied / 'model.py'}:Qwen3_1_7B_DecoderLayer"
     rejected = tf("analyze", targetless, "--compute-cost", "--dim", "ctx_len=128")


### PR DESCRIPTION
## Why
- One analysed line spent 455 characters saying `v1 = relu(v0)`: 212 of them a type
  the printer already knows how to sugar, and the rest five families each spelling
  one value their own way.
- `format_comment` lived on `IRMetadata`, so "renders itself as a comment" was part
  of being metadata. Six records carried a form string, and five printed keys that
  no longer matched the field they reported (`bytes=` for `traffic`, `bound=` for
  `ideal_ns`, and three more).
- JSON was five handwritten projections restating field names, so a key could drift
  from its field with no output assertion noticing.
- The summary was six handwritten prefixes with their own separators, one of them
  rebuilding three numbers a record already held.

## What
- Annotated types go through the same mesh-name map as the signature and the mesh
  prelude, in every field of a tuple type: 212 characters become 48.
- A record is typed fields and nothing else. Inspection declares what each one
  emits; one walk renders it, keys come from field names, a unit lives in the name,
  and a key that measured nothing is left out — a zero-cost reshard collapses to
  `compute-cost; roofline; timeline=[0,0)`. Two value types are added because
  Python cannot read a bare pair as whole-and-per-unit or two ints as a
  trip-parameterized interval; `int`, tokens and mappings get no type.
- JSON walks the same declarations: field names verbatim, nothing left out, one
  projection still reading the expression (`operands`).
- Every summary line is a record on that same walk, so a line and an equation
  cannot spell one value two ways.
- The operand split moves behind `analyze --operands`; JSON carries it either way.

## Contract
- Comment and summary text change shape. `docs/spec/inspection.md` gains §2.8 (the
  separator ladder, key derivation, suppression, the single-key rule, quoted prose);
  `analysis.md` restates every family's annotation and summary form and the
  report-projection rule; `core-ir.md` drops `format_comment` from `IRMetadata`;
  `cli.md` records `--operands`.
- `--json` is byte-identical: verified on the mega kernel, on `gqa_decode` at
  `ctx_len=8`, and on an advisory-bearing module.
- `render_text` now takes the `AnalysisRendering` rather than the report dict,
  because a summary line is read off records. `report()` and `render_json()` are
  unchanged.
- `PythonPrintOptions` gains `comment_opt_in`; `AnalysisRendering` gains `summary`.

## Risk
- `topology=none` no longer prints for an unplaced program: `"none"` is that
  field's declared default and the suppression rule leaves it out. Nothing asserted
  it before.
- A summary line that has to hold prose now quotes and escapes it
  (`advisory="…"`); a reader splitting a layer must split outside quotes.
- No numbers changed. Every figure is the same record read a different way, which
  the byte-identical JSON is the evidence for.
