### PR TITLE
docs(readme): hand the compiler to the agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,49 +2,54 @@
   <img src="https://github.com/user-attachments/assets/3e29ee3e-2fae-4243-ba73-0efc04ac7645" alt="TileFoundry" width="100%">
 </p>
 
+<h3 align="center">Hand the compiler to the agent.</h3>
+
+<p align="center">
+  <i>Not an agent that becomes the compiler,<br>
+  and not an agent plugged in as one of its passes.<br>
+  The compiler stays a tool — the agent is simply the one holding it.</i>
+</p>
+
+<p align="center">
+  <b>One prompt in</b>&nbsp; · &nbsp;<b>612 tok/s out</b>&nbsp; · &nbsp;<b>nobody in the loop</b>
+</p>
+
 ---
 
 <p align="center">
   <a href="https://pypi.org/project/tilefoundry/"><img src="https://img.shields.io/pypi/v/tilefoundry.svg" alt="PyPI"></a>
   <a href="https://codecov.io/gh/tile-ai/TileFoundry"><img src="https://codecov.io/gh/tile-ai/TileFoundry/branch/main/graph/badge.svg" alt="Coverage"></a>
-  <img src="https://img.shields.io/badge/status-early%20development-orange" alt="Status: early development">
   <a href="https://github.com/tile-ai/TileFoundry/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT"></a>
 </p>
 
 <p align="center">
   <a href="https://tile-ai.github.io/TileFoundry.github.io/">Documentation</a> &middot;
-  <a href="https://github.com/tile-ai/TileFoundry#installation">Installation</a> &middot;
+  <a href="https://github.com/tile-ai/TileFoundry#quick-start">Quick Start</a> &middot;
   <a href="https://github.com/tile-ai/TileFoundry/tree/main/examples">Examples</a>
 </p>
-
-**TileFoundry** is a tile-based, agentic platform for automatic high-performance program generation across hardware.
 
 ## Latest News
 
 - 08/2026 🎉: **TileFoundry 0.0.1 is on PyPI** — the first public release.
 - 08/2026 📦: Four [worked examples](https://github.com/tile-ai/TileFoundry/tree/main/examples) added — Qwen3-1.7B (tilelang), Qwen3.5-35B-A3B (tilelang), MiniCPM3-4B (CuTeDSL) and granite-4.0-h-small (CUDA C) — each one a real agent run kept whole, with the decode throughput it measured.
 
-## Installation
-
-TileFoundry needs Python 3.12 or newer.
-
-```sh
-pip install tilefoundry
-```
-
-Check the install — it prints the commands an agent will ask:
-
-```sh
-tilefoundry
-```
-
-Running a model an agent generates additionally needs one NVIDIA GPU and the
-checkpoint already on disk.
-
 ## Quick Start
 
-There is **no API to learn** first. Give your coding agent this, with a checkpoint
-directory of your own:
+### 1 · Install
+
+```sh
+pip install tilefoundry    # needs Python 3.12 or newer
+tilefoundry                # check the install: the commands an agent will ask
+```
+
+This run also needs one NVIDIA GPU, `pip install tilelang`, the published
+`Qwen/Qwen3-1.7B` checkpoint on disk (3.8 GB), and a coding agent started in an
+empty directory.
+
+### 2 · Hand it the prompt
+
+There is **no API to learn** first. Give your coding agent this, with a
+checkpoint directory of your own:
 
 ```text
 Get real tokens out of Qwen3-1.7B on TileFoundry, and make it fast.
@@ -57,7 +62,9 @@ ask a person, do not go looking elsewhere. The model itself is yours to research
 Done when this runs from outside, prints the continuation, and reports a
 tokens-per-second number measured over the whole generation:
 
-    python run.py --prompt "Write a detailed explanation of how a GPU executes a matrix multiplication." --max-new-tokens 2048
+    python run.py \
+        --prompt "Write a detailed explanation of how a GPU executes a matrix multiplication." \
+        --max-new-tokens 2048
 
 Measure over a long generation -- 2048 new tokens, more than 2000 characters of
 text. A 32-token sample is too short for the number to mean anything.
@@ -65,9 +72,27 @@ text. A 32-token sample is too short for the number to mean anything.
 
 That is the whole input — nothing under it is written by hand.
 
-Claude Opus 5 at xhigh reasoning effort ran this prompt for 2.1 hours with **no
-interaction**, and reached **612 tok/s** on one H200. What it wrote is
-[`examples/qwen3_1_7b-tilelang/`](https://github.com/tile-ai/TileFoundry/tree/main/examples/qwen3_1_7b-tilelang).
+### 3 · Come back in two hours
+
+Claude Opus 5 at xhigh reasoning effort worked 2.1 hours and 177 tool calls
+without a single interaction, and left a `run.py` behind — it prints the
+continuation, and the number it measured: **612 tok/s** on one H200.
+
+```sh
+python run.py --ckpt <checkpoint directory> \
+    --prompt "Write a detailed explanation of how a GPU executes a matrix multiplication." \
+    --max-new-tokens 2048
+```
+
+The first run compiles the kernels — once, a few minutes.
+
+## Where to go next
+
+That run is kept whole in
+[`examples/qwen3_1_7b-tilelang/`](https://github.com/tile-ai/TileFoundry/tree/main/examples/qwen3_1_7b-tilelang),
+with three more beside it. The specifications are meant to be argued with:
+[open an issue](https://github.com/tile-ai/TileFoundry/issues/new), or start from
+[`docs/develop.md`](https://github.com/tile-ai/TileFoundry/blob/main/docs/develop.md).
 
 ## License
 


### PR DESCRIPTION
Special thanks to @lcy-seso (Cao Ying) for the thoughtful rewrite and for sharpening how TileFoundry presents the relationship between the agent and the compiler.

## Why
- The front page says what TileFoundry is, but the agent/compiler boundary and the demonstrated unattended workflow are not the first things a reader sees.
- Installation, the prompt, and the generated result read as separate pieces rather than one path a reader can follow.
- The README is both the GitHub front page and the PyPI landing page, so that path has to stand on its own.

## What
- Lead with the distinction that the compiler stays a tool held by the agent, followed by the demonstrated 612 tok/s outcome.
- Replace the separate Installation and Quick Start sections with a three-step install / prompt / result sequence. The final command includes the required --ckpt argument and the first-run compilation cost.
- Remove the early-development badge and generic one-line description from the header, and point its middle navigation item at Quick Start.
- Add a next-step path to the preserved run, the issue tracker, and docs/develop.md.

## Contract
- Documentation only. No public API, CLI, specification, packaging, or runtime behavior changes.
- README.md remains self-contained for GitHub and PyPI: all repository links are absolute and no local asset is added.

## Verification
- The committed file is byte-for-byte the supplied README.
- git diff --check passes.
- pre-commit run --files README.md passes: no-machine-paths and english-only; all unrelated hooks skip.
- All eight linked destinations return HTTP 200.

## Risk
- The 2.1 hours, 177 tool calls, and 612 tok/s are preserved measurements from the existing Qwen3-1.7B example; CI does not re-run that GPU workload.
- The visible early-development badge is removed while the package metadata still classifies the project as Alpha. This is a presentation change, not a maturity change.
- The Quick Start is demonstrated on one H200 and still requires the reader to provide a compatible NVIDIA environment and checkpoint.