### PR TITLE
feat(ci): measure coverage in both test modes and report it to Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,3 +145,18 @@ jobs:
           name: requirements
           path: requirements*.txt
           if-no-files-found: ignore
+      # Neither mode reaches what the other does -- the source run never enters the
+      # CLI commands only a shipped wheel exercises -- so each uploads under its own
+      # flag and Codecov unions them. The uploader runs from a throwaway
+      # environment: it pins `click<8.3`, which this project's `transformers` cannot
+      # live with.
+      - name: Upload coverage to Codecov
+        if: always()
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: |
+          for mode in source installed; do
+            [ -f "coverage-$mode.xml" ] || continue
+            uvx --from "codecov-cli==11.3.1" codecovcli upload-process \
+              --flag "$mode" --file "coverage-$mode.xml" --disable-search
+          done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,15 @@ jobs:
         run: |
           mkdir -p third_party/cutlass
           ln -sfnT /opt/cutlass/include third_party/cutlass/include
+      # `pytest-cov` owns the measurement because it owns the xdist half: plain
+      # `coverage run -m pytest -n 4` leaves the workers disagreeing about what
+      # they collected. `--cov-context=test` records which test reached each
+      # branch, which is what reading a report for redundancy needs.
       - name: Run tests
-        run: .venv/bin/python -m pytest tests/ -n 4
+        run: |
+          .venv/bin/python -m pytest tests/ -n 4 \
+            --cov=tilefoundry --cov-branch --cov-context=test \
+            --cov-report=xml:coverage-source.xml --cov-report=
       - name: Build the wheel
         run: |
           mkdir -p "$RUNNER_TEMP/wheel"
@@ -49,11 +56,57 @@ jobs:
             "$RUNNER_TEMP"/wheel/tilefoundry-*.whl
       - name: Verify the installed surface
         run: |
-          TF_SMOKE_VENV="$PWD/.wheel-venv" \
+          clean_site=$(.wheel-venv/bin/python -c \
+            'import sysconfig; print(sysconfig.get_path("purelib"))')
+          # What runs the wheel is a subprocess in the clean environment, not this
+          # pytest, so coverage starts inside that interpreter. The package is
+          # copied in beside the wheel rather than reached through the shared
+          # read-only environment: a `.pth` that cannot import writes a traceback
+          # to stderr, and these tests assert stderr is empty.
+          coverage_package=$(.venv/bin/python -c \
+            'import coverage, pathlib; print(pathlib.Path(coverage.__file__).parent)')
+          cp -r "$coverage_package" "$clean_site/coverage"
+          printf 'import coverage; coverage.process_startup()\n' \
+            > "$clean_site/zzz-coverage-subprocess.pth"
+          # `[paths]` folds the wheel's own location back onto the checkout, so
+          # both modes report the same files.
+          cat > coveragerc-installed <<EOF
+          [run]
+          branch = True
+          parallel = True
+          source = tilefoundry
+          data_file = $PWD/.coverage-installed
+
+          [paths]
+          package =
+              $PWD/src/tilefoundry
+              $clean_site/tilefoundry
+          EOF
+          COVERAGE_PROCESS_START="$PWD/coveragerc-installed" \
+            TF_SMOKE_VENV="$PWD/.wheel-venv" \
             .wheel-venv/bin/python -m pytest tests/installed \
             -o python_files='smoke_*.py' -q -n 8
+          .venv/bin/python -m coverage combine --rcfile=coveragerc-installed
+          .venv/bin/python -m coverage xml --rcfile=coveragerc-installed \
+            -o coverage-installed.xml
       - name: Decode the published checkpoint with the shipped source
         run: |
           .wheel-venv/bin/python tests/installed/qwen3_1_7b_l3.py \
             --venv "$PWD/.wheel-venv" \
             --work "$RUNNER_TEMP/l3"
+      # A readable report of the source run, whose `--show-contexts` names the
+      # tests that reached each line. Percentages alone cannot answer which test
+      # a line is covered by, which is the question consolidating the suite asks.
+      - name: Publish the coverage report
+        if: always()
+        run: |
+          if [ -f .coverage ]; then
+            .venv/bin/python -m coverage html --show-contexts -d htmlcov \
+              --data-file=.coverage
+          fi
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-html
+          path: htmlcov/
+          if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,36 +24,25 @@ jobs:
     container: tilefoundry-ci-runner:local
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      # The package cache lives in the runner's work directory, the same mount the
-      # checkout is on. Hardlinks cannot cross a mount point even within one
-      # filesystem, so a cache anywhere else would cost this job a full copy of
-      # every package -- 4.9 GB and nine seconds -- instead of links.
       UV_CACHE_DIR: /__w/uv-cache
       UV_NO_PROGRESS: "1"
     steps:
       - uses: actions/checkout@v4
-      # This job builds its whole environment from one pinned resolution of this
-      # checkout's pyproject.toml. Nothing is inherited from an environment on the
-      # host: venvs cannot nest, so sharing one needs a `.pth` bridge, and a branch
-      # that changes dependencies could not then test itself.
       - name: Prepare the project environment
         run: |
+          mkdir -p test_results
           uv venv --clear --no-project --python /usr/local/bin/python3.12 .venv
           uv pip compile --quiet --all-extras --generate-hashes \
-            --python .venv/bin/python pyproject.toml -o "$RUNNER_TEMP/requirements.txt"
+            --python .venv/bin/python pyproject.toml \
+            -o test_results/requirements.txt
           uv pip compile --quiet --generate-hashes \
             --python .venv/bin/python pyproject.toml \
-            -o "$RUNNER_TEMP/requirements-runtime.txt"
+            -o test_results/requirements-runtime.txt
           uv pip sync --python .venv/bin/python \
-            --require-hashes "$RUNNER_TEMP/requirements.txt"
+            --require-hashes test_results/requirements.txt
           uv pip install --python .venv/bin/python \
             --no-deps --no-build-isolation --editable .
-          # What activating would set, for every later step.
           echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
-          echo "VIRTUAL_ENV=$PWD/.venv" >> "$GITHUB_ENV"
-          # `isl-python` ships its own libisl under `<venv>/lib` but asks
-          # `ctypes.util.find_library` for it, which answers with the older system
-          # copy `libisl23` -- a package gcc depends on, so it cannot be removed.
           echo "LD_LIBRARY_PATH=$PWD/.venv/lib:${LD_LIBRARY_PATH:-}" >> "$GITHUB_ENV"
       - name: Run pre-commit
         run: pre-commit run --all-files
@@ -61,34 +50,22 @@ jobs:
         run: |
           mkdir -p third_party/cutlass
           ln -sfnT /opt/cutlass/include third_party/cutlass/include
-      # `pytest-cov` owns the measurement because it owns the xdist half: plain
-      # `coverage run -m pytest -n 4` leaves the workers disagreeing about what
-      # they collected. `--cov-context=test` records which test reached each
-      # branch, which is what reading a report for redundancy needs.
       - name: Run tests
+        env:
+          COVERAGE_FILE: test_results/.coverage
         run: |
           pytest tests/ -n 4 \
             --cov=tilefoundry --cov-branch --cov-context=test \
-            --cov-report=xml:coverage-source.xml --cov-report=
+            --cov-report=xml:test_results/coverage-source.xml --cov-report=
       - name: Build the wheel
         run: uv build --wheel --out-dir "$RUNNER_TEMP/wheel"
-      # Only what a user's `pip install tilefoundry` would bring, then the wheel
-      # itself with no dependency resolution of its own.
       - name: Install the wheel into a clean environment
         run: |
           uv venv --clear --no-project --python /usr/local/bin/python3.12 .wheel-venv
           uv pip sync --python .wheel-venv/bin/python \
-            --require-hashes "$RUNNER_TEMP/requirements-runtime.txt"
+            --require-hashes test_results/requirements-runtime.txt
           uv pip install --python .wheel-venv/bin/python \
             --no-deps "$RUNNER_TEMP"/wheel/tilefoundry-*.whl
-      # The tests run from this job's own environment and aim the installed one at
-      # the wheel: the clean environment holds no test tooling, which is the point
-      # of it. What runs the wheel is a subprocess there, not this pytest, so
-      # coverage starts inside that interpreter -- the package is copied in and
-      # hooked with a `.pth`, because a `.pth` that cannot import writes a
-      # traceback to stderr and these tests assert stderr is empty. `[paths]` folds
-      # the wheel's own location back onto the checkout, so both modes report the
-      # same files.
       - name: Verify the installed surface
         run: |
           export LD_LIBRARY_PATH="$PWD/.wheel-venv/lib:$LD_LIBRARY_PATH"
@@ -99,63 +76,48 @@ jobs:
           cp -r "$coverage_package" "$clean_site/coverage"
           printf 'import coverage; coverage.process_startup()\n' \
             > "$clean_site/zzz-coverage-subprocess.pth"
-          cat > coveragerc-installed <<EOF
+          cat > test_results/coveragerc-installed <<EOF
           [run]
           branch = True
           parallel = True
           source = tilefoundry
-          data_file = $PWD/.coverage-installed
+          data_file = $PWD/test_results/.coverage-installed
 
           [paths]
           package =
               $PWD/src/tilefoundry
               $clean_site/tilefoundry
           EOF
-          COVERAGE_PROCESS_START="$PWD/coveragerc-installed" \
+          COVERAGE_PROCESS_START="$PWD/test_results/coveragerc-installed" \
             TF_SMOKE_VENV="$PWD/.wheel-venv" \
             pytest tests/installed -o python_files='smoke_*.py' -q -n 8
-          coverage combine --rcfile=coveragerc-installed
-          coverage xml --rcfile=coveragerc-installed -o coverage-installed.xml
+          coverage combine --rcfile=test_results/coveragerc-installed
+          coverage xml --rcfile=test_results/coveragerc-installed \
+            -o test_results/coverage-installed.xml
       - name: Decode the published checkpoint with the shipped source
         run: |
           export LD_LIBRARY_PATH="$PWD/.wheel-venv/lib:$LD_LIBRARY_PATH"
           .wheel-venv/bin/python tests/installed/qwen3_1_7b_l3.py \
             --venv "$PWD/.wheel-venv" \
             --work "$RUNNER_TEMP/l3"
-      # A readable report of the source run, whose `--show-contexts` names the
-      # tests that reached each line. Percentages alone cannot answer which test a
-      # line is covered by, which is the question consolidating the suite asks.
       - name: Publish the coverage report
         if: always()
         run: |
-          if [ -f .coverage ]; then
-            coverage html --show-contexts -d htmlcov --data-file=.coverage
+          if [ -f test_results/.coverage ]; then
+            coverage html --show-contexts -d test_results/htmlcov \
+              --data-file=test_results/.coverage
           fi
-          cp "$RUNNER_TEMP"/requirements*.txt . 2>/dev/null || true
-      # One artifact, so one upload: this runner reset the connection on a second
-      # one right after the first succeeded. The resolution rides along because it
-      # is generated rather than tracked, and a report is worth little without
-      # knowing what was installed under it.
       - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: coverage-report
-          path: |
-            htmlcov/
-            requirements*.txt
+          path: test_results/
           if-no-files-found: ignore
-      # Neither mode reaches what the other does -- the source run never enters the
-      # CLI commands only a shipped wheel exercises -- so each uploads under its own
-      # flag and Codecov unions them. The uploader runs from a throwaway
-      # environment: it pins `click<8.3`, which this project's `transformers` cannot
-      # live with. Codecov answers a tokenless upload for this repository with
-      # `Token required because branch is protected`, so the step runs only where
-      # the secret is readable -- never on a fork's pull request.
       - name: Upload coverage to Codecov
         if: always() && env.CODECOV_TOKEN != ''
         run: |
           for mode in source installed; do
-            [ -f "coverage-$mode.xml" ] || continue
+            [ -f "test_results/coverage-$mode.xml" ] || continue
             uvx --from "codecov-cli==11.3.1" codecovcli upload-process \
-              --flag "$mode" --file "coverage-$mode.xml" --disable-search
+              --flag "$mode" --file "test_results/coverage-$mode.xml" --disable-search
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,13 +69,8 @@ jobs:
       - name: Verify the installed surface
         run: |
           export LD_LIBRARY_PATH="$PWD/.wheel-venv/lib:$LD_LIBRARY_PATH"
-          clean_site=$(.wheel-venv/bin/python -c \
-            'import sysconfig; print(sysconfig.get_path("purelib"))')
-          coverage_package=$(python -c \
-            'import coverage, pathlib; print(pathlib.Path(coverage.__file__).parent)')
-          cp -r "$coverage_package" "$clean_site/coverage"
-          printf 'import coverage; coverage.process_startup()\n' \
-            > "$clean_site/zzz-coverage-subprocess.pth"
+          uv pip install --python .wheel-venv/bin/python --no-deps \
+            --constraint test_results/requirements.txt coverage pytest-cov
           cat > test_results/coveragerc-installed <<EOF
           [run]
           branch = True
@@ -86,7 +81,7 @@ jobs:
           [paths]
           package =
               $PWD/src/tilefoundry
-              $clean_site/tilefoundry
+              $PWD/.wheel-venv/lib/*/site-packages/tilefoundry
           EOF
           COVERAGE_PROCESS_START="$PWD/test_results/coveragerc-installed" \
             TF_SMOKE_VENV="$PWD/.wheel-venv" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ concurrency:
 
 permissions:
   contents: read
+  id-token: write
 
 defaults:
   run:
@@ -23,7 +24,6 @@ jobs:
     runs-on: [self-hosted, tilefoundry]
     container: tilefoundry-ci-runner:local
     env:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       UV_CACHE_DIR: /__w/uv-cache
       UV_NO_PROGRESS: "1"
     steps:
@@ -113,11 +113,17 @@ jobs:
           name: coverage-report
           path: test_results/
           if-no-files-found: ignore
-      - name: Upload coverage to Codecov
-        if: always() && env.CODECOV_TOKEN != ''
-        run: |
-          for mode in source installed; do
-            [ -f "test_results/coverage-$mode.xml" ] || continue
-            uvx --from "codecov-cli==11.3.1" codecovcli upload-process \
-              --flag "$mode" --file "test_results/coverage-$mode.xml" --disable-search
-          done
+      - uses: codecov/codecov-action@v5
+        if: always() && !github.event.pull_request.head.repo.fork && hashFiles('test_results/coverage-source.xml') != ''
+        with:
+          use_oidc: true
+          files: test_results/coverage-source.xml
+          flags: source
+          disable_search: true
+      - uses: codecov/codecov-action@v5
+        if: always() && !github.event.pull_request.head.repo.fork && hashFiles('test_results/coverage-installed.xml') != ''
+        with:
+          use_oidc: true
+          files: test_results/coverage-installed.xml
+          flags: installed
+          disable_search: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,15 +22,40 @@ jobs:
   ci:
     runs-on: [self-hosted, tilefoundry]
     container: tilefoundry-ci-runner:local
+    env:
+      # The package cache lives in the runner's work directory, the same mount the
+      # checkout is on. Hardlinks cannot cross a mount point even within one
+      # filesystem, so a cache anywhere else would cost this job a full copy of
+      # every package -- 4.9 GB and nine seconds -- instead of links.
+      UV_CACHE_DIR: /__w/uv-cache
+      UV_NO_PROGRESS: "1"
     steps:
       - uses: actions/checkout@v4
+      # This job builds its whole environment from one pinned resolution of this
+      # checkout's pyproject.toml. Nothing is inherited from an environment on the
+      # host: venvs cannot nest, so sharing one needs a `.pth` bridge, and a branch
+      # that changes dependencies could not then test itself.
       - name: Prepare the project environment
         run: |
-          python -m venv --system-site-packages .venv
-          .venv/bin/python -m pip install \
+          uv venv --clear --no-project --python /usr/local/bin/python3.12 .venv
+          uv pip compile --quiet --all-extras --generate-hashes \
+            --python .venv/bin/python pyproject.toml -o "$RUNNER_TEMP/requirements.txt"
+          uv pip compile --quiet --generate-hashes \
+            --python .venv/bin/python pyproject.toml \
+            -o "$RUNNER_TEMP/requirements-runtime.txt"
+          uv pip sync --python .venv/bin/python \
+            --require-hashes "$RUNNER_TEMP/requirements.txt"
+          uv pip install --python .venv/bin/python \
             --no-deps --no-build-isolation --editable .
+          # What activating would set, for every later step.
+          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
+          echo "VIRTUAL_ENV=$PWD/.venv" >> "$GITHUB_ENV"
+          # `isl-python` ships its own libisl under `<venv>/lib` but asks
+          # `ctypes.util.find_library` for it, which answers with the older system
+          # copy `libisl23` -- a package gcc depends on, so it cannot be removed.
+          echo "LD_LIBRARY_PATH=$PWD/.venv/lib:${LD_LIBRARY_PATH:-}" >> "$GITHUB_ENV"
       - name: Run pre-commit
-        run: .venv/bin/python -m pre_commit run --all-files
+        run: pre-commit run --all-files
       - name: Link CUTLASS headers
         run: |
           mkdir -p third_party/cutlass
@@ -41,35 +66,38 @@ jobs:
       # branch, which is what reading a report for redundancy needs.
       - name: Run tests
         run: |
-          .venv/bin/python -m pytest tests/ -n 4 \
+          pytest tests/ -n 4 \
             --cov=tilefoundry --cov-branch --cov-context=test \
             --cov-report=xml:coverage-source.xml --cov-report=
       - name: Build the wheel
-        run: |
-          mkdir -p "$RUNNER_TEMP/wheel"
-          .venv/bin/python -m pip wheel . --no-deps --no-build-isolation \
-            --wheel-dir "$RUNNER_TEMP/wheel"
+        run: uv build --wheel --out-dir "$RUNNER_TEMP/wheel"
+      # Only what a user's `pip install tilefoundry` would bring, then the wheel
+      # itself with no dependency resolution of its own.
       - name: Install the wheel into a clean environment
         run: |
-          python -m venv --system-site-packages .wheel-venv
-          .wheel-venv/bin/python -m pip install --no-deps \
-            "$RUNNER_TEMP"/wheel/tilefoundry-*.whl
+          uv venv --clear --no-project --python /usr/local/bin/python3.12 .wheel-venv
+          uv pip sync --python .wheel-venv/bin/python \
+            --require-hashes "$RUNNER_TEMP/requirements-runtime.txt"
+          uv pip install --python .wheel-venv/bin/python \
+            --no-deps "$RUNNER_TEMP"/wheel/tilefoundry-*.whl
+      # The tests run from this job's own environment and aim the installed one at
+      # the wheel: the clean environment holds no test tooling, which is the point
+      # of it. What runs the wheel is a subprocess there, not this pytest, so
+      # coverage starts inside that interpreter -- the package is copied in and
+      # hooked with a `.pth`, because a `.pth` that cannot import writes a
+      # traceback to stderr and these tests assert stderr is empty. `[paths]` folds
+      # the wheel's own location back onto the checkout, so both modes report the
+      # same files.
       - name: Verify the installed surface
         run: |
+          export LD_LIBRARY_PATH="$PWD/.wheel-venv/lib:$LD_LIBRARY_PATH"
           clean_site=$(.wheel-venv/bin/python -c \
             'import sysconfig; print(sysconfig.get_path("purelib"))')
-          # What runs the wheel is a subprocess in the clean environment, not this
-          # pytest, so coverage starts inside that interpreter. The package is
-          # copied in beside the wheel rather than reached through the shared
-          # read-only environment: a `.pth` that cannot import writes a traceback
-          # to stderr, and these tests assert stderr is empty.
-          coverage_package=$(.venv/bin/python -c \
+          coverage_package=$(python -c \
             'import coverage, pathlib; print(pathlib.Path(coverage.__file__).parent)')
           cp -r "$coverage_package" "$clean_site/coverage"
           printf 'import coverage; coverage.process_startup()\n' \
             > "$clean_site/zzz-coverage-subprocess.pth"
-          # `[paths]` folds the wheel's own location back onto the checkout, so
-          # both modes report the same files.
           cat > coveragerc-installed <<EOF
           [run]
           branch = True
@@ -84,29 +112,36 @@ jobs:
           EOF
           COVERAGE_PROCESS_START="$PWD/coveragerc-installed" \
             TF_SMOKE_VENV="$PWD/.wheel-venv" \
-            .wheel-venv/bin/python -m pytest tests/installed \
-            -o python_files='smoke_*.py' -q -n 8
-          .venv/bin/python -m coverage combine --rcfile=coveragerc-installed
-          .venv/bin/python -m coverage xml --rcfile=coveragerc-installed \
-            -o coverage-installed.xml
+            pytest tests/installed -o python_files='smoke_*.py' -q -n 8
+          coverage combine --rcfile=coveragerc-installed
+          coverage xml --rcfile=coveragerc-installed -o coverage-installed.xml
       - name: Decode the published checkpoint with the shipped source
         run: |
+          export LD_LIBRARY_PATH="$PWD/.wheel-venv/lib:$LD_LIBRARY_PATH"
           .wheel-venv/bin/python tests/installed/qwen3_1_7b_l3.py \
             --venv "$PWD/.wheel-venv" \
             --work "$RUNNER_TEMP/l3"
       # A readable report of the source run, whose `--show-contexts` names the
-      # tests that reached each line. Percentages alone cannot answer which test
-      # a line is covered by, which is the question consolidating the suite asks.
+      # tests that reached each line. Percentages alone cannot answer which test a
+      # line is covered by, which is the question consolidating the suite asks.
       - name: Publish the coverage report
         if: always()
         run: |
           if [ -f .coverage ]; then
-            .venv/bin/python -m coverage html --show-contexts -d htmlcov \
-              --data-file=.coverage
+            coverage html --show-contexts -d htmlcov --data-file=.coverage
           fi
+          cp "$RUNNER_TEMP"/requirements*.txt . 2>/dev/null || true
       - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: coverage-html
           path: htmlcov/
+          if-no-files-found: ignore
+      # The resolution is generated, not tracked, so the run keeps a copy of the
+      # one it installed.
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: requirements
+          path: requirements*.txt
           if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
     runs-on: [self-hosted, tilefoundry]
     container: tilefoundry-ci-runner:local
     env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       # The package cache lives in the runner's work directory, the same mount the
       # checkout is on. Hardlinks cannot cross a mount point even within one
       # filesystem, so a cache anywhere else would cost this job a full copy of
@@ -131,29 +132,27 @@ jobs:
             coverage html --show-contexts -d htmlcov --data-file=.coverage
           fi
           cp "$RUNNER_TEMP"/requirements*.txt . 2>/dev/null || true
+      # One artifact, so one upload: this runner reset the connection on a second
+      # one right after the first succeeded. The resolution rides along because it
+      # is generated rather than tracked, and a report is worth little without
+      # knowing what was installed under it.
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: coverage-html
-          path: htmlcov/
-          if-no-files-found: ignore
-      # The resolution is generated, not tracked, so the run keeps a copy of the
-      # one it installed.
-      - uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: requirements
-          path: requirements*.txt
+          name: coverage-report
+          path: |
+            htmlcov/
+            requirements*.txt
           if-no-files-found: ignore
       # Neither mode reaches what the other does -- the source run never enters the
       # CLI commands only a shipped wheel exercises -- so each uploads under its own
       # flag and Codecov unions them. The uploader runs from a throwaway
       # environment: it pins `click<8.3`, which this project's `transformers` cannot
-      # live with.
+      # live with. Codecov answers a tokenless upload for this repository with
+      # `Token required because branch is protected`, so the step runs only where
+      # the secret is readable -- never on a fork's pull request.
       - name: Upload coverage to Codecov
-        if: always()
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        if: always() && env.CODECOV_TOKEN != ''
         run: |
           for mode in source installed; do
             [ -f "coverage-$mode.xml" ] || continue

--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,10 @@ coverage-source.xml
 coverage-installed.xml
 coveragerc-installed
 .coverage-installed*
+#   The resolution each run installs from. Generated, not tracked; a run keeps its
+#   own copy as an artifact.
+/requirements.txt
+/requirements-runtime.txt
 
 # Translations
 *.mo

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,12 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 cover/
+#   What a CI run leaves in the checkout: one report per measured mode, plus the
+#   config and the data file the installed run combines its subprocesses into.
+coverage-source.xml
+coverage-installed.xml
+coveragerc-installed
+.coverage-installed*
 
 # Translations
 *.mo

--- a/.gitignore
+++ b/.gitignore
@@ -58,16 +58,6 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 cover/
-#   What a CI run leaves in the checkout: one report per measured mode, plus the
-#   config and the data file the installed run combines its subprocesses into.
-coverage-source.xml
-coverage-installed.xml
-coveragerc-installed
-.coverage-installed*
-#   The resolution each run installs from. Generated, not tracked; a run keeps its
-#   own copy as an artifact.
-/requirements.txt
-/requirements-runtime.txt
 
 # Translations
 *.mo

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 <p align="center">
   <a href="https://pypi.org/project/tilefoundry/"><img src="https://img.shields.io/pypi/v/tilefoundry.svg" alt="PyPI"></a>
+  <a href="https://codecov.io/gh/tile-ai/TileFoundry"><img src="https://codecov.io/gh/tile-ai/TileFoundry/branch/main/graph/badge.svg" alt="Coverage"></a>
   <img src="https://img.shields.io/badge/status-early%20development-orange" alt="Status: early development">
   <a href="https://github.com/tile-ai/TileFoundry/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT"></a>
 </p>

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,27 @@
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  status:
+    # Consolidating the suite moves each file's percentage around, so the status
+    # reports the number and never blocks the merge.
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+# Two flags, one per mode, because neither mode reaches what the other does: the
+# source run misses the CLI commands only the installed wheel exercises. Codecov
+# unions them. Both name their files `src/tilefoundry/...` -- coverage.py writes
+# paths relative to the checkout, and the installed run folds the wheel's
+# site-packages location back onto the checkout before it reports -- so no path
+# fix is needed here.
+flags:
+  source:
+    paths:
+      - src/
+  installed:
+    paths:
+      - src/

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,8 +3,6 @@ codecov:
 
 coverage:
   status:
-    # Consolidating the suite moves each file's percentage around, so the status
-    # reports the number and never blocks the merge.
     project:
       default:
         informational: true
@@ -12,12 +10,6 @@ coverage:
       default:
         informational: true
 
-# Two flags, one per mode, because neither mode reaches what the other does: the
-# source run misses the CLI commands only the installed wheel exercises. Codecov
-# unions them. Both name their files `src/tilefoundry/...` -- coverage.py writes
-# paths relative to the checkout, and the installed run folds the wheel's
-# site-packages location back onto the checkout before it reports -- so no path
-# fix is needed here.
 flags:
   source:
     paths:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,11 +17,6 @@ dependencies = [
     "apache-tvm-ffi",
     "torch>=2.7",  # DType.f8e8m0 -> torch.float8_e8m0fnu, added in torch 2.7
     "graphviz>=0.20",
-    # 5.15.0 cannot instantiate MiniCPM3 at all: `yarn_apply_mscale` reads
-    # `rope_parameters["factor"]` for every non-default rope type, and the
-    # longrope parameters MiniCPM3-4B ships carry `long_factor` / `short_factor`
-    # instead -- and the value it reads is only used when `mscale_all_dim` is set.
-    # Held below it until that read moves inside the branch that uses it.
     "transformers>=5.13,<5.15",
     "ortools>=9.15",
 ]
@@ -45,13 +40,9 @@ dev = ["pre-commit>=3", "ruff>=0.14", "clang-format==18.1.8", "setuptools>=68", 
 
 [tool.coverage.run]
 branch = true
-# The importable package, not a directory: the source run measures the checkout
-# and the installed run measures the same package inside a wheel's site-packages.
 source = ["tilefoundry"]
 
 [tool.coverage.report]
-# Coverage here is an instrument for consolidating the suite, not a pass mark; a
-# threshold waits until that consolidation is done.
 skip_empty = true
 
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,19 @@ Repository = "https://github.com/tile-ai/TileFoundry"
 tilefoundry = "tilefoundry.cli:main"
 
 [project.optional-dependencies]
-test = ["pytest>=8", "pytest-xdist>=3"]
+test = ["pytest>=8", "pytest-xdist>=3", "pytest-cov>=7"]
 dev = ["pre-commit>=3", "ruff>=0.14", "setuptools>=68", "setuptools-scm>=8"]
+
+[tool.coverage.run]
+branch = true
+# The importable package, not a directory: the source run measures the checkout
+# and the installed run measures the same package inside a wheel's site-packages.
+source = ["tilefoundry"]
+
+[tool.coverage.report]
+# Coverage here is an instrument for consolidating the suite, not a pass mark; a
+# threshold waits until that consolidation is done.
+skip_empty = true
 
 [tool.setuptools_scm]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ tilefoundry = "tilefoundry.cli:main"
 
 [project.optional-dependencies]
 test = ["pytest>=8", "pytest-xdist>=3", "pytest-cov>=7"]
-dev = ["pre-commit>=3", "ruff>=0.14", "setuptools>=68", "setuptools-scm>=8"]
+dev = ["pre-commit>=3", "ruff>=0.14", "clang-format==18.1.8", "setuptools>=68", "setuptools-scm>=8"]
 
 [tool.coverage.run]
 branch = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,12 @@ dependencies = [
     "apache-tvm-ffi",
     "torch>=2.7",  # DType.f8e8m0 -> torch.float8_e8m0fnu, added in torch 2.7
     "graphviz>=0.20",
-    "transformers>=5.13",
+    # 5.15.0 cannot instantiate MiniCPM3 at all: `yarn_apply_mscale` reads
+    # `rope_parameters["factor"]` for every non-default rope type, and the
+    # longrope parameters MiniCPM3-4B ships carry `long_factor` / `short_factor`
+    # instead -- and the value it reads is only used when `mscale_all_dim` is set.
+    # Held below it until that read moves inside the branch that uses it.
+    "transformers>=5.13,<5.15",
     "ortools>=9.15",
 ]
 classifiers = [


### PR DESCRIPTION
## Why
- Nothing measures this suite. Consolidating it module by module needs an
  instrument that answers "did merging these two tests drop coverage", and a
  percentage per file cannot answer it -- which tests reached a line can.
- One mode is not enough: the installed run reaches 1073 arcs the source run
  never does, almost all in the CLI commands only a shipped wheel exercises.
  Reporting the source run alone would put a wrong number on the front page.
- Measuring it surfaced why adding one test dependency was hard. CI's packages
  came from a shared venv mounted read-only, and venvs cannot nest, so a `.pth`
  line had to inject it into the base interpreter -- with a shebang rewrite, a
  hash-named directory and a stale docker volume around it. A branch that
  changed dependencies could not test itself.

## What
- Both modes report. The source run measures through `pytest-cov`, which owns
  the xdist half, and records per-test contexts; the installed run starts
  coverage inside the subprocesses it tests through, with `[paths]` folding the
  wheel's location back onto the checkout.
- Every environment is built from one hash-pinned resolution of this checkout's
  `pyproject.toml`: `uv venv` plus `uv pip sync --require-hashes`, with packages
  hardlinked out of a cache in the runner's work directory. Measured in the job
  image: under a second and 12 MiB per job. The shared venv, the `.pth` bridge
  and the shebang rewrite are all unnecessary now.
- The clean environment holds only what `pip install tilefoundry` would bring,
  and the wheel is built with `uv build` -- uv's venvs carry no pip.
- `$GITHUB_PATH` does what activating a venv does, so no step needs a
  `.venv/bin/` prefix any more.
- Each report uploads under its own flag; Codecov unions them. GitHub's OIDC
  identity stands in for an upload token, so nothing has to be stored or
  provisioned. README carries the badge.

## Contract
- No coverage threshold. Percentages move while the suite is consolidated, so a
  gate now would trip itself; both Codecov statuses are `informational`.
- What CI collects is unchanged: the same `tests/` and `tests/installed` paths,
  the same `-n 4` / `-n 8`, the same `python_files='smoke_*.py'`.

## Risk
- The resolution is generated rather than tracked, so two runs can install
  different versions over time. Each keeps its copy as an artifact, which makes
  that visible after the fact but not before.
- Two follow-ups live outside this repository: deleting the shared-environment
  machinery now that nothing reads it, and an upstream issue for `isl-python`,
  whose bundled libisl loses to an older system copy gcc depends on -- one
  `LD_LIBRARY_PATH` line covers that meanwhile.
- The upload cannot be exercised from this pull request: a fork gets no identity
  token, so both upload steps skip themselves. The first report -- and the first
  number on the badge -- comes from the push to `main` that merges this.
