### PR TITLE
perf(expr): memoize expression DAG traversals

### DIFF
--- a/docs/spec/hir.md
+++ b/docs/spec/hir.md
@@ -267,12 +267,21 @@ freeze** below).
 
 - `variants` is a canonical IR field — it participates in structural
   equality, hashing, and canonical printing.
-- A variant MAY carry a **display label**, taken from the identifier its author
-  decorated ([parser §1.1](./parser.md#11-decorators)). The label is
-  non-canonical metadata: it MUST NOT participate in structural equality,
-  hashing, or the canonical signature, and nothing MAY select an implementation
-  by it. Printing a variant back to source MUST preserve it, since it is the only
-  thing distinguishing two implementations that share a name.
+- Parser-time Function roles use the following naming and handle contract:
+
+  | role | purpose | lookup handle | `_` allowed | binding uniqueness | parser ledger classification |
+  |---|---|---|---|---|---|
+  | **kernel / prototype** | Module execution unit | `fn.name` | no | unique within the Module class body | `_Entry.bound[binding] = KERNEL`; `id(fn)` is not in `_Entry.owned` |
+  | **variant** | Implementation for a dim range | `f"{base}${dim}${lo}_{hi}"` | no | unique within the base | `_Entry.bound[binding] = VARIANT`; `id(fn)` is in `_Entry.owned` |
+  | **converter** | Offline weight conversion | `f"{base}.converter[{weight}]"` | yes | reusable | `_Entry.bound[binding] = CONVERTER`; `id(fn)` is in `_Entry.owned` |
+
+  The parser enforces this table during decoration. A parser-authored variant
+  MUST carry a non-underscore display label, while a `Function` built directly
+  in IR MAY omit the non-canonical label. The label MUST NOT participate in
+  structural equality, hashing, or the canonical signature, and nothing MAY
+  select an implementation by it. A printer emitting an unlabeled IR variant
+  MUST choose a valid source binding so the emitted definition remains
+  importable.
 - Every variant of a base MUST share the base's `name`, `params`, and
   `return_type`: a variant specializes the body, not the signature. A variant
   runs in the same execution domain as its base because both are owned by the

--- a/docs/spec/inspection.md
+++ b/docs/spec/inspection.md
@@ -239,14 +239,15 @@ def f(x: Tensor[(S,), "f32"]) -> Tensor[(S,), "f32"]:
     pass
 
 @f.specialize(DimVarRangePat("S", 1, 4))
-def _(x: Tensor[(S,), "f32"]) -> Tensor[(S,), "f32"]:
+def small_sequence(x: Tensor[(S,), "f32"]) -> Tensor[(S,), "f32"]:
     ...
 ```
 
 The pattern prints in its constructor form (`DimVarRangePat("S", 1, 4)`;
-other `Pattern` subclasses fall back to `repr(pattern)`). The emitted form
-mirrors the authoring surface
-([parser.md §1.1](./parser.md#11-decorators)). Because a
+other `Pattern` subclasses fall back to `repr(pattern)`). The emitted binding
+mirrors the authoring surface ([parser.md §1.1](./parser.md#11-decorators));
+when an IR variant has no display label, the printer synthesizes a valid binding
+from its canonical specialization signature. Because a
 dispatch prototype has a `DimVar` parameter, its rendering is a
 **display-only** surface ([§2.7](#27-round-trip-contract)): human-readable, not a round-trip
 validation artifact.

--- a/docs/spec/parser.md
+++ b/docs/spec/parser.md
@@ -104,14 +104,11 @@ def _(x: Tensor[(S,), "f32"]) -> Tensor[(S,), "f32"]:
   `specializations=(pattern,)`), registers it on `base.variants`, and
   returns the variant.
 - The decorated identifier is the variant's **display label** and nothing more.
-  It MUST NOT become the variant's `name`, and MUST NOT take part in equality,
-  hashing, dispatch or TIR identity ([hir.md §1.1](./hir.md#11-function)): the
-  variants of one base share that base's name, and which one runs is decided by
-  the pattern alone. `def _` states no label and remains legal — `_` is reusable
-  across variants because the base is the persistent handle — and anything
-  reporting an unlabelled variant names it by its canonical specialization
-  signature instead. A label is for a reader who has to be told which of two
-  implementations ran.
+  Variant naming, binding uniqueness, and lookup handles follow the contract in
+  [hir §1.1](./hir.md#11-function). The label MUST NOT become the variant's
+  `name`, and MUST NOT take part in equality, hashing, dispatch, or TIR
+  identity: the variants of one base share that base's name, and which one runs
+  is decided by the pattern alone.
 - `pattern` MUST be a single `DimVarRangePat` (see
   [core-ir §3](./core-ir.md#3-pattern)); other `Pattern` subclasses are rejected for
   v0. The referenced `DimVar` and its `(lo, hi)` envelope live on the base

--- a/docs/spec/visitor-mutator.md
+++ b/docs/spec/visitor-mutator.md
@@ -1,18 +1,24 @@
 # TileFoundry Spec — IR Visitor / Mutator
 
-The IR traversal / rewrite framework: `ExprVisitor[T]` /
-`ExprMutator` / `StmtVisitor[T]` / `StmtMutator` / `StmtExprMutator`.
+The IR traversal / rewrite framework: `ExprFunctor[T]` /
+`ExprVisitor[T]` / `ExprWalker[T]` / `ExprMutator` / `StmtVisitor[T]` /
+`StmtMutator` / `StmtExprMutator`.
 A shared compiler facility, owned by neither analysis nor any
 specific pass.
 
 ```mermaid
 flowchart TB
+    ExprFunctor["<b>ExprFunctor[T]</b><br/>dispatch only"]
     ExprVisitor["<b>ExprVisitor[T]</b><br/>read-only"]
+    ExprWalker["<b>ExprWalker[T]</b><br/>common side-effect walk"]
     ExprMutator["<b>ExprMutator</b><br/>identity-preserving rewrite"]
     StmtVisitor["<b>StmtVisitor[T]</b>"]
     StmtMutator["<b>StmtMutator</b>"]
     StmtExprMutator["<b>StmtExprMutator</b><br/>Stmt + embedded Expr rewrite"]
 
+    ExprVisitor --> ExprFunctor
+    ExprWalker --> ExprVisitor
+    ExprMutator --> ExprFunctor
     StmtExprMutator --> StmtMutator
 ```
 
@@ -43,13 +49,14 @@ is injected by overriding `visit_<ClassName>` in subclasses.
 - and so on.
 
 `visit(node)` looks up `visit_<type(node).__name__>` on the subclass and calls
-it, falling back to `generic_visit(node)` when no such override exists.
+it, falling back to `default_visit(node)` when no such override exists.
 
 - **Most-specific wins.** `Call` is a subclass of `Expr`, but with
   both `visit_Call` and `visit_Expr` defined, `visit_Call` wins —
   dispatch keys on the runtime class name.
-- **Fallback to `generic_visit(node)`.** Default behaviour is
-  recursive traversal of all child nodes.
+- **Fallback to `default_visit(node)`.** `ExprFunctor.default_visit` raises
+  `NotImplementedError`; a visitor or mutator must explicitly implement a
+  node's behavior or call its child traversal/rebuild helper.
 - **No Op-level dispatch lives here.** A `Call(target=Add)` is
   caught by `visit_Call`; per-Op dispatch is the analysis registry's
   responsibility ([visitor-registry](./visitor-registry.md)).
@@ -60,14 +67,33 @@ Read-only Expr-tree traversal. `T` is user-chosen (`None` for
 side-effect collection, `set[Var]` for free-var analysis, etc.).
 
 ```python
-class ExprVisitor(Generic[T]):                     # read-only Expr traversal; T is the user-chosen visit result type
-    def visit(self, expr: Expr) -> T: ...          # dispatch to visit_<Type> else generic_visit
-    def generic_visit(self, expr: Expr) -> T: ...  # recurse child Exprs; returns None by default
+class ExprFunctor(Generic[T]):                     # dispatch only; no memo
+    def visit(self, expr: Expr) -> T: ...          # dispatch to visit_<Type> else default_visit
+    def default_visit(self, expr: Expr) -> T: ... # raises NotImplementedError
+
+class ExprVisitor(ExprFunctor[T]):                 # read-only Expr traversal; T is user-chosen
+    def dispatch_visit(self, expr: Expr) -> T: ...  # memoized single dispatch point
+    def visit_operands(self, expr: Expr) -> None: ... # visits _expr_children(expr)
+    def clear(self) -> None: ...                   # clears memo and root
 ```
 
 - constraints:
-  - `generic_visit` recurses into all child Exprs and returns `None` by default;
-    subclasses MAY override to aggregate.
+  - `ExprVisitor` memoizes by `id(expr)` at `dispatch_visit`; each value keeps
+    the original `Expr` alive together with the result to prevent id reuse.
+  - `visit_operands` uses the fixed class-match table `_expr_children` in
+    `ir/visitor.py`, not the dataclass-field walker `child_exprs` in
+    `ir/core/expr.py`. It visits value children only and excludes binding-site
+    Vars, including `GridRegionExpr.carried_args` and Function parameters.
+  - `_expr_children` raises `AssertionError` for an unknown `Expr` subclass;
+    it does not silently return an empty tuple.
+  - The explicit `visit_function_body` entry supplies the root Function
+    (`root_function` or the first Function passed to that helper) before
+    applying `can_visit_function_body`. `visit_other_functions=True` allows
+    that explicit entry to visit other Function bodies. This gate does not
+    apply to `visit_operands`: when its `_expr_children` result is a
+    `hir.Function`, it visits that Function's body unconditionally, preserving
+    the existing recursive traversal behavior. The specialization walk is a
+    future caller for the explicit gate.
 
 `_expr_children(expr)` enumerates child Exprs of any Expr node by
 fixed field order. The mapping is module-local and is the single
@@ -83,6 +109,11 @@ table that grows whenever a new Expr subclass appears:
 | `GridRegionExpr` | `init_args`, `body`, `yield_values` (binding-site Vars are excluded) |
 | `hir.Function` | `body` (parameter binding-site Vars are excluded) |
 
+The `GridRegionExpr` row intentionally excludes `carried_args`; passes that
+collect dimension variables from carried bindings must enumerate that field
+explicitly. `child_exprs` remains the broader dataclass-field helper for
+module ownership and is not the visitor traversal contract.
+
 Example — collect every `Var`:
 
 ```python
@@ -94,6 +125,13 @@ class VarCollector(ExprVisitor[None]):
         self.vars.add(var)
 ```
 
+`ExprWalker[T]` is the shared side-effect traversal layer for the standard
+Expr shapes. It supplies no-op leaves for `Var`, `Constant`, `SymbolRef`, and
+`ShapeOf`, and operand traversal for `Tuple`, `GridRegionExpr`, and
+`hir.Function`. A side-effect pass inherits it and overrides only the node
+types where it collects or derives state; all of those defaults use the same
+memo and `_expr_children` contract.
+
 ## 4. `ExprMutator`
 
 Recursive Expr rewrite returning the same node kind. Core invariant:
@@ -101,13 +139,13 @@ Recursive Expr rewrite returning the same node kind. Core invariant:
 preservation).
 
 ```python
-class ExprMutator:                                    # identity-preserving Expr rewrite
-    def visit(self, expr: Expr) -> Expr: ...          # dispatch to visit_<Type> else generic_visit
-    def generic_visit(self, expr: Expr) -> Expr: ...  # recurse children; return original node when no child changed (identity preservation)
+class ExprMutator(ExprFunctor[Expr]):                  # identity-preserving Expr rewrite
+    def visit(self, expr: Expr) -> Expr: ...          # dispatch to visit_<Type> else default_visit
+    def default_visit(self, expr: Expr) -> Expr: ...  # recurse/rebuild children; preserve identity
 ```
 
 - constraints:
-  - When no child changed, `generic_visit` returns the original node (identity
+  - When no child changed, `default_visit` returns the original node (identity
     preservation).
 
 `_rebuild_expr(expr, new_children)` constructs a new Expr of the
@@ -122,9 +160,10 @@ Identity preservation matters for three reasons:
 3. **Cache validity.** `typeinfer` / cost caches keyed on Expr
    identity remain valid for unchanged nodes.
 
-A `visit_Call` override MUST itself respect identity preservation:
-the unchanged branch routes through `generic_visit(call)` rather
-than `return call`, so child Exprs are still recursed.
+An Expr visitor `visit_Call` override that needs recursive children MUST call
+`visit_operands(call)`. An Expr mutator override that needs the generic
+identity-preserving rebuild MUST call `default_visit(call)`; it may return the
+original node directly only after it has explicitly handled the children.
 
 ## 5. `StmtVisitor[T]` / `StmtMutator`
 
@@ -221,7 +260,7 @@ position, instead of `Evaluate(op, args)`, is malformed IR
 
 ## 8. Implementation location
 
-- Public exports: `ExprVisitor`, `ExprMutator`, `StmtVisitor`,
+- Public exports: `ExprFunctor`, `ExprVisitor`, `ExprWalker`, `ExprMutator`, `StmtVisitor`,
   `StmtMutator`, `StmtExprMutator`, `walk_prim_function`,
   `rewrite_prim_function`.
 - The four child-enumeration / rebuild tables

--- a/src/tilefoundry/analysis/check.py
+++ b/src/tilefoundry/analysis/check.py
@@ -37,6 +37,7 @@ from tilefoundry.ir.types.substitute import (
     substitute_shape_dim,
     substitute_topology_dims,
 )
+from tilefoundry.ir.visitor import ExprMutator
 from tilefoundry.visitor_registry.contexts import CostContext, FunctionScope, TypeInferContext
 from tilefoundry.visitor_registry.visitors import CostEvaluator
 
@@ -515,6 +516,127 @@ def _view_metadata(expr: Expr) -> tuple:
     )
 
 
+class _InlineMutator(ExprMutator):
+    def __init__(self, owner, env, memo, function, path, active) -> None:
+        super().__init__()
+        self.owner = owner
+        self.env = env
+        self.memo = memo
+        self.function = function
+        self.path = path
+        self.active = active
+
+    def _cached(self, expr):
+        bound = self.env.get(id(expr))
+        if bound is not None:
+            return bound
+        return self.memo.get(id(expr))
+
+    def _finish(self, expr, rebuilt):
+        self.memo[id(expr)] = rebuilt
+        return rebuilt
+
+    def visit_Var(self, expr: Var) -> Expr:
+        cached = self._cached(expr)
+        if cached is not None:
+            return cached
+        return self._finish(expr, replace(expr, metadata=_view_metadata(expr)))
+
+    def visit_Constant(self, expr: Constant) -> Expr:
+        cached = self._cached(expr)
+        if cached is not None:
+            return cached
+        return self._finish(expr, replace(expr, metadata=_view_metadata(expr)))
+
+    def visit_Tuple(self, expr: Tuple) -> Expr:
+        cached = self._cached(expr)
+        if cached is not None:
+            return cached
+        rebuilt = replace(
+            expr,
+            elements=tuple(self.visit(item) for item in expr.elements),
+            metadata=_view_metadata(expr),
+        )
+        return self._finish(expr, rebuilt)
+
+    def visit_GridRegionExpr(self, grid: GridRegionExpr) -> GridRegionExpr:
+        cached = self._cached(grid)
+        if cached is not None:
+            return cached
+        init_args = tuple(self.visit(item) for item in grid.init_args)
+        induction_var = replace(
+            grid.induction_var, metadata=_view_metadata(grid.induction_var)
+        )
+        carried_args = tuple(
+            replace(item, metadata=_view_metadata(item)) for item in grid.carried_args
+        )
+        inner_env = dict(self.env)
+        inner_env[id(grid.induction_var)] = induction_var
+        inner_env.update(
+            (id(old), new) for old, new in zip(grid.carried_args, carried_args)
+        )
+        inner = _InlineMutator(
+            self.owner,
+            inner_env,
+            self.memo,
+            self.function,
+            self.path,
+            self.active,
+        )
+        body = inner.visit(grid.body)
+        yield_values = tuple(inner.visit(item) for item in grid.yield_values)
+        rebuilt = replace(
+            grid,
+            induction_var=induction_var,
+            carried_args=carried_args,
+            init_args=init_args,
+            body=body,
+            yield_values=yield_values,
+            metadata=_view_metadata(grid),
+        )
+        return self._finish(grid, rebuilt)
+
+    def visit_Call(self, expr: Call) -> Expr:
+        cached = self._cached(expr)
+        if cached is not None:
+            return cached
+        target = expr.target
+        call_index = None
+        if isinstance(target, Function):
+            call_index = self.owner.function_call_counters[-1]
+            self.owner.function_call_counters[-1] += 1
+        new_args = tuple(self.visit(arg) for arg in expr.args)
+        if isinstance(target, Function):
+            reading = _call_reading(self.owner.module, self.function, expr)
+            supplied = iter(new_args)
+            callee_env: dict[int, Expr] = {}
+            for param in target.params:
+                if reading is not None and param.is_const:
+                    callee_env[id(param)] = self.owner.resources[
+                        (self.owner.module_paths[id(reading)], param.name)
+                    ]
+                else:
+                    callee_env[id(param)] = next(supplied)
+            rebuilt = self.owner.function_body(
+                target,
+                callee_env,
+                (*self.path, target.name, str(call_index)),
+                self.active,
+            )
+            return self._finish(expr, rebuilt)
+        metadata = (
+            *_view_metadata(expr),
+            BindingMetadata(self.owner._binding()),
+            OccurrenceProvenance(
+                source_call=id(_authored_call(self.function, expr)), call_path=self.path
+            ),
+        )
+        return self._finish(expr, replace(expr, args=new_args, metadata=metadata))
+
+    def default_visit(self, expr: Expr) -> Expr:
+        raise AnalysisError(f"cannot inline unsupported HIR node {type(expr).__name__}")
+
+
 class _Inliner:
     def __init__(
         self,
@@ -574,108 +696,7 @@ class _Inliner:
         path: tuple[str, ...],
         active: frozenset[int],
     ) -> Expr:
-        bound = env.get(id(expr))
-        if bound is not None:
-            return bound
-        cached = memo.get(id(expr))
-        if cached is not None:
-            return cached
-
-        match expr:
-            case Var():
-                rebuilt = replace(expr, metadata=_view_metadata(expr))
-            case Constant():
-                rebuilt = replace(expr, metadata=_view_metadata(expr))
-            case Tuple(elements=elements):
-                rebuilt = replace(
-                    expr,
-                    elements=tuple(
-                        self.expr(item, env, memo, function, path, active)
-                        for item in elements
-                    ),
-                    metadata=_view_metadata(expr),
-                )
-            case GridRegionExpr():
-                rebuilt = self._grid(expr, env, memo, function, path, active)
-            case Call(target=target, args=args) if isinstance(target, Function):
-                call_index = self.function_call_counters[-1]
-                self.function_call_counters[-1] += 1
-                new_args = tuple(
-                    self.expr(arg, env, memo, function, path, active) for arg in args
-                )
-                reading = _call_reading(self.module, function, expr)
-                supplied = iter(new_args)
-                callee_env: dict[int, Expr] = {}
-                for param in target.params:
-                    if reading is not None and param.is_const:
-                        callee_env[id(param)] = self.resources[
-                            (self.module_paths[id(reading)], param.name)
-                        ]
-                    else:
-                        callee_env[id(param)] = next(supplied)
-                rebuilt = self.function_body(
-                    target,
-                    callee_env,
-                    (*path, target.name, str(call_index)),
-                    active,
-                )
-            case Call(args=args):
-                new_args = tuple(
-                    self.expr(arg, env, memo, function, path, active) for arg in args
-                )
-                metadata = (
-                    *_view_metadata(expr),
-                    BindingMetadata(self._binding()),
-                    OccurrenceProvenance(
-                        source_call=id(_authored_call(function, expr)), call_path=path
-                    ),
-                )
-                rebuilt = replace(expr, args=new_args, metadata=metadata)
-            case _:
-                raise AnalysisError(
-                    f"cannot inline unsupported HIR node {type(expr).__name__}"
-                )
-        memo[id(expr)] = rebuilt
-        return rebuilt
-
-    def _grid(
-        self,
-        grid: GridRegionExpr,
-        env: Mapping[int, Expr],
-        memo: dict[int, Expr],
-        function: Function,
-        path: tuple[str, ...],
-        active: frozenset[int],
-    ) -> GridRegionExpr:
-        init_args = tuple(
-            self.expr(item, env, memo, function, path, active)
-            for item in grid.init_args
-        )
-        induction_var = replace(
-            grid.induction_var, metadata=_view_metadata(grid.induction_var)
-        )
-        carried_args = tuple(
-            replace(item, metadata=_view_metadata(item)) for item in grid.carried_args
-        )
-        inner_env = dict(env)
-        inner_env[id(grid.induction_var)] = induction_var
-        inner_env.update(
-            (id(old), new) for old, new in zip(grid.carried_args, carried_args)
-        )
-        body = self.expr(grid.body, inner_env, memo, function, path, active)
-        yield_values = tuple(
-            self.expr(item, inner_env, memo, function, path, active)
-            for item in grid.yield_values
-        )
-        return replace(
-            grid,
-            induction_var=induction_var,
-            carried_args=carried_args,
-            init_args=init_args,
-            body=body,
-            yield_values=yield_values,
-            metadata=_view_metadata(grid),
-        )
+        return _InlineMutator(self, env, memo, function, path, active).visit(expr)
 
 
 def _inline_view(module: Module, function: Function, budget: int) -> Function:

--- a/src/tilefoundry/analysis/poly.py
+++ b/src/tilefoundry/analysis/poly.py
@@ -28,6 +28,7 @@ from tilefoundry.ir.hir.tensor.zeros import Zeros
 from tilefoundry.ir.types import TensorType, TupleType
 from tilefoundry.ir.types.dim import DimVar, is_dim_op_call
 from tilefoundry.ir.types.shard.shard_layout import shard_layout_of, split_target_axes
+from tilefoundry.ir.visitor import ExprVisitor
 from tilefoundry.visitor_registry.access_relation import AccessRelationResult, build_relation
 
 from .walk import children, postorder
@@ -120,35 +121,48 @@ def _buffer_namer():
     used: set[str] = set()
     anonymous = itertools.count()
 
+    class _NameVisitor(ExprVisitor[str]):
+        def __init__(self, prefix: str) -> None:
+            super().__init__()
+            self.prefix = prefix
+
+        def _assign(self, expr, base: str | None = None) -> str:
+            key = id(expr)
+            cached = seen.get(key)
+            if cached is not None:
+                return cached
+            if base is None:
+                base = binding_name(expr) or f"t{next(anonymous)}"
+            base = f"{self.prefix}{base}"
+            candidate = base
+            suffix = 0
+            while candidate in used:
+                suffix += 1
+                candidate = f"{base}_{suffix}"
+            used.add(candidate)
+            seen[key] = candidate
+            return candidate
+
+        def visit_Call(self, expr: Call) -> str:
+            if isinstance(expr.target, TupleGetItem):
+                base = _NameVisitor("").visit(expr.args[0])
+                name = f"{base}_{expr.target.index}"
+                seen[id(expr)] = name
+                return name
+            if isinstance(expr.target, (Reshape, IndexSelect, Slice)):
+                name = _NameVisitor("").visit(expr.args[0])
+                seen[id(expr)] = name
+                return name
+            return self._assign(expr)
+
+        def visit_Var(self, expr: Var) -> str:
+            return self._assign(expr, expr.name)
+
+        def default_visit(self, expr) -> str:
+            return self._assign(expr)
+
     def name_for(expr, prefix: str = "") -> str:
-        key = id(expr)
-        cached = seen.get(key)
-        if cached is not None:
-            return cached
-        if isinstance(expr, Call) and isinstance(expr.target, TupleGetItem):
-            name = f"{name_for(expr.args[0])}_{expr.target.index}"
-            seen[key] = name
-            return name
-        if isinstance(expr, Call) and isinstance(expr.target, (Reshape, IndexSelect, Slice)):
-            name = name_for(expr.args[0])
-            seen[key] = name
-            return name
-        if isinstance(expr, Var):
-            base = expr.name
-        else:
-
-
-
-            base = binding_name(expr) or f"t{next(anonymous)}"
-        base = f"{prefix}{base}"
-        candidate = base
-        suffix = 0
-        while candidate in used:
-            suffix += 1
-            candidate = f"{base}_{suffix}"
-        used.add(candidate)
-        seen[key] = candidate
-        return candidate
+        return _NameVisitor(prefix).visit(expr)
 
     def alias(phi: Var, yielded) -> None:
         """One buffer for a loop carry: ``phi`` and ``yielded`` share a name.
@@ -772,29 +786,43 @@ def _loop_axes(root):
     axis_of: dict[int, GridRegionExpr] = {}
     seed: dict[int, tuple] = {}
     depth: dict[int, int] = {}
-    seen: set[int] = set()
+    class _LoopAxisVisitor(ExprVisitor[None]):
+        def __init__(self) -> None:
+            super().__init__()
+            self.level = 0
 
-    def visit(expr, level: int) -> None:
-        if id(expr) in seen:
-            return
-        seen.add(id(expr))
-        if isinstance(expr, GridRegionExpr):
-            axis = expr
-            axis_of[id(expr)] = axis
-            depth[id(axis)] = level
-            seed[id(expr.induction_var)] = (axis, None)
+        def _visit_at(self, expr, level: int) -> None:
+            previous = self.level
+            self.level = level
+            try:
+                self.visit(expr)
+            finally:
+                self.level = previous
+
+        def visit_Call(self, expr: Call) -> None:
+            for arg in expr.args:
+                self._visit_at(arg, self.level)
+
+        def visit_Tuple(self, expr: Tuple) -> None:
+            for element in expr.elements:
+                self._visit_at(element, self.level)
+
+        def visit_GridRegionExpr(self, expr: GridRegionExpr) -> None:
+            axis_of[id(expr)] = expr
+            depth[id(expr)] = self.level
+            seed[id(expr.induction_var)] = (expr, None)
             for phi, init in zip(expr.carried_args, expr.init_args):
-                seed[id(phi)] = (axis, init)
+                seed[id(phi)] = (expr, init)
             for init in expr.init_args:
-                visit(init, level)
-            visit(expr.body, level + 1)
+                self._visit_at(init, self.level)
+            self._visit_at(expr.body, self.level + 1)
             for value in expr.yield_values:
-                visit(value, level + 1)
-            return
-        for child in children(expr):
-            visit(child, level)
+                self._visit_at(value, self.level + 1)
 
-    visit(root, 0)
+        def default_visit(self, expr) -> None:
+            return None
+
+    _LoopAxisVisitor()._visit_at(root, 0)
     return axis_of, seed, depth
 
 

--- a/src/tilefoundry/analysis/walk.py
+++ b/src/tilefoundry/analysis/walk.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from tilefoundry.ir.core import (
     Call,
+    Constant,
     Expr,
     IRMetadata,
     SourceSpanMetadata,
@@ -19,25 +20,21 @@ from tilefoundry.ir.core.module import Module
 from tilefoundry.ir.core.module import owning_module as _owning_module
 from tilefoundry.ir.hir.function import Function
 from tilefoundry.ir.hir.grid_region import GridRegionExpr
+from tilefoundry.ir.tir.shape import ShapeOf
 from tilefoundry.ir.types import TensorType, TupleType, Type, tensor_bytes
 from tilefoundry.ir.types.shard import Mesh, shard_layout_of
 from tilefoundry.ir.types.shard.layout_algebra import size
 from tilefoundry.ir.types.storage import StorageKind
+from tilefoundry.ir.visitor import ExprWalker, _expr_children
 
 from .errors import AnalysisError
 
 
 def children(expr: Expr) -> tuple[Expr, ...]:
     """The operand expressions of *expr*, in authored order."""
-    match expr:
-        case Call(args=args):
-            return args
-        case Tuple(elements=elements):
-            return elements
-        case GridRegionExpr(init_args=init_args, body=body, yield_values=yield_values):
-            return (*init_args, body, *yield_values)
-        case _:
-            return ()
+    if isinstance(expr, (Function, ShapeOf)):
+        return ()
+    return _expr_children(expr)
 
 
 def enclosing_trips(root: Expr | None) -> dict[int, int]:
@@ -105,18 +102,42 @@ def postorder(root: Expr | None) -> tuple[Expr, ...]:
     """
     if root is None:
         return ()
-    seen: set[int] = set()
     result: list[Expr] = []
 
-    def visit(expr: Expr) -> None:
-        if id(expr) in seen:
-            return
-        seen.add(id(expr))
-        for child in children(expr):
-            visit(child)
-        result.append(expr)
+    class _Postorder(ExprWalker[None]):
+        def _record(self, expr: Expr) -> None:
+            result.append(expr)
 
-    visit(root)
+        def visit_Call(self, expr: Call) -> None:
+            self.visit_operands(expr)
+            self._record(expr)
+
+        def visit_Var(self, expr: Var) -> None:
+            self._record(expr)
+
+        def visit_Constant(self, expr: Constant) -> None:
+            self._record(expr)
+
+        def visit_Tuple(self, expr: Tuple) -> None:
+            self.visit_operands(expr)
+            self._record(expr)
+
+        def visit_GridRegionExpr(self, expr: GridRegionExpr) -> None:
+            self.visit_operands(expr)
+            self._record(expr)
+
+        def visit_Function(self, expr: Function) -> None:
+            self.visit_operands(expr)
+            self._record(expr)
+
+        def visit_SymbolRef(self, expr) -> None:
+            self._record(expr)
+
+        def visit_ShapeOf(self, expr) -> None:
+            self._record(expr)
+
+    if root is not None:
+        _Postorder().visit(root)
     return tuple(result)
 
 

--- a/src/tilefoundry/codegen/cpu/module.py
+++ b/src/tilefoundry/codegen/cpu/module.py
@@ -17,7 +17,7 @@ from tilefoundry.codegen.cuda.tir.prim_function import (
 )
 from tilefoundry.codegen.linkable import LinkableFunction, LinkableModule
 from tilefoundry.codegen.registry import CodeGenerator
-from tilefoundry.ir.core import Call, Var
+from tilefoundry.ir.core import Call, Constant, Var
 from tilefoundry.ir.core.module import Module
 from tilefoundry.ir.core.pattern import DimVarRangePat
 from tilefoundry.ir.tir.dispatch import DispatchCall
@@ -37,6 +37,7 @@ from tilefoundry.ir.types.dim import (
 )
 from tilefoundry.ir.types.shape_helpers import static_dim_value
 from tilefoundry.ir.types.storage import StorageKind
+from tilefoundry.ir.visitor import ExprVisitor
 from tilefoundry.target import Target
 
 _STORAGE_DEVICE_TYPE = {
@@ -76,6 +77,43 @@ _DIM_BINOP_CXX = {
 }
 
 
+class _HostIntExprVisitor(ExprVisitor[str]):
+    def visit_Constant(self, expr: Constant) -> str:
+        value = static_dim_value(expr)
+        if value is None:
+            raise ValueError(
+                "emit_host_module: unsupported launch-extent node "
+                f"{type(expr).__name__}"
+            )
+        return str(value)
+
+    def visit_ShapeOf(self, expr: ShapeOf) -> str:
+        return f"{expr.param.name}.shape()[{expr.axis}]"
+
+    def visit_Call(self, expr: Call) -> str:
+        target = expr.target
+        sym = next((s for op, s in _DIM_BINOP_CXX.items() if isinstance(target, op)), None)
+        if sym is not None:
+            a, b = expr.args
+            return f"({self.visit(a)} {sym} {self.visit(b)})"
+        if isinstance(target, (DimMin, DimMax)):
+            a, b = expr.args
+            ca = self.visit(a)
+            cb = self.visit(b)
+            cmp = "<" if isinstance(target, DimMin) else ">"
+            return f"(({ca}) {cmp} ({cb}) ? ({ca}) : ({cb}))"
+        raise ValueError(
+            f"emit_host_module: unsupported launch-extent op "
+            f"{type(target).__name__}"
+        )
+
+    def default_visit(self, expr) -> str:
+        raise ValueError(
+            f"emit_host_module: unsupported launch-extent node "
+            f"{type(expr).__name__}"
+        )
+
+
 def _emit_host_int_expr(expr) -> str:
     """Lower a launch-extent Expr to a host C++ integer expression.
 
@@ -87,28 +125,8 @@ def _emit_host_int_expr(expr) -> str:
     sv = static_dim_value(expr)
     if sv is not None:
         return str(sv)
-    if isinstance(expr, ShapeOf):
-        return f"{expr.param.name}.shape()[{expr.axis}]"
-    if isinstance(expr, Call):
-        target = expr.target
-        sym = next(
-            (s for op, s in _DIM_BINOP_CXX.items() if isinstance(target, op)), None
-        )
-        if sym is not None:
-            a, b = expr.args
-            return (
-                f"({_emit_host_int_expr(a)} {sym} {_emit_host_int_expr(b)})"
-            )
-        if isinstance(target, (DimMin, DimMax)):
-            a, b = expr.args
-            ca = _emit_host_int_expr(a)
-            cb = _emit_host_int_expr(b)
-            cmp = "<" if isinstance(target, DimMin) else ">"
-            return f"(({ca}) {cmp} ({cb}) ? ({ca}) : ({cb}))"
-        raise ValueError(
-            f"emit_host_module: unsupported launch-extent op "
-            f"{type(target).__name__}"
-        )
+    if isinstance(expr, (ShapeOf, Call, Constant)):
+        return _HostIntExprVisitor().visit(expr)
     raise ValueError(
         f"emit_host_module: unsupported launch-extent node "
         f"{type(expr).__name__}"

--- a/src/tilefoundry/codegen/cuda/emit.py
+++ b/src/tilefoundry/codegen/cuda/emit.py
@@ -13,9 +13,13 @@ import logging
 import os
 import pkgutil
 
-from tilefoundry.ir.core import Call
+from tilefoundry.ir.core import Call, Constant, Tuple, Var
+from tilefoundry.ir.hir.grid_region import GridRegionExpr
+from tilefoundry.ir.tir.shape import ShapeOf
 from tilefoundry.ir.tir.stmts import LetStmt, MeshScope, Sequential
+from tilefoundry.ir.tir.symbol_ref import SymbolRef
 from tilefoundry.ir.types.shard.shard_layout import ShardLayout
+from tilefoundry.ir.visitor import ExprWalker
 
 _log = logging.getLogger(__name__)
 _tir_path = os.path.dirname(__file__)
@@ -130,13 +134,34 @@ def _derive_launch_config(
             grid_x = max(grid_x, g)
             block_x = max(block_x, b)
 
-    def _walk_expr(e):
-        if isinstance(e, Call):
-            _harvest_from_layout(getattr(e.type, "layout", None))
-            for a in e.args:
-                _walk_expr(a)
-        else:
-            _harvest_from_layout(getattr(getattr(e, "type", None), "layout", None))
+    class _LayoutVisitor(ExprWalker[None]):
+        def _record(self, expr) -> None:
+            _harvest_from_layout(getattr(getattr(expr, "type", None), "layout", None))
+
+        def visit_Call(self, expr: Call) -> None:
+            self._record(expr)
+            self.visit_operands(expr)
+
+        def visit_Tuple(self, expr: Tuple) -> None:
+            self._record(expr)
+
+        def visit_GridRegionExpr(self, expr: GridRegionExpr) -> None:
+            self._record(expr)
+
+        def visit_Var(self, expr: Var) -> None:
+            self._record(expr)
+
+        def visit_Constant(self, expr: Constant) -> None:
+            self._record(expr)
+
+        def visit_SymbolRef(self, expr: SymbolRef) -> None:
+            self._record(expr)
+
+        def visit_ShapeOf(self, expr: ShapeOf) -> None:
+            self._record(expr)
+
+        def default_visit(self, expr) -> None:
+            self._record(expr)
 
     def walk(stmt) -> None:
         nonlocal grid_x, block_x
@@ -156,7 +181,7 @@ def _derive_launch_config(
 
 
                 if hasattr(stmt, "value"):
-                    _walk_expr(stmt.value)
+                    _LayoutVisitor().visit(stmt.value)
                 if hasattr(stmt, "var") and getattr(stmt.var, "type", None) is not None:
                     _harvest_from_layout(getattr(stmt.var.type, "layout", None))
                 walk(stmt.body)

--- a/src/tilefoundry/codegen/cuda/tir/memory/tensor_view.py
+++ b/src/tilefoundry/codegen/cuda/tir/memory/tensor_view.py
@@ -28,6 +28,7 @@ from tilefoundry.ir.types.shard.shard_layout import (
     shard_layout_local_shape,
 )
 from tilefoundry.ir.types.shard.shard_layout import ShardLayout as SL
+from tilefoundry.ir.visitor import ExprVisitor
 
 
 def _render_layout(shape, strides) -> str:
@@ -197,6 +198,38 @@ def render_shard_layout_value(var_name: str, sl: SL, dim_var_runtime=None):
 _COORD_OPERATORS = {DimAdd: "+", DimSub: "-", DimMul: "*"}
 
 
+class _CoordinateVisitor(ExprVisitor[str]):
+    def __init__(self, ctx: CodegenContext) -> None:
+        super().__init__()
+        self.ctx = ctx
+
+    def visit_Constant(self, expr: Constant) -> str:
+        return str(int(expr.value))
+
+    def visit_Call(self, expr: Call) -> str:
+        operator = _COORD_OPERATORS.get(type(expr.target))
+        if operator is not None:
+            lhs, rhs = (self.visit(arg) for arg in expr.args)
+            return f"({lhs} {operator} {rhs})"
+        return self._leaf(expr)
+
+    def _leaf(self, expr) -> str:
+        name = self.ctx.name_for(expr)
+        shape = getattr(getattr(expr, "type", None), "shape", ()) or ()
+        dims = tuple(getattr(d, "value", d) for d in shape)
+        if dims == ():
+            return name
+        if dims == (1,):
+            return f"{name}_tensor(0)" if self.ctx.is_kernel_param(expr) else f"{name}(0)"
+        raise NotImplementedError(
+            f"local_tile coordinate from a rank-{len(dims)} offset {dims} "
+            "is not supported"
+        )
+
+    def default_visit(self, expr) -> str:
+        return self._leaf(expr)
+
+
 def _coord_ref(index_var, ctx: CodegenContext) -> str:
     """Render a compile-time, scalar, or one-element absolute coordinate.
 
@@ -206,24 +239,7 @@ def _coord_ref(index_var, ctx: CodegenContext) -> str:
     placement after an ordinal is converted to an element start, and an addition
     moves a window's base by a compile-time offset. Other forms fail closed.
     """
-    if isinstance(index_var, Constant):
-        return str(int(index_var.value))
-    if isinstance(index_var, Call):
-        operator = _COORD_OPERATORS.get(type(index_var.target))
-        if operator is not None:
-            lhs, rhs = (_coord_ref(arg, ctx) for arg in index_var.args)
-            return f"({lhs} {operator} {rhs})"
-    name = ctx.name_for(index_var)
-    shape = getattr(getattr(index_var, "type", None), "shape", ()) or ()
-    dims = tuple(getattr(d, "value", d) for d in shape)
-    if dims == ():
-        return name
-    if dims == (1,):
-        return f"{name}_tensor(0)" if ctx.is_kernel_param(index_var) else f"{name}(0)"
-    raise NotImplementedError(
-        f"local_tile coordinate from a rank-{len(dims)} offset {dims} "
-        "is not supported"
-    )
+    return _CoordinateVisitor(ctx).visit(index_var)
 
 
 @register_codegen_cuda(TensorView)

--- a/src/tilefoundry/codegen/cuda/tir/stmts/if_.py
+++ b/src/tilefoundry/codegen/cuda/tir/stmts/if_.py
@@ -12,6 +12,7 @@ from tilefoundry.codegen.cuda.context import CodegenContext, register_codegen_cu
 from tilefoundry.ir.core import Call, Constant, Var
 from tilefoundry.ir.core.kinds import BinaryKind
 from tilefoundry.ir.tir.stmts import If
+from tilefoundry.ir.visitor import ExprVisitor
 
 _SCALAR_BINARY_OP: dict[BinaryKind, str] = {
     BinaryKind.EQ: "==",
@@ -24,13 +25,12 @@ _SCALAR_BINARY_OP: dict[BinaryKind, str] = {
 }
 
 
-def render_scalar_predicate(expr, ctx: CodegenContext) -> str:
-    """Render a scalar boolean / integer expression as a C source string.
+class _PredicateVisitor(ExprVisitor[str]):
+    def __init__(self, ctx: CodegenContext) -> None:
+        super().__init__()
+        self.ctx = ctx
 
-    Intended for ``tir.If.cond`` and any other scalar predicate site.
-    Walks only the small Expr subset listed in the module docstring.
-    """
-    if isinstance(expr, Constant):
+    def visit_Constant(self, expr: Constant) -> str:
         value = expr.value
         if isinstance(value, bool):
             return "true" if value else "false"
@@ -41,30 +41,41 @@ def render_scalar_predicate(expr, ctx: CodegenContext) -> str:
             f"{type(value).__name__!r} is not supported "
             f"(only int / bool)."
         )
-    if isinstance(expr, Var):
-        return ctx.name_for(expr)
-    if isinstance(expr, Call):
+
+    def visit_Var(self, expr: Var) -> str:
+        return self.ctx.name_for(expr)
+
+    def visit_Call(self, expr: Call) -> str:
         op = expr.target
         kind = getattr(op, "kind", None)
         if not isinstance(kind, BinaryKind) or kind not in _SCALAR_BINARY_OP:
             raise NotImplementedError(
                 f"render_scalar_predicate: Call target {type(op).__name__} "
                 f"with kind {kind!r} is not a supported scalar binary. "
-                f"Supported kinds: "
-                f"{sorted(k.name for k in _SCALAR_BINARY_OP)}."
+                f"Supported kinds: {sorted(k.name for k in _SCALAR_BINARY_OP)}."
             )
         if len(expr.args) != 2:
             raise ValueError(
                 f"render_scalar_predicate: scalar Binary expects 2 args, "
                 f"got {len(expr.args)}"
             )
-        lhs = render_scalar_predicate(expr.args[0], ctx)
-        rhs = render_scalar_predicate(expr.args[1], ctx)
+        lhs, rhs = (self.visit(arg) for arg in expr.args)
         return f"({lhs}) {_SCALAR_BINARY_OP[kind]} ({rhs})"
-    raise NotImplementedError(
-        f"render_scalar_predicate: Expr type {type(expr).__name__!r} is "
-        f"not supported."
-    )
+
+    def default_visit(self, expr) -> str:
+        raise NotImplementedError(
+            f"render_scalar_predicate: Expr type {type(expr).__name__!r} is "
+            f"not supported."
+        )
+
+
+def render_scalar_predicate(expr, ctx: CodegenContext) -> str:
+    """Render a scalar boolean / integer expression as a C source string.
+
+    Intended for ``tir.If.cond`` and any other scalar predicate site.
+    Walks only the small Expr subset listed in the module docstring.
+    """
+    return _PredicateVisitor(ctx).visit(expr)
 
 
 @register_codegen_cuda(If)

--- a/src/tilefoundry/evaluator/dim.py
+++ b/src/tilefoundry/evaluator/dim.py
@@ -26,6 +26,7 @@ from tilefoundry.ir.types.dim import (
     DimSub,
     DimVar,
 )
+from tilefoundry.ir.visitor import ExprVisitor
 
 _FOLDERS: dict[type, Callable[[int, int], int]] = {
     DimAdd: lambda a, b: a + b,
@@ -36,6 +37,38 @@ _FOLDERS: dict[type, Callable[[int, int], int]] = {
     DimMin: min,
     DimMax: max,
 }
+
+
+class _DimResolver(ExprVisitor[int]):
+    def __init__(self, bindings: dict[str, int]) -> None:
+        super().__init__()
+        self.bindings = bindings
+
+    def visit_Constant(self, dim: Constant) -> int:
+        value = dim.value
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise ValueError(f"resolve_dim: non-integer Constant value {value!r}")
+        return value
+
+    def visit_DimVar(self, dim: DimVar) -> int:
+        try:
+            return self.bindings[dim.name]
+        except KeyError:
+            raise ValueError(f"resolve_dim: unbound DimVar {dim.name!r}") from None
+
+    def visit_Call(self, dim: Call) -> int:
+        op_cls = type(dim.target)
+        fold = _FOLDERS.get(op_cls)
+        if fold is None:
+            raise ValueError(f"resolve_dim: non-dim Call target {op_cls.__name__}")
+        a = self.visit(dim.args[0])
+        b = self.visit(dim.args[1])
+        if op_cls in (DimFloorDiv, DimMod) and b == 0:
+            raise ValueError("resolve_dim: division/modulo by zero")
+        return int(fold(a, b))
+
+    def default_visit(self, dim) -> int:
+        raise ValueError(f"resolve_dim: unrecognised Dim {type(dim).__name__}")
 
 
 def resolve_dim(dim, bindings: dict[str, int]) -> int:
@@ -51,26 +84,8 @@ def resolve_dim(dim, bindings: dict[str, int]) -> int:
         raise ValueError(f"resolve_dim: bool {dim!r} is not a valid Dim")
     if isinstance(dim, int):
         return dim
-    if isinstance(dim, Constant):
-        v = dim.value
-        if isinstance(v, bool) or not isinstance(v, int):
-            raise ValueError(f"resolve_dim: non-integer Constant value {v!r}")
-        return v
-    if isinstance(dim, DimVar):
-        try:
-            return bindings[dim.name]
-        except KeyError:
-            raise ValueError(f"resolve_dim: unbound DimVar {dim.name!r}") from None
-    if isinstance(dim, Call):
-        op_cls = type(dim.target)
-        fold = _FOLDERS.get(op_cls)
-        if fold is None:
-            raise ValueError(f"resolve_dim: non-dim Call target {op_cls.__name__}")
-        a = resolve_dim(dim.args[0], bindings)
-        b = resolve_dim(dim.args[1], bindings)
-        if op_cls in (DimFloorDiv, DimMod) and b == 0:
-            raise ValueError("resolve_dim: division/modulo by zero")
-        return int(fold(a, b))
+    if isinstance(dim, (Constant, DimVar, Call)):
+        return _DimResolver(bindings).visit(dim)
     raise ValueError(f"resolve_dim: unrecognised Dim {type(dim).__name__}")
 
 

--- a/src/tilefoundry/evaluator/interpreter.py
+++ b/src/tilefoundry/evaluator/interpreter.py
@@ -77,27 +77,18 @@ def child_reading(reading, callee: Function):
 
 
 class Evaluator(ExprVisitor):
-    """``ExprVisitor[Value]`` memoized on ``id(expr)`` within one scope."""
+    """``ExprVisitor[Value]`` evaluated with one memo per execution scope."""
 
     def __init__(
         self, env: dict[int, Value], device: str,
         dim_env: dict[str, int] | None = None,
         reading=None,
     ) -> None:
+        super().__init__()
         self.env = env
         self.device = device
         self.dim_env = dim_env or {}
         self.reading = reading
-        self.memo: dict[int, Value] = {}
-
-    def visit(self, expr) -> Value:
-        key = id(expr)
-        if key in self.memo:
-            return self.memo[key]
-        value = super().visit(expr)
-        self.memo[key] = value
-        return value
-
     def visit_Var(self, var: Var) -> Value:
         try:
             return self.env[id(var)]

--- a/src/tilefoundry/inspection/dot.py
+++ b/src/tilefoundry/inspection/dot.py
@@ -13,6 +13,7 @@ from tilefoundry.ir.core.module import Module
 from tilefoundry.ir.hir.function import Function as HirFunction
 from tilefoundry.ir.hir.sharding.reshard import Reshard
 from tilefoundry.ir.types import TensorType
+from tilefoundry.ir.visitor import ExprWalker
 
 from .python_printer import _collect_meshes, _mesh_name_map, _op_display_name, _tensor_annotation
 
@@ -47,8 +48,6 @@ def hir_function_to_dot(fn: HirFunction) -> str:
              '  edge [fontsize=10, fontcolor="#555555"];', '']
     _counter = [0]
     _ids = {}
-    _emitted: set[int] = set()
-
     def _id(node):
         key = id(node)
         if key not in _ids:
@@ -72,64 +71,62 @@ def hir_function_to_dot(fn: HirFunction) -> str:
     CALL_FILL = "#d5f5e3"
     SHARDING_FILL = "#e8daef"
 
-    def walk(expr):
-        nid = _id(expr)
-        key = id(expr)
-        is_new = key not in _emitted
-        if is_new:
-            _emitted.add(key)
+    class _DotWalker(ExprWalker[None]):
+        def _emit_leaf(self, expr, label_lines, fill) -> None:
+            _emit_node(_id(expr), label_lines, fill=fill)
 
-        match expr:
-            case Var():
-                if is_new:
-                    _emit_node(nid, [
-                        f"Var: {expr.name}",
-                        *_type_lines(expr.type, mesh_map),
-                    ], fill=VAR_FILL)
-            case Constant():
-                if is_new:
-                    val = f"{expr.value:.6g}" if isinstance(expr.value, float) else str(expr.value)
-                    _emit_node(nid, [
-                        f"Const: {val}",
-                        *_type_lines(expr.type, mesh_map),
-                    ], fill=CONST_FILL)
-            case Call():
-                target = expr.target
-                if isinstance(target, Reshard):
-                    if is_new:
-                        name = binding_name(expr)
-                        header = f"{name}\\nReshard" if name else "Reshard"
-                        _emit_node(nid, [
-                            header,
-                            *_type_lines(expr.type, mesh_map),
-                        ], fill=SHARDING_FILL)
-                        for arg in expr.args:
-                            walk(arg)
-                            _emit_edge(_id(arg), nid)
-                    return
+        def visit_Var(self, expr: Var) -> None:
+            self._emit_leaf(
+                expr,
+                [f"Var: {expr.name}", *_type_lines(expr.type, mesh_map)],
+                VAR_FILL,
+            )
 
-                op_label = _op_display_name(target)
+        def visit_Constant(self, expr: Constant) -> None:
+            value = f"{expr.value:.6g}" if isinstance(expr.value, float) else str(expr.value)
+            self._emit_leaf(
+                expr,
+                [f"Const: {value}", *_type_lines(expr.type, mesh_map)],
+                CONST_FILL,
+            )
+
+        def visit_Call(self, expr: Call) -> None:
+            nid = _id(expr)
+            target = expr.target
+            if isinstance(target, Reshard):
                 name = binding_name(expr)
-                header = f"{name}\\n{op_label}" if name else op_label
-                if is_new:
-                    _emit_node(nid, [
-                        header,
-                        *_type_lines(expr.type, mesh_map),
-                    ], fill=CALL_FILL)
-                    for i, arg in enumerate(expr.args):
-                        walk(arg)
-                        edge_label = f"arg[{i}]" if len(expr.args) > 1 else ""
-                        _emit_edge(_id(arg), nid, edge_label)
-                else:
-                    for arg in expr.args:
-                        walk(arg)
-            case _:
-                if is_new:
-                    _emit_node(nid, [type(expr).__name__], fill="#ffffff")
+                header = f"{name}\\nReshard" if name else "Reshard"
+                _emit_node(nid, [header, *_type_lines(expr.type, mesh_map)], fill=SHARDING_FILL)
+                for arg in expr.args:
+                    self.visit(arg)
+                    _emit_edge(_id(arg), nid)
+                return
 
-    walk(fn.body)
-    for p in fn.params:
-        walk(p)
+            op_label = _op_display_name(target)
+            name = binding_name(expr)
+            header = f"{name}\\n{op_label}" if name else op_label
+            _emit_node(nid, [header, *_type_lines(expr.type, mesh_map)], fill=CALL_FILL)
+            for i, arg in enumerate(expr.args):
+                self.visit(arg)
+                edge_label = f"arg[{i}]" if len(expr.args) > 1 else ""
+                _emit_edge(_id(arg), nid, edge_label)
+
+        def visit_Tuple(self, expr) -> None:
+            self._emit_leaf(expr, [type(expr).__name__], "#ffffff")
+
+        def visit_GridRegionExpr(self, expr) -> None:
+            self._emit_leaf(expr, [type(expr).__name__], "#ffffff")
+
+        def visit_ShapeOf(self, expr) -> None:
+            _emit_node(_id(expr), ["ShapeOf"], fill="#ffffff")
+
+        def default_visit(self, expr) -> None:
+            _emit_node(_id(expr), [type(expr).__name__], fill="#ffffff")
+
+    walker = _DotWalker()
+    walker.visit(fn.body)
+    for param in fn.params:
+        walker.visit(param)
 
 
     lines.append("")

--- a/src/tilefoundry/inspection/python_printer.py
+++ b/src/tilefoundry/inspection/python_printer.py
@@ -35,6 +35,7 @@ from tilefoundry.ir.core.kinds import BinaryKind, UnaryKind
 from tilefoundry.ir.core.module import Module
 from tilefoundry.ir.core.pattern import DimVarRangePat, Pattern
 from tilefoundry.ir.hir.function import Function as HirFunction
+from tilefoundry.ir.hir.function import canonical_specialization_signature
 from tilefoundry.ir.hir.grid_region import GridRegionExpr
 from tilefoundry.ir.hir.math.binary import Binary
 from tilefoundry.ir.hir.math.unary import Unary
@@ -67,7 +68,7 @@ from tilefoundry.ir.types.shard.shard_layout import (
 )
 from tilefoundry.ir.types.storage import StorageKind
 from tilefoundry.ir.types.substitute import dim_vars_by_name
-from tilefoundry.ir.visitor import _expr_children
+from tilefoundry.ir.visitor import ExprFunctor, _expr_children
 from tilefoundry.utils.python_source import PythonExpr
 
 from .values import PARTS, render_comment
@@ -168,46 +169,57 @@ def shape_entry_str(entry: object) -> str:
     return _shape_entry_str(entry, nested=False)
 
 
-def _shape_entry_str(entry: object, *, nested: bool) -> str:
-    if isinstance(entry, bool):
-        return repr(entry)
-    if isinstance(entry, int):
-        return str(entry)
-    if isinstance(entry, DimVar):
+class _ShapeEntryVisitor(ExprFunctor[str]):
+    def __init__(self, nested: bool) -> None:
+        super().__init__()
+        self.nested = nested
+
+    def visit_DimVar(self, entry: DimVar) -> str:
         return entry.name
-    if isinstance(entry, Var):
+
+    def visit_Var(self, entry: Var) -> str:
         return entry.name
-    if isinstance(entry, Constant):
+
+    def visit_Constant(self, entry: Constant) -> str:
         return str(entry.value)
-    if isinstance(entry, Call):
+
+    def visit_Call(self, entry: Call) -> str:
         ceildiv_args = _ceildiv_args(entry)
         if ceildiv_args is not None:
             a, b = ceildiv_args
-            return (
-                f"ceildiv({_shape_entry_str(a, nested=False)}, "
-                f"{_shape_entry_str(b, nested=False)})"
-            )
+            return f"ceildiv({self._render(a, False)}, {self._render(b, False)})"
         target = entry.target
         if isinstance(target, DimConst):
             return str(target.value)
         for op_cls, sym in _DIM_INFIX_OPS.items():
             if isinstance(target, op_cls):
                 a, b = entry.args
-                rendered = (
-                    f"{_shape_entry_str(a, nested=True)} {sym} "
-                    f"{_shape_entry_str(b, nested=True)}"
-                )
-                return f"({rendered})" if nested else rendered
+                rendered = f"{self._render(a, True)} {sym} {self._render(b, True)}"
+                return f"({rendered})" if self.nested else rendered
         for op_cls, fname in _DIM_FUNC_OPS.items():
             if isinstance(target, op_cls):
-                rendered = ", ".join(
-                    _shape_entry_str(a, nested=False) for a in entry.args
-                )
+                rendered = ", ".join(self._render(arg, False) for arg in entry.args)
                 return f"{fname}({rendered})"
         return repr(entry)
-    if isinstance(entry, Expr):
+
+    def default_visit(self, entry) -> str:
+        if isinstance(entry, bool):
+            return repr(entry)
+        if isinstance(entry, int):
+            return str(entry)
         return repr(entry)
-    return repr(entry)
+
+    def _render(self, entry, nested: bool) -> str:
+        previous = self.nested
+        self.nested = nested
+        try:
+            return self.visit(entry)
+        finally:
+            self.nested = previous
+
+
+def _shape_entry_str(entry: object, *, nested: bool) -> str:
+    return _ShapeEntryVisitor(nested).visit(entry)
 
 
 def _ceildiv_args(entry: Call) -> tuple[object, object] | None:
@@ -1152,41 +1164,67 @@ def _emit_def(
         )
         printed.add(id(expr))
 
-    def _emit_expr(expr: Expr, level: str) -> None:
-        key = id(expr)
-        if key in printed:
-            return
-        if key in _inlined_start_ids:
-            printed.add(key)
-            return
-        if isinstance(expr, Var):
-            printed.add(key)
-            return
-        if isinstance(expr, Constant):
-            lines.append(f"{level}{_names[key]} = {repr(expr.value)}{_comments(expr, options, mesh_map)}")
-            printed.add(key)
-            return
-        if isinstance(expr, Tuple):
+    class _ExprEmitter(ExprFunctor[None]):
+        def __init__(self, level: str) -> None:
+            super().__init__()
+            self.level = level
+
+        def emit(self, expr: Expr) -> None:
+            self.visit(expr)
+
+        def visit(self, expr):
+            key = id(expr)
+            if key in printed:
+                return None
+            if key in _inlined_start_ids:
+                printed.add(key)
+                return None
+            return super().visit(expr)
+
+        def visit_Var(self, expr: Var) -> None:
+            printed.add(id(expr))
+
+        def visit_Constant(self, expr: Constant) -> None:
+            lines.append(
+                f"{self.level}{_names[id(expr)]} = {repr(expr.value)}"
+                f"{_comments(expr, options, mesh_map)}"
+            )
+            printed.add(id(expr))
+
+        def visit_Tuple(self, expr: Tuple) -> None:
             for element in expr.elements:
                 if not isinstance(element, Constant):
-                    _emit_expr(element, level)
-            printed.add(key)
-            return
-        if isinstance(expr, GridRegionExpr):
-            _emit_grid(expr, level)
-            return
-        if isinstance(expr, Call):
+                    self.visit(element)
+            printed.add(id(expr))
+
+        def visit_GridRegionExpr(self, expr: GridRegionExpr) -> None:
+            _emit_grid(expr, self.level)
+
+        def visit_Call(self, expr: Call) -> None:
             if (
                 isinstance(expr.target, TupleGetItem)
                 and len(expr.args) == 1
                 and isinstance(expr.args[0], GridRegionExpr)
             ):
-                _emit_grid(expr.args[0], level)
-                printed.add(key)
+                _emit_grid(expr.args[0], self.level)
+                printed.add(id(expr))
                 return
             for arg in expr.args:
-                _emit_expr(arg, level)
-            _emit_inline_call(expr, level)
+                self.visit(arg)
+            _emit_inline_call(expr, self.level)
+
+        def default_visit(self, expr) -> None:
+            return None
+
+    _expr_emitter = _ExprEmitter("")
+
+    def _emit_expr(expr: Expr, level: str) -> None:
+        previous = _expr_emitter.level
+        _expr_emitter.level = level
+        try:
+            _expr_emitter.emit(expr)
+        finally:
+            _expr_emitter.level = previous
 
     def _emit_grid(grid: GridRegionExpr, level: str) -> None:
         key = id(grid)
@@ -1358,6 +1396,15 @@ def _emit_header(
     return lines
 
 
+def _variant_binding_name(variant: HirFunction) -> str:
+    """Return a valid source binding for a variant without display metadata."""
+    label = display_name(variant)
+    if label is not None:
+        return label
+    signature = canonical_specialization_signature(variant.specializations)
+    return "variant_" + re.sub(r"[^0-9A-Za-z_]", "_", signature)
+
+
 def _emit_decorated_defs(
     fn: HirFunction, mesh_map: dict[int, str], indent: str, options: PythonPrintOptions,
     child_entries: dict[int, str] | None = None,
@@ -1394,7 +1441,7 @@ def _emit_decorated_defs(
         )
         lines.extend(
             _emit_def(
-                variant, display_name(variant) or "_", mesh_map, indent, options,
+                variant, _variant_binding_name(variant), mesh_map, indent, options,
                 child_entries,
                 line_offset=line_offset + _physical_line_count(lines),
                 statements=statements,

--- a/src/tilefoundry/inspection/viewer/builder.py
+++ b/src/tilefoundry/inspection/viewer/builder.py
@@ -26,6 +26,7 @@ from tilefoundry.ir.types.dim import DimVar
 from tilefoundry.ir.types.shard.mesh import Mesh
 from tilefoundry.ir.types.shard.shard_layout import ShardLayout
 from tilefoundry.ir.types.tensor_type import TensorType, TupleType
+from tilefoundry.ir.visitor import ExprVisitor
 
 from .htmltable import Cell, Span, Table
 from .palette import (
@@ -227,6 +228,36 @@ def _op_attributes(
     return out
 
 
+class _DimSpanVisitor(ExprVisitor[list[Span]]):
+    def visit_DimVar(self, dim: DimVar) -> list[Span]:
+        return [Span(text=dim.name, color=DIMVAR_COLOR, bold=True)]
+
+    def visit_Constant(self, dim: Constant) -> list[Span]:
+        return [Span(text=str(dim.value))]
+
+    def visit_Call(self, dim: Call) -> list[Span]:
+        target = dim.target
+        for op_cls, sym in _DIM_INFIX_OPS.items():
+            if isinstance(target, op_cls):
+                spans = list(self.visit(dim.args[0]))
+                spans.append(Span(text=f" {sym} "))
+                spans.extend(self.visit(dim.args[1]))
+                return spans
+        for op_cls, fname in _DIM_FUNC_OPS.items():
+            if isinstance(target, op_cls):
+                spans = [Span(text=f"{fname}(")]
+                for i, arg in enumerate(dim.args):
+                    if i:
+                        spans.append(Span(text=", "))
+                    spans.extend(self.visit(arg))
+                spans.append(Span(text=")"))
+                return spans
+        return [Span(text=shape_entry_str(dim))]
+
+    def default_visit(self, dim) -> list[Span]:
+        return [Span(text=shape_entry_str(dim))]
+
+
 def _format_dim(dim) -> list[Span]:
     """Render a shape dimension as inline viewer spans.
 
@@ -235,28 +266,7 @@ def _format_dim(dim) -> list[Span]:
     symbol; integers remain plain.
     See [inspection §2.3](docs/spec/inspection.md#23-dsl-text-forms).
     """
-    if isinstance(dim, DimVar):
-        return [Span(text=dim.name, color=DIMVAR_COLOR, bold=True)]
-    if isinstance(dim, Constant):
-        return [Span(text=str(dim.value))]
-    if isinstance(dim, Call):
-        tgt = dim.target
-        for op_cls, sym in _DIM_INFIX_OPS.items():
-            if isinstance(tgt, op_cls):
-                spans = list(_format_dim(dim.args[0]))
-                spans.append(Span(text=f" {sym} "))
-                spans.extend(_format_dim(dim.args[1]))
-                return spans
-        for op_cls, fname in _DIM_FUNC_OPS.items():
-            if isinstance(tgt, op_cls):
-                spans = [Span(text=f"{fname}(")]
-                for i, a in enumerate(dim.args):
-                    if i:
-                        spans.append(Span(text=", "))
-                    spans.extend(_format_dim(a))
-                spans.append(Span(text=")"))
-                return spans
-    return [Span(text=shape_entry_str(dim))]
+    return _DimSpanVisitor().visit(dim)
 
 
 def _shard_inline(ty: TensorType, mesh_name_map: dict[int, str] | None):

--- a/src/tilefoundry/ir/core/module.py
+++ b/src/tilefoundry/ir/core/module.py
@@ -76,24 +76,20 @@ def _calls_in(function) -> tuple:
     Its own body and nothing else: a variant this dispatch did not select is
     not running, and a converter runs offline rather than here.
     """
-    from tilefoundry.ir.core.expr import Call, child_exprs  # noqa: PLC0415 -- cycle
+    from tilefoundry.ir.core.expr import Call  # noqa: PLC0415 -- cycle
+    from tilefoundry.ir.visitor import ExprWalker  # noqa: PLC0415
 
     found: list[Call] = []
-    seen: set[int] = set()
 
-    def visit(expr) -> None:
-        if expr is None or id(expr) in seen:
-            return
-        seen.add(id(expr))
-        if isinstance(expr, Call) and isinstance(expr.target, HirFunction):
-            found.append(expr)
-            for arg in expr.args:
-                visit(arg)
-            return
-        for child in child_exprs(expr):
-            visit(child)
+    class _CallVisitor(ExprWalker[None]):
+        def visit_Call(self, expr: Call) -> None:
+            if isinstance(expr.target, HirFunction):
+                found.append(expr)
+            self.visit_operands(expr)
 
-    visit(getattr(function, "body", None))
+    body = getattr(function, "body", None)
+    if body is not None:
+        _CallVisitor().visit(body)
     return tuple(found)
 
 

--- a/src/tilefoundry/ir/hir/function.py
+++ b/src/tilefoundry/ir/hir/function.py
@@ -257,9 +257,14 @@ def _elaborate_from_bound_types(
         Rebuild ``callee.body`` under ``subst`` (memoized by node
         identity so SSA-as-DAG sharing survives), re-stamping every
         changed node's type through the shared typeinfer visitor.
+
+        The local memo stays here because each result depends on this
+        elaborator's substitution and body context; it must not be shared
+        through ExprVisitor's read-only memo.
         """
 
         def __init__(self, body_ctx: TypeInferContext) -> None:
+            super().__init__()
             self.body_ctx = body_ctx
             self._memo: dict[int, Expr] = {}
 
@@ -356,8 +361,8 @@ def _elaborate_from_bound_types(
             )
             return self._retyped(rebuilt)
 
-        def generic_visit(self, expr: Expr) -> Expr:
-            rebuilt = super().generic_visit(expr)
+        def default_visit(self, expr: Expr) -> Expr:
+            rebuilt = super().default_visit(expr)
             if rebuilt is expr:
                 return expr
             return self._retyped(rebuilt)

--- a/src/tilefoundry/ir/hir/specialize.py
+++ b/src/tilefoundry/ir/hir/specialize.py
@@ -13,12 +13,15 @@ from __future__ import annotations
 import dataclasses
 from collections.abc import Mapping
 
+from tilefoundry.ir.core import Call, Constant, Expr, Tuple, Var
 from tilefoundry.ir.core.pattern import DimVarRangePat
+from tilefoundry.ir.hir.grid_region import GridRegionExpr
 from tilefoundry.ir.types.substitute import (
     dim_vars_by_name,
     has_symbolic_dims,
     substitute_dims,
 )
+from tilefoundry.ir.visitor import ExprVisitor, ExprWalker
 from tilefoundry.visitor_registry.contexts import TypeInferContext
 
 from .function import Function, _elaborate_from_bound_types
@@ -232,42 +235,90 @@ def dim_vars_reached(fn: Function) -> dict[str, object]:
     that has to restate the bounds a dimension was declared with.
     """
     found: dict[str, object] = {}
-    _walk_function(fn, found, set())
+    _DimVarCollector(found).visit_function(fn)
     return found
 
 
-def _walk_function(fn: Function, found: dict[str, object], seen: set[int]) -> None:
-    if id(fn) in seen:
-        return
-    seen.add(id(fn))
-    for param in fn.params:
-        found.update(dim_vars_by_name(param.type))
-    found.update(dim_vars_by_name(fn.return_type))
-    for variant in fn.variants:
-        _walk_function(variant, found, seen)
-    if fn.body is not None:
-        _walk(fn.body, found, seen)
+class _DimVarCollector(ExprWalker[None]):
+    """Collect dimensions from Expr values plus Function/Op side fields."""
 
+    def __init__(self, found: dict[str, object]) -> None:
+        super().__init__()
+        self.found = found
+        self.seen_functions: set[int] = set()
 
-def _walk(expr: object, found: dict[str, object], seen: set[int], depth: int = 0) -> None:
-    from tilefoundry.ir.types.substitute import _collect  # noqa: PLC0415
+    def _collect_expr(self, expr: Expr) -> None:
+        from tilefoundry.ir.types.substitute import _collect  # noqa: PLC0415
 
-    if expr is None or depth > 256:
-        return
-    _collect(getattr(expr, "type", None), found)
-    target = getattr(expr, "target", None)
-    if isinstance(target, Function):
-        _walk_function(target, found, seen)
-    elif target is not None:
+        _collect(expr.type, self.found)
+
+    def _collect_target(self, expr: Call) -> None:
+        target = expr.target
+        if isinstance(target, Function):
+            self.visit_function(target)
+            return
         for attribute in getattr(type(target), "params", lambda: ())():
             if attribute.kind == "attribute":
-                _collect_entries(getattr(target, attribute.name, None), found)
-    for name in ("args", "elements", "init_args", "yield_values", "carried_args"):
-        for child in getattr(expr, name, ()) or ():
-            _walk(child, found, seen, depth + 1)
-    for bound in ("extent", "step", "start"):
-        _collect_entries(getattr(expr, bound, None), found)
-    _walk(getattr(expr, "body", None), found, seen, depth + 1)
+                _collect_entries(getattr(target, attribute.name, None), self.found)
+
+    def _collect_bounds(self, expr: Expr) -> None:
+        for bound in ("extent", "step", "start"):
+            _collect_entries(getattr(expr, bound, None), self.found)
+
+    def _visit_children(self, expr: Expr) -> None:
+        for child in (
+            getattr(expr, "args", ())
+            + getattr(expr, "elements", ())
+            + getattr(expr, "init_args", ())
+            + getattr(expr, "yield_values", ())
+            + getattr(expr, "carried_args", ())
+        ):
+            self.visit(child)
+        body = getattr(expr, "body", None)
+        if body is not None:
+            self.visit(body)
+
+    def visit_function(self, fn: Function) -> None:
+        if id(fn) in self.seen_functions:
+            return
+        self.seen_functions.add(id(fn))
+        for param in fn.params:
+            self.found.update(dim_vars_by_name(param.type))
+        self.found.update(dim_vars_by_name(fn.return_type))
+        for variant in fn.variants:
+            self.visit_function(variant)
+        if fn.body is not None:
+            self.visit(fn.body)
+
+    def visit_Call(self, expr: Call) -> None:
+        self._collect_expr(expr)
+        self._collect_target(expr)
+        self._collect_bounds(expr)
+        self._visit_children(expr)
+
+    def visit_Tuple(self, expr: Tuple) -> None:
+        self._collect_expr(expr)
+        self._visit_children(expr)
+
+    def visit_GridRegionExpr(self, expr: GridRegionExpr) -> None:
+        self._collect_expr(expr)
+        self._collect_bounds(expr)
+        self._visit_children(expr)
+
+    def visit_Function(self, expr: Function) -> None:
+        self.visit_function(expr)
+
+    def visit_Var(self, expr: Var) -> None:
+        self._collect_expr(expr)
+
+    def visit_Constant(self, expr: Constant) -> None:
+        self._collect_expr(expr)
+
+    def visit_SymbolRef(self, expr: Expr) -> None:
+        self._collect_expr(expr)
+
+    def visit_ShapeOf(self, expr: Expr) -> None:
+        self._collect_expr(expr)
 
 
 def _collect_entries(value: object, found: dict[str, object]) -> None:
@@ -282,49 +333,85 @@ def _collect_entries(value: object, found: dict[str, object]) -> None:
 
 def is_concrete(fn: Function) -> bool:
     """Whether *fn* states extents everywhere a size is required."""
-    return not _function_has_symbolic_dims(fn, set())
+    return not _SymbolicDimVisitor().visit_function(fn)
 
 
-def _function_has_symbolic_dims(fn: Function, seen: set[int]) -> bool:
-    if id(fn) in seen:
-        return False
-    seen.add(id(fn))
-    if any(has_symbolic_dims(param.type) for param in fn.params):
-        return True
-    if has_symbolic_dims(fn.return_type):
-        return True
-    if any(_function_has_symbolic_dims(variant, seen) for variant in fn.variants):
-        return True
-    return _expr_has_symbolic_dims(fn.body, seen)
+class _SymbolicDimVisitor(ExprVisitor[bool]):
+    """Detect symbolic dimensions across Expr values and Function side fields."""
 
+    def __init__(self) -> None:
+        super().__init__()
+        self.seen_functions: set[int] = set()
 
-def _expr_has_symbolic_dims(expr: object, seen: set[int], depth: int = 0) -> bool:
-    if expr is None or depth > 256:
-        return False
-    if has_symbolic_dims(getattr(expr, "type", None)):
-        return True
-    target = getattr(expr, "target", None)
-    if isinstance(target, Function):
-        if _function_has_symbolic_dims(target, seen):
+    def _expr_has_symbolic(self, expr: Expr) -> bool:
+        if has_symbolic_dims(expr.type):
             return True
-    elif target is not None:
-        for attribute in getattr(type(target), "params", lambda: ())():
-            if attribute.kind == "attribute" and has_symbolic_dims(
-                getattr(target, attribute.name, None)
-            ):
+        for bound in ("extent", "step", "start"):
+            if has_symbolic_dims(getattr(expr, bound, None)):
                 return True
-    for name in ("args", "elements", "init_args", "yield_values", "carried_args"):
-        if any(
-            _expr_has_symbolic_dims(child, seen, depth + 1)
-            for child in getattr(expr, name, ()) or ()
-        ):
+        return False
+
+    def _target_has_symbolic(self, target) -> bool:
+        if isinstance(target, Function):
+            return self.visit_function(target)
+        return any(
+            attribute.kind == "attribute"
+            and has_symbolic_dims(getattr(target, attribute.name, None))
+            for attribute in getattr(type(target), "params", lambda: ())()
+        )
+
+    def _children_have_symbolic(self, expr: Expr) -> bool:
+        children = (
+            getattr(expr, "args", ())
+            + getattr(expr, "elements", ())
+            + getattr(expr, "init_args", ())
+            + getattr(expr, "yield_values", ())
+            + getattr(expr, "carried_args", ())
+        )
+        body = getattr(expr, "body", None)
+        return any(self.visit(child) for child in children) or (
+            body is not None and self.visit(body)
+        )
+
+    def visit_function(self, fn: Function) -> bool:
+        if id(fn) in self.seen_functions:
+            return False
+        self.seen_functions.add(id(fn))
+        if any(has_symbolic_dims(param.type) for param in fn.params):
             return True
-    if any(
-        has_symbolic_dims(getattr(expr, bound, None))
-        for bound in ("extent", "step", "start")
-    ):
-        return True
-    return _expr_has_symbolic_dims(getattr(expr, "body", None), seen, depth + 1)
+        if has_symbolic_dims(fn.return_type):
+            return True
+        if any(self.visit_function(variant) for variant in fn.variants):
+            return True
+        return fn.body is not None and self.visit(fn.body)
+
+    def visit_Call(self, expr: Call) -> bool:
+        return (
+            self._expr_has_symbolic(expr)
+            or self._target_has_symbolic(expr.target)
+            or self._children_have_symbolic(expr)
+        )
+
+    def visit_Tuple(self, expr: Tuple) -> bool:
+        return self._expr_has_symbolic(expr) or self._children_have_symbolic(expr)
+
+    def visit_GridRegionExpr(self, expr: GridRegionExpr) -> bool:
+        return self._expr_has_symbolic(expr) or self._children_have_symbolic(expr)
+
+    def visit_Function(self, expr: Function) -> bool:
+        return self.visit_function(expr)
+
+    def visit_Var(self, expr: Var) -> bool:
+        return self._expr_has_symbolic(expr)
+
+    def visit_Constant(self, expr: Constant) -> bool:
+        return self._expr_has_symbolic(expr)
+
+    def visit_SymbolRef(self, expr: Expr) -> bool:
+        return self._expr_has_symbolic(expr)
+
+    def visit_ShapeOf(self, expr: Expr) -> bool:
+        return self._expr_has_symbolic(expr)
 
 
 __all__ = [

--- a/src/tilefoundry/ir/hir/tensor/slice.py
+++ b/src/tilefoundry/ir/hir/tensor/slice.py
@@ -26,6 +26,7 @@ from tilefoundry.ir.types.shard.shard_layout import (
     layout_axis_to_tensor_axis,
     split_target_axes,
 )
+from tilefoundry.ir.visitor import ExprVisitor
 from tilefoundry.visitor_registry import register_typeinfer
 from tilefoundry.visitor_registry.access_relation import (
     identity_relations,
@@ -78,6 +79,30 @@ def _constant_int(expr: Expr) -> int | None:
     return None
 
 
+class _WindowBaseVisitor(ExprVisitor[tuple[Expr | None, int]]):
+    def visit_Constant(self, expr: Constant) -> tuple[Expr | None, int]:
+        value = _constant_int(expr)
+        return (None, value) if value is not None else (expr, 0)
+
+    def visit_Call(self, expr: Call) -> tuple[Expr | None, int]:
+        if not isinstance(expr.target, (DimAdd, DimSub)):
+            return expr, 0
+        sign = 1 if isinstance(expr.target, DimAdd) else -1
+        left, right = expr.args
+        right_offset = _constant_int(right)
+        if right_offset is not None:
+            base, offset = self.visit(left)
+            return base, offset + sign * right_offset
+        left_offset = _constant_int(left)
+        if left_offset is not None and sign == 1:
+            base, offset = self.visit(right)
+            return base, offset + left_offset
+        return expr, 0
+
+    def default_visit(self, expr) -> tuple[Expr | None, int]:
+        return expr, 0
+
+
 def window_base(start: Expr) -> "tuple[Expr | None, int]":
     """Split a window start into the base it moves off and its constant offset.
 
@@ -90,18 +115,7 @@ def window_base(start: Expr) -> "tuple[Expr | None, int]":
     value = _constant_int(start)
     if value is not None:
         return None, value
-    if isinstance(start, Call) and isinstance(start.target, (DimAdd, DimSub)):
-        sign = 1 if isinstance(start.target, DimAdd) else -1
-        left, right = start.args
-        right_offset = _constant_int(right)
-        if right_offset is not None:
-            base, offset = window_base(left)
-            return base, offset + sign * right_offset
-        left_offset = _constant_int(left)
-        if left_offset is not None and sign == 1:
-            base, offset = window_base(right)
-            return base, offset + left_offset
-    return start, 0
+    return _WindowBaseVisitor().visit(start)
 
 
 def _dim_mul(left, right):

--- a/src/tilefoundry/ir/hir/tensor/topk.py
+++ b/src/tilefoundry/ir/hir/tensor/topk.py
@@ -38,6 +38,7 @@ from tilefoundry.ir.types.shard.shard_layout import (
     layout_axis_to_tensor_axis,
     shard_layout_of,
 )
+from tilefoundry.ir.visitor import ExprVisitor
 from tilefoundry.visitor_registry import register_typeinfer
 from tilefoundry.visitor_registry.access_relation import (
     AccessRelationResult,
@@ -87,6 +88,40 @@ def _static_dim_value(d) -> "int | None":
     return None
 
 
+class _DimUpperBoundVisitor(ExprVisitor[int | None]):
+    def visit_Constant(self, d: Constant) -> int | None:
+        value = d.value
+        return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+    def visit_DimVar(self, d: DimVar) -> int:
+        return d.hi - 1
+
+    def visit_Call(self, d: Call) -> int | None:
+        target = d.target
+        if isinstance(target, (DimMin, DimMax, DimAdd, DimMul)):
+            a_hi = self.visit(d.args[0])
+            b_hi = self.visit(d.args[1])
+            if a_hi is None or b_hi is None:
+                return None
+            if isinstance(target, DimMin):
+                return min(a_hi, b_hi)
+            if isinstance(target, DimMax):
+                return max(a_hi, b_hi)
+            if isinstance(target, DimAdd):
+                return a_hi + b_hi
+            return None if a_hi < 0 or b_hi < 0 else a_hi * b_hi
+        if isinstance(target, (DimFloorDiv, DimMod)):
+            a_hi = self.visit(d.args[0])
+            b_val = _static_dim_value(d.args[1])
+            if a_hi is None or b_val is None or b_val <= 0:
+                return None
+            return a_hi // b_val if isinstance(target, DimFloorDiv) else b_val - 1
+        return None
+
+    def default_visit(self, d) -> int | None:
+        return None
+
+
 def _dim_upper_bound(d) -> "int | None":
     """Return a best-effort inclusive static upper bound.
 
@@ -103,28 +138,8 @@ def _dim_upper_bound(d) -> "int | None":
     if isinstance(d, Constant):
         v = d.value
         return v if isinstance(v, int) and not isinstance(v, bool) else None
-    if isinstance(d, DimVar):
-        return d.hi - 1
-    if isinstance(d, Call):
-        target = d.target
-        if isinstance(target, (DimMin, DimMax, DimAdd, DimMul)):
-            a_hi = _dim_upper_bound(d.args[0])
-            b_hi = _dim_upper_bound(d.args[1])
-            if a_hi is None or b_hi is None:
-                return None
-            if isinstance(target, DimMin):
-                return min(a_hi, b_hi)
-            if isinstance(target, DimMax):
-                return max(a_hi, b_hi)
-            if isinstance(target, DimAdd):
-                return a_hi + b_hi
-            return None if a_hi < 0 or b_hi < 0 else a_hi * b_hi
-        if isinstance(target, (DimFloorDiv, DimMod)):
-            a_hi = _dim_upper_bound(d.args[0])
-            b_val = _static_dim_value(d.args[1])
-            if a_hi is None or b_val is None or b_val <= 0:
-                return None
-            return a_hi // b_val if isinstance(target, DimFloorDiv) else b_val - 1
+    if isinstance(d, (DimVar, Call)):
+        return _DimUpperBoundVisitor().visit(d)
     return None
 
 

--- a/src/tilefoundry/ir/hir/verify.py
+++ b/src/tilefoundry/ir/hir/verify.py
@@ -7,6 +7,7 @@ from tilefoundry.ir.tir.stmt import Stmt
 from tilefoundry.ir.types import TensorType
 from tilefoundry.ir.types.dim import DimVar
 from tilefoundry.ir.types.tensor_type import TupleType
+from tilefoundry.ir.visitor import ExprVisitor
 
 from .function import Function, canonical_specialization_signature
 
@@ -134,21 +135,33 @@ def _ingest_dim_vars(ty: object, bounds: dict[str, tuple[int, int]]) -> None:
             _ingest_dim_vars(field, bounds)
 
 
-def _ingest_shape_entry(entry: object, bounds: dict[str, tuple[int, int]]) -> None:
-    if isinstance(entry, DimVar):
-        prior = bounds.get(entry.name)
+class _SignatureDimVisitor(ExprVisitor[None]):
+    def __init__(self, bounds: dict[str, tuple[int, int]]) -> None:
+        super().__init__()
+        self.bounds = bounds
+
+    def visit_DimVar(self, entry: DimVar) -> None:
+        prior = self.bounds.get(entry.name)
         if prior is None:
-            bounds[entry.name] = (entry.lo, entry.hi)
+            self.bounds[entry.name] = (entry.lo, entry.hi)
         elif prior != (entry.lo, entry.hi):
             raise VerifyError(
                 f"inconsistent DimVar bounds for {entry.name!r} within "
                 f"function signature: [{prior[0]}, {prior[1]}) vs "
                 f"[{entry.lo}, {entry.hi})"
             )
-        return
-    if isinstance(entry, Call):
+
+    def visit_Call(self, entry: Call) -> None:
         for arg in entry.args:
-            _ingest_shape_entry(arg, bounds)
+            self.visit(arg)
+
+    def default_visit(self, entry) -> None:
+        return None
+
+
+def _ingest_shape_entry(entry: object, bounds: dict[str, tuple[int, int]]) -> None:
+    if isinstance(entry, (DimVar, Call)):
+        _SignatureDimVisitor(bounds).visit(entry)
 
 
 def _collect_param_dim_vars(fn: Function) -> dict[str, tuple[int, int]]:
@@ -199,12 +212,24 @@ def _verify_signature_dim_vars(fn: Function) -> None:
             )
 
 
-def _reject_stmt_nodes(expr: Expr) -> None:
-    if isinstance(expr, Stmt):
-        raise VerifyError(f"hir body contains a Stmt node {type(expr).__name__}; hir is expr-only")
-    if isinstance(expr, Call):
+class _StmtRejectingVisitor(ExprVisitor[None]):
+    def visit_Call(self, expr: Call) -> None:
         for arg in expr.args:
-            _reject_stmt_nodes(arg)
+            if isinstance(arg, Stmt):
+                raise VerifyError(
+                    f"hir body contains a Stmt node {type(arg).__name__}; hir is expr-only"
+                )
+            self.visit(arg)
+
+    def default_visit(self, expr) -> None:
+        if isinstance(expr, Stmt):
+            raise VerifyError(
+                f"hir body contains a Stmt node {type(expr).__name__}; hir is expr-only"
+            )
+
+
+def _reject_stmt_nodes(expr: Expr) -> None:
+    _StmtRejectingVisitor().visit(expr)
 
 
 __all__ = ["verify_function"]

--- a/src/tilefoundry/ir/tir/launch.py
+++ b/src/tilefoundry/ir/tir/launch.py
@@ -46,6 +46,54 @@ class Launch(Op):
     attrs = ParamDef(kind="attribute", default=LaunchAttrs())
 
 
+_LAUNCH_EXTENT_MUTATOR_TYPE = None
+
+
+def _launch_extent_mutator_type():
+    global _LAUNCH_EXTENT_MUTATOR_TYPE
+    if _LAUNCH_EXTENT_MUTATOR_TYPE is None:
+        from tilefoundry.ir.visitor import ExprMutator  # noqa: PLC0415
+
+        class _LaunchExtentMutator(ExprMutator):
+            def __init__(self, dimvar_src, dim_ops, i32, shape_of) -> None:
+                super().__init__()
+                self.dimvar_src = dimvar_src
+                self.dim_ops = dim_ops
+                self.i32 = i32
+                self.shape_of = shape_of
+
+            def visit_Constant(self, dim):
+                return dim
+
+            def visit_DimVar(self, dim):
+                src = self.dimvar_src.get(id(dim))
+                if src is None:
+                    raise ValueError(
+                        f"launch_call: launch extent references dimension variable "
+                        f"{dim.name!r}, which is not a bare axis of any forwarded "
+                        f"tensor argument; its runtime extent cannot be resolved"
+                    )
+                arg, axis = src
+                return self.shape_of(type=self.i32, param=arg, axis=axis)
+
+            def visit_Call(self, dim):
+                if not isinstance(dim.target, self.dim_ops):
+                    raise ValueError(
+                        f"launch_call: unsupported launch extent {type(dim).__name__}"
+                    )
+                from dataclasses import replace  # noqa: PLC0415
+
+                return replace(dim, args=tuple(self.visit(arg) for arg in dim.args))
+
+            def default_visit(self, dim):
+                raise ValueError(
+                    f"launch_call: unsupported launch extent {type(dim).__name__}"
+                )
+
+        _LAUNCH_EXTENT_MUTATOR_TYPE = _LaunchExtentMutator
+    return _LAUNCH_EXTENT_MUTATOR_TYPE
+
+
 def launch_call(
     callee,
     forwarded_args,
@@ -65,8 +113,6 @@ def launch_call(
 
     See [tir §2.3](docs/spec/tir.md#23-tir-ops).
     """
-    from dataclasses import replace  # noqa: PLC0415
-
     from tilefoundry.ir.core import Call, Constant  # noqa: PLC0415
     from tilefoundry.ir.tir.shape import ShapeOf  # noqa: PLC0415
     from tilefoundry.ir.tir.stmts import Evaluate  # noqa: PLC0415
@@ -117,20 +163,11 @@ def launch_call(
             raise ValueError(f"launch_call: bool is not a launch extent: {dim!r}")
         if isinstance(dim, int):
             return Constant(type=i64, value=dim)
-        if isinstance(dim, Constant):
-            return dim
-        if isinstance(dim, DimVar):
-            src = dimvar_src.get(id(dim))
-            if src is None:
-                raise ValueError(
-                    f"launch_call: launch extent references dimension variable "
-                    f"{dim.name!r}, which is not a bare axis of any forwarded "
-                    f"tensor argument; its runtime extent cannot be resolved"
-                )
-            arg, axis = src
-            return ShapeOf(type=i32, param=arg, axis=axis)
-        if isinstance(dim, Call) and isinstance(dim.target, _DIM_OPS):
-            return replace(dim, args=tuple(_canon(a) for a in dim.args))
+        if isinstance(dim, (Constant, DimVar, Call)):
+            mutator = _launch_extent_mutator_type()(
+                dimvar_src, _DIM_OPS, i32, ShapeOf
+            )
+            return mutator.visit(dim)
         raise ValueError(f"launch_call: unsupported launch extent {type(dim).__name__}")
 
     grid_e = tuple(_canon(d) for d in grid)

--- a/src/tilefoundry/ir/tir/verify.py
+++ b/src/tilefoundry/ir/tir/verify.py
@@ -34,6 +34,7 @@ from tilefoundry.ir.types.dim import (
 from tilefoundry.ir.types.shard.mesh import Mesh
 from tilefoundry.ir.types.shard.shard_layout import ShardLayout
 from tilefoundry.ir.types.storage import StorageKind
+from tilefoundry.ir.visitor import ExprVisitor
 from tilefoundry.target import CudaTarget
 from tilefoundry.utils.spec_ref import spec_ref_render
 from tilefoundry.visitor_registry import verify_stmt_registry
@@ -204,6 +205,28 @@ def _check_rank0_bool(ctx, stmt, expr):
         raise VerifyError(f"condition must be rank-0 bool, got {t}")
 
 
+class _AllocTensorRejectingVisitor(ExprVisitor[None]):
+    def __init__(self, *, at_letstmt_value: bool) -> None:
+        super().__init__()
+        self.at_letstmt_value = at_letstmt_value
+
+    def visit_Call(self, expr: Call) -> None:
+        if isinstance(expr.target, AllocTensorOp):
+            if not self.at_letstmt_value:
+                raise VerifyError(
+                    f"{spec_ref_render(_PRIM_FUNCTION)}: Call(AllocTensor, ...) may only appear "
+                    f"as a direct LetStmt.value; found nested inside another Expr"
+                )
+            self.at_letstmt_value = False
+            self.visit_operands(expr)
+            return
+        self.at_letstmt_value = False
+        self.visit_operands(expr)
+
+    def default_visit(self, expr) -> None:
+        return None
+
+
 def _reject_nested_alloc_tensor(expr: Expr, *, at_letstmt_value: bool) -> None:
     """Reject an ``AllocTensor`` call nested outside a ``LetStmt`` value.
 
@@ -211,18 +234,8 @@ def _reject_nested_alloc_tensor(expr: Expr, *, at_letstmt_value: bool) -> None:
 
     See [tir §1.3](docs/spec/tir.md#13-primfunction).
     """
-    if isinstance(expr, Call) and isinstance(expr.target, AllocTensorOp):
-        if at_letstmt_value:
-            for a in expr.args:
-                _reject_nested_alloc_tensor(a, at_letstmt_value=False)
-            return
-        raise VerifyError(
-            f"{spec_ref_render(_PRIM_FUNCTION)}: Call(AllocTensor, ...) may only appear "
-            f"as a direct LetStmt.value; found nested inside another Expr"
-        )
-    if isinstance(expr, Call):
-        for a in expr.args:
-            _reject_nested_alloc_tensor(a, at_letstmt_value=False)
+    visitor = _AllocTensorRejectingVisitor(at_letstmt_value=at_letstmt_value)
+    visitor.visit(expr)
 
 
 def _check_embedded_sharding(expr: Expr, scope, fn):
@@ -390,6 +403,48 @@ def _verify_symbol_call(stmt: Evaluate, fn, module_fn_map, ctx):
 _LAUNCH_EXTENT_OPS = (DimAdd, DimSub, DimMul, DimFloorDiv, DimMod, DimMin, DimMax)
 
 
+class _LaunchExtentVisitor(ExprVisitor[None]):
+    def __init__(self, extent_params, ref_name) -> None:
+        super().__init__()
+        self.extent_params = extent_params
+        self.ref_name = ref_name
+
+    def visit_Constant(self, extent: Constant) -> None:
+        if isinstance(extent.value, bool) or not isinstance(extent.value, int):
+            raise VerifyError(
+                f"Launch of {self.ref_name!r}: grid/block extent Constant must be an "
+                f"int, got {extent.value!r}"
+            )
+
+    def visit_ShapeOf(self, extent: ShapeOf) -> None:
+        param = self.extent_params.get(id(extent.param))
+        if param is None:
+            raise VerifyError(
+                f"Launch of {self.ref_name!r}: grid/block extent ShapeOf references "
+                f"{extent.param.name!r}, which is not a forwarded launch "
+                f"argument or host parameter"
+            )
+        rank = len(param.type.shape) if isinstance(param.type, TensorType) else 0
+        if not isinstance(param.type, TensorType) or not (0 <= extent.axis < rank):
+            raise VerifyError(
+                f"Launch of {self.ref_name!r}: grid/block extent ShapeOf axis "
+                f"{extent.axis} is out of range for {extent.param.name!r} "
+                f"(rank {rank})"
+            )
+
+    def visit_Call(self, extent: Call) -> None:
+        if not (isinstance(extent.target, _LAUNCH_EXTENT_OPS)):
+            self.default_visit(extent)
+            return
+        self.visit_operands(extent)
+
+    def default_visit(self, extent) -> None:
+        raise VerifyError(
+            f"Launch of {self.ref_name!r}: grid/block extent must be an integer "
+            f"Constant, ShapeOf, or dim-arithmetic Call, got {type(extent).__name__}"
+        )
+
+
 def _verify_launch_extent(extent, extent_params, ref_name) -> None:
     """Verify launch extent.
 
@@ -397,37 +452,9 @@ def _verify_launch_extent(extent, extent_params, ref_name) -> None:
     ``ShapeOf`` of a forwarded / entry tensor parameter, or a dim-arithmetic
     ``Call`` whose operands are themselves valid extents.
     """
-    if isinstance(extent, Constant):
-        if isinstance(extent.value, bool) or not isinstance(extent.value, int):
-            raise VerifyError(
-                f"Launch of {ref_name!r}: grid/block extent Constant must be an "
-                f"int, got {extent.value!r}"
-            )
+    if isinstance(extent, int) and not isinstance(extent, bool):
         return
-    if isinstance(extent, ShapeOf):
-        p = extent_params.get(id(extent.param))
-        if p is None:
-            raise VerifyError(
-                f"Launch of {ref_name!r}: grid/block extent ShapeOf references "
-                f"{extent.param.name!r}, which is not a forwarded launch "
-                f"argument or host parameter"
-            )
-        rank = len(p.type.shape) if isinstance(p.type, TensorType) else 0
-        if not isinstance(p.type, TensorType) or not (0 <= extent.axis < rank):
-            raise VerifyError(
-                f"Launch of {ref_name!r}: grid/block extent ShapeOf axis "
-                f"{extent.axis} is out of range for {extent.param.name!r} "
-                f"(rank {rank})"
-            )
-        return
-    if isinstance(extent, Call) and isinstance(extent.target, _LAUNCH_EXTENT_OPS):
-        for operand in extent.args:
-            _verify_launch_extent(operand, extent_params, ref_name)
-        return
-    raise VerifyError(
-        f"Launch of {ref_name!r}: grid/block extent must be an integer "
-        f"Constant, ShapeOf, or dim-arithmetic Call, got {type(extent).__name__}"
-    )
+    _LaunchExtentVisitor(extent_params, ref_name).visit(extent)
 
 
 def _verify_launch(stmt: Evaluate, fn, module_fn_map, ctx):

--- a/src/tilefoundry/ir/types/dim.py
+++ b/src/tilefoundry/ir/types/dim.py
@@ -166,6 +166,41 @@ def simplify_dim(op_cls: type[Op], args: tuple) -> Expr:
 
 _DIM_OP_TYPES = (DimAdd, DimSub, DimMul, DimFloorDiv, DimMod, DimMin, DimMax)
 
+_DIM_EXPR_VISITOR_TYPE = None
+_DIM_EXPR_VISITOR = None
+
+
+def _dim_expr_visitor_type():
+    global _DIM_EXPR_VISITOR_TYPE
+    if _DIM_EXPR_VISITOR_TYPE is None:
+        from ..visitor import ExprVisitor  # noqa: PLC0415
+
+        class _DimExprVisitor(ExprVisitor[bool]):
+            def visit_DimVar(self, value: DimVar) -> bool:
+                return True
+
+            def visit_Constant(self, value: Constant) -> bool:
+                return isinstance(value.value, int) and not isinstance(value.value, bool)
+
+            def visit_Call(self, value: Call) -> bool:
+                return isinstance(value.target, _DIM_OP_TYPES) and all(
+                    self.visit(arg) for arg in value.args
+                )
+
+            def default_visit(self, value) -> bool:
+                return False
+
+        _DIM_EXPR_VISITOR_TYPE = _DimExprVisitor
+    return _DIM_EXPR_VISITOR_TYPE
+
+
+def _dim_expr_visitor():
+    global _DIM_EXPR_VISITOR
+    if _DIM_EXPR_VISITOR is None:
+        _DIM_EXPR_VISITOR = _dim_expr_visitor_type()()
+    _DIM_EXPR_VISITOR.clear()
+    return _DIM_EXPR_VISITOR
+
 
 def is_dim_expr(value) -> bool:
     """True iff *value* is a valid static-or-symbolic dim expression.
@@ -181,12 +216,8 @@ def is_dim_expr(value) -> bool:
         return False
     if isinstance(value, int):
         return True
-    if isinstance(value, DimVar):
-        return True
-    if isinstance(value, Constant):
-        return isinstance(value.value, int) and not isinstance(value.value, bool)
-    if isinstance(value, Call):
-        return isinstance(value.target, _DIM_OP_TYPES) and all(is_dim_expr(a) for a in value.args)
+    if isinstance(value, (DimVar, Constant, Call)):
+        return _dim_expr_visitor().visit(value)
     return False
 
 

--- a/src/tilefoundry/ir/types/dim_isl.py
+++ b/src/tilefoundry/ir/types/dim_isl.py
@@ -64,6 +64,126 @@ def _bind_param(
     return name
 
 
+_RANGE_EXPR_VISITOR_TYPE = None
+_DIM_RANGE_VISITOR_TYPE = None
+
+
+def _range_expr_visitor_type():
+    global _RANGE_EXPR_VISITOR_TYPE
+    if _RANGE_EXPR_VISITOR_TYPE is None:
+        from tilefoundry.ir.visitor import ExprVisitor  # noqa: PLC0415
+
+        class _RangeExprVisitor(ExprVisitor[str]):
+            def __init__(self, params, param_map, identities) -> None:
+                super().__init__()
+                self.params = params
+                self.param_map = param_map
+                self.identities = identities
+
+            def visit_Constant(self, dim: Constant) -> str:
+                return str(int(dim.value))
+
+            def visit_DimVar(self, dim: DimVar) -> str:
+                return _bind_param(dim, self.params, self.param_map, self.identities)
+
+            def visit_Var(self, dim: Var) -> str:
+                return _bind_param(dim, self.params, self.param_map, self.identities)
+
+            def visit_Call(self, dim: Call) -> str:
+                op = type(dim.target)
+                if op not in _DIM_OP_TYPES:
+                    return _bind_param(dim, self.params, self.param_map, self.identities)
+                a, b = dim.args
+                if op is DimMul and not (_is_const(a) or _is_const(b)):
+                    name = _bind_param(dim, self.params, self.param_map, self.identities)
+                    if self.params[name] is None:
+                        self.params[name] = dim_range(dim)
+                    return name
+                if op in (DimFloorDiv, DimMod) and not _is_const(b):
+                    raise NotImplementedError(
+                        f"{op.__name__} by a symbolic divisor has no isl representation"
+                    )
+                sa = self.visit(a)
+                sb = self.visit(b)
+                if op is DimAdd:
+                    return f"({sa} + {sb})"
+                if op is DimSub:
+                    return f"({sa} - {sb})"
+                if op is DimMul:
+                    return f"({sa} * {sb})"
+                if op is DimFloorDiv:
+                    return f"floor({sa}/{sb})"
+                if op is DimMod:
+                    return f"({sa} mod {sb})"
+                if op is DimMax:
+                    return f"max({sa}, {sb})"
+                if op is DimMin:
+                    return f"min({sa}, {sb})"
+                raise AssertionError(f"unhandled dim op {op.__name__}")
+
+            def default_visit(self, value) -> str:
+                if isinstance(value, bool):
+                    raise TypeError("ShapeDim must not be bool")
+                if isinstance(value, int):
+                    return str(value)
+                if self.identities is None:
+                    raise TypeError(f"unsupported ShapeDim {type(value).__name__}")
+                return _bind_param(value, self.params, self.param_map, self.identities)
+
+        _RANGE_EXPR_VISITOR_TYPE = _RangeExprVisitor
+    return _RANGE_EXPR_VISITOR_TYPE
+
+
+def _dim_range_visitor_type():
+    global _DIM_RANGE_VISITOR_TYPE
+    if _DIM_RANGE_VISITOR_TYPE is None:
+        from tilefoundry.ir.visitor import ExprVisitor  # noqa: PLC0415
+
+        class _DimRangeVisitor(ExprVisitor[tuple[int, int]]):
+            def visit_Constant(self, value: Constant) -> tuple[int, int]:
+                number = int(value.value)
+                return number, number + 1
+
+            def visit_DimVar(self, value: DimVar) -> tuple[int, int]:
+                return value.lo, value.hi
+
+            def visit_Call(self, value: Call) -> tuple[int, int]:
+                if type(value.target) is DimMul:
+                    a, b = value.args
+                    if not (_is_const(a) or _is_const(b)):
+                        alo, ahi = self.visit(a)
+                        blo, bhi = self.visit(b)
+                        corners = (
+                            alo * blo,
+                            alo * (bhi - 1),
+                            (ahi - 1) * blo,
+                            (ahi - 1) * (bhi - 1),
+                        )
+                        return min(corners), max(corners) + 1
+                params: dict[str, tuple[int, int] | None] = {}
+                expr = _range_expr(value, params)
+                prefix = f"[{', '.join(params)}] -> " if params else ""
+                pw_aff = isl.pw_aff(prefix + f"{{ [{expr}] }}")
+                if params:
+                    bounds = " and ".join(
+                        f"{lo} <= {name} <= {hi - 1}"
+                        for name, bound in params.items()
+                        for lo, hi in (bound,)
+                    )
+                    pw_aff = pw_aff.intersect_params(isl.set(prefix + f"{{ : {bounds} }}"))
+                return int(pw_aff.min_val().num_si()), int(pw_aff.max_val().num_si()) + 1
+
+            def default_visit(self, value) -> tuple[int, int]:
+                if isinstance(value, bool):
+                    raise TypeError("ShapeDim must not be bool")
+                if isinstance(value, int):
+                    return value, value + 1
+                raise TypeError(f"unsupported ShapeDim {type(value).__name__}")
+
+        _DIM_RANGE_VISITOR_TYPE = _DimRangeVisitor
+    return _DIM_RANGE_VISITOR_TYPE
+
+
 def _range_expr(
     dim,
     params: dict[str, tuple[int, int] | None],
@@ -71,45 +191,7 @@ def _range_expr(
     param_map: dict[str, object] | None = None,
     identities: dict[int, str] | None = None,
 ) -> str:
-    if isinstance(dim, bool):
-        raise TypeError("ShapeDim must not be bool")
-    if isinstance(dim, int):
-        return str(dim)
-    if isinstance(dim, Constant):
-        return str(int(dim.value))
-    if isinstance(dim, (DimVar, Var)):
-        return _bind_param(dim, params, param_map, identities)
-    if isinstance(dim, Call):
-        op = type(dim.target)
-        if op not in _DIM_OP_TYPES:
-            return _bind_param(dim, params, param_map, identities)
-        a, b = dim.args
-        if op is DimMul and not (_is_const(a) or _is_const(b)):
-            name = _bind_param(dim, params, param_map, identities)
-            if params[name] is None:
-                params[name] = dim_range(dim)
-            return name
-        if op in (DimFloorDiv, DimMod) and not _is_const(b):
-            raise NotImplementedError(
-                f"{op.__name__} by a symbolic divisor has no isl representation"
-            )
-        sa = _range_expr(a, params, param_map=param_map, identities=identities)
-        sb = _range_expr(b, params, param_map=param_map, identities=identities)
-        if op is DimAdd:
-            return f"({sa} + {sb})"
-        if op is DimSub:
-            return f"({sa} - {sb})"
-        if op is DimMul:
-            return f"({sa} * {sb})"
-        if op is DimFloorDiv:
-            return f"floor({sa}/{sb})"
-        if op is DimMod:
-            return f"({sa} mod {sb})"
-        if op is DimMax:
-            return f"max({sa}, {sb})"
-        if op is DimMin:
-            return f"min({sa}, {sb})"
-    raise TypeError(f"unsupported ShapeDim {type(dim).__name__}")
+    return _range_expr_visitor_type()(params, param_map, identities).visit(dim)
 
 
 def _raw_dim_call(op_cls, args: tuple):
@@ -208,39 +290,7 @@ def normalize_dim_entries(value):
 
 def dim_range(dim) -> tuple[int, int]:
     """Return conservative half-open value bounds ``[lo, hi)`` for *dim*."""
-    if isinstance(dim, bool):
-        raise TypeError("ShapeDim must not be bool")
-    if isinstance(dim, int):
-        return (dim, dim + 1)
-    if isinstance(dim, Constant):
-        value = int(dim.value)
-        return (value, value + 1)
-    if isinstance(dim, DimVar):
-        return (dim.lo, dim.hi)
-    if isinstance(dim, Call) and type(dim.target) is DimMul:
-        a, b = dim.args
-        if not (_is_const(a) or _is_const(b)):
-            alo, ahi = dim_range(a)
-            blo, bhi = dim_range(b)
-            corners = (
-                alo * blo,
-                alo * (bhi - 1),
-                (ahi - 1) * blo,
-                (ahi - 1) * (bhi - 1),
-            )
-            return (min(corners), max(corners) + 1)
-    params: dict[str, tuple[int, int] | None] = {}
-    expr = _range_expr(dim, params)
-    prefix = f"[{', '.join(params)}] -> " if params else ""
-    pw_aff = isl.pw_aff(prefix + f"{{ [{expr}] }}")
-    if params:
-        bounds = " and ".join(
-            f"{lo} <= {name} <= {hi - 1}"
-            for name, bound in params.items()
-            for lo, hi in (bound,)
-        )
-        pw_aff = pw_aff.intersect_params(isl.set(prefix + f"{{ : {bounds} }}"))
-    return (int(pw_aff.min_val().num_si()), int(pw_aff.max_val().num_si()) + 1)
+    return _dim_range_visitor_type()().visit(dim)
 
 
 def to_domain(extents: tuple) -> tuple:

--- a/src/tilefoundry/ir/types/substitute.py
+++ b/src/tilefoundry/ir/types/substitute.py
@@ -21,6 +21,72 @@ class DimSubstitutionError(ValueError):
     """A dimension was bound to something its declaration does not admit."""
 
 
+_DIM_COLLECTOR_TYPE = None
+_SHAPE_DIM_MUTATOR_TYPE = None
+
+
+def _dim_collector_type():
+    global _DIM_COLLECTOR_TYPE
+    if _DIM_COLLECTOR_TYPE is None:
+        from tilefoundry.ir.visitor import ExprWalker  # noqa: PLC0415
+
+        class _DimCollector(ExprWalker[None]):
+            def __init__(self, found) -> None:
+                super().__init__()
+                self.found = found
+
+            def visit_DimVar(self, expr: DimVar) -> None:
+                self.found[expr.name] = expr
+
+            def visit_Call(self, expr: Call) -> None:
+                if isinstance(expr.target, _DIM_OP_TYPES):
+                    self.visit_operands(expr)
+
+        _DIM_COLLECTOR_TYPE = _DimCollector
+    return _DIM_COLLECTOR_TYPE
+
+
+def _shape_dim_mutator_type():
+    global _SHAPE_DIM_MUTATOR_TYPE
+    if _SHAPE_DIM_MUTATOR_TYPE is None:
+        from tilefoundry.ir.visitor import ExprMutator  # noqa: PLC0415
+
+        class _ShapeDimMutator(ExprMutator):
+            def __init__(self, bindings) -> None:
+                super().__init__()
+                self.bindings = bindings
+
+            def visit(self, value):
+                if isinstance(value, bool):
+                    raise DimSubstitutionError(f"{value!r} is not a shape entry")
+                return super().visit(value)
+
+            def visit_DimVar(self, value):
+                if value.name not in self.bindings:
+                    return value
+                return _checked(value, self.bindings[value.name])
+
+            def visit_Constant(self, value):
+                return value
+
+            def visit_Call(self, value):
+                if not isinstance(value.target, _DIM_OP_TYPES):
+                    return value
+                args = tuple(self.visit(arg) for arg in value.args)
+                if args == value.args:
+                    return value
+                folded = normalize_dim(simplify_dim(type(value.target), args))
+                if isinstance(folded, Constant) and isinstance(folded.value, int):
+                    return int(folded.value)
+                return folded
+
+            def default_visit(self, value):
+                return value
+
+        _SHAPE_DIM_MUTATOR_TYPE = _ShapeDimMutator
+    return _SHAPE_DIM_MUTATOR_TYPE
+
+
 def dim_vars_in(value: object) -> tuple[str, ...]:
     """Every distinct `DimVar` name reachable from *value*, in first-seen order.
 
@@ -83,8 +149,7 @@ def _collect(value: object, found: dict[str, "DimVar"]) -> None:
         _collect_layout(value, found)
         return
     if isinstance(value, Call) and isinstance(value.target, _DIM_OP_TYPES):
-        for arg in value.args:
-            _collect(arg, found)
+        _dim_collector_type()(found).visit(value)
 
 
 def _collect_layout(layout: object, found: dict[str, "DimVar"]) -> None:
@@ -294,21 +359,8 @@ def substitute_shape_dim(entry: object, bindings: Mapping[str, int]) -> object:
         raise DimSubstitutionError(f"{entry!r} is not a shape entry")
     if isinstance(entry, int):
         return entry
-    if isinstance(entry, DimVar):
-        if entry.name not in bindings:
-            return entry
-        return _checked(entry, bindings[entry.name])
-    if isinstance(entry, Constant):
-        return entry
-    if isinstance(entry, Call) and isinstance(entry.target, _DIM_OP_TYPES):
-        args = tuple(substitute_shape_dim(arg, bindings) for arg in entry.args)
-        if args == tuple(entry.args):
-            return entry
-        folded = normalize_dim(simplify_dim(type(entry.target), args))
-
-        if isinstance(folded, Constant) and isinstance(folded.value, int):
-            return int(folded.value)
-        return folded
+    if isinstance(entry, (DimVar, Constant, Call)):
+        return _shape_dim_mutator_type()(bindings).visit(entry)
     return entry
 
 

--- a/src/tilefoundry/ir/visitor.py
+++ b/src/tilefoundry/ir/visitor.py
@@ -16,6 +16,7 @@ from tilefoundry.ir.core import Call, Constant, Expr, Tuple, Var
 from tilefoundry.ir.hir.grid_region import GridRegionExpr
 from tilefoundry.ir.tir.dispatch import DispatchCall
 from tilefoundry.ir.tir.prim_function import PrimFunction
+from tilefoundry.ir.tir.shape import ShapeOf
 from tilefoundry.ir.tir.stmt import Stmt
 from tilefoundry.ir.tir.stmts import (
     Abort,
@@ -31,7 +32,9 @@ from tilefoundry.ir.tir.stmts import (
 from tilefoundry.ir.tir.symbol_ref import SymbolRef
 
 __all__ = [
+    "ExprFunctor",
     "ExprVisitor",
+    "ExprWalker",
     "ExprMutator",
     "StmtVisitor",
     "StmtMutator",
@@ -183,32 +186,125 @@ def _stmt_expr_fields(stmt: Stmt) -> tuple[str, ...]:
             return ()
 
 
-class ExprVisitor[T]:
-    """Read-only Expr traversal. Override visit_<ClassName> to inject logic."""
+class ExprFunctor[T]:
+    """Expr dispatch without memoization.
+
+    Read-only visitors and identity-preserving mutators share this dispatch
+    layer. The first expression visited is retained as a diagnostic root; a
+    caller that enters through a function body must provide the Function root
+    explicitly through ``ExprVisitor(root_function=...)``.
+    """
+
+    def __init__(self) -> None:
+        self._root: Expr | None = None
 
     def visit(self, expr: Expr) -> T:
+        if self._root is None:
+            self._root = expr
+        return self.dispatch_visit(expr)
+
+    def dispatch_visit(self, expr: Expr) -> T:
         method = getattr(self, f"visit_{type(expr).__name__}", None)
         if method is not None:
             return method(expr)
-        return self.generic_visit(expr)
+        return self.default_visit(expr)
 
-    def generic_visit(self, expr: Expr) -> T:
-        """Default: recurse into all children; return None.
+    def default_visit(self, expr: Expr) -> T:
+        raise NotImplementedError(f"no visit routine for {type(expr).__name__}")
 
-        Default: recurse into all children; return None. Subclasses may
-        override to aggregate.
+    def clear(self) -> None:
+        self._root = None
+
+
+class ExprVisitor[T](ExprFunctor[T]):
+    """Read-only Expr traversal with identity-based DAG memoization."""
+
+    def __init__(
+        self,
+        *,
+        visit_other_functions: bool = False,
+        root_function: Expr | None = None,
+    ) -> None:
+        """Create a visitor with an identity memo and optional Function root.
+
+        The Expr in each memo value pins the object that owns the integer key.
+        Without that strong reference, Python may reuse an id after collection
+        and return a result belonging to a different expression.
         """
+        super().__init__()
+        self._root = root_function
+        self._visit_other_functions = visit_other_functions
+        self._memo: dict[int, tuple[Expr, T]] = {}
+
+    def dispatch_visit(self, expr: Expr) -> T:
+        hit = self._memo.get(id(expr))
+        if hit is not None:
+            return hit[1]
+        result = super().dispatch_visit(expr)
+        self._memo[id(expr)] = (expr, result)
+        return result
+
+    def visit_operands(self, expr: Expr) -> None:
+        """Visit value children from the fixed `_expr_children` table."""
         for child in _expr_children(expr):
             self.visit(child)
+
+    def can_visit_function_body(self, fn: Expr) -> bool:
+        return self._visit_other_functions or fn is self._root
+
+    def visit_function_body(self, fn: Expr) -> T:
+        """Enter `fn.body` while retaining `fn` as the explicit root."""
+        if self._root is None:
+            self._root = fn
+        if not self.can_visit_function_body(fn):
+            return None  # type: ignore[return-value]
+        body = getattr(fn, "body", None)
+        if body is None:
+            raise ValueError(f"cannot visit body of prototype {fn!r}")
+        return self.visit(body)
+
+    def clear(self) -> None:
+        self._memo.clear()
+        super().clear()
+
+
+class ExprWalker[T](ExprVisitor[T]):
+    """Memoized side-effect traversal for the known value Expr shapes."""
+
+    def visit_Call(self, call: Call) -> T:
+        self.visit_operands(call)
+        return None  # type: ignore[return-value]
+
+    def visit_Var(self, var: Var) -> T:
+        return None  # type: ignore[return-value]
+
+    def visit_Constant(self, const: Constant) -> T:
+        return None  # type: ignore[return-value]
+
+    def visit_SymbolRef(self, ref: SymbolRef) -> T:
+        return None  # type: ignore[return-value]
+
+    def visit_Tuple(self, tup: Tuple) -> T:
+        self.visit_operands(tup)
+        return None  # type: ignore[return-value]
+
+    def visit_GridRegionExpr(self, grid: GridRegionExpr) -> T:
+        self.visit_operands(grid)
+        return None  # type: ignore[return-value]
+
+    def visit_Function(self, fn: Expr) -> T:
+        self.visit_operands(fn)
+        return None  # type: ignore[return-value]
+
+    def visit_ShapeOf(self, shape: ShapeOf) -> T:
         return None  # type: ignore[return-value]
 
 
 def _dispatch(obj: Any, node: Any, generic: Callable[[Any], Any]) -> Any:
-    """`visit_<type(node).__name__>` dispatch, falling back to `generic`.
+    """Dispatch a statement or embedded expression, falling back to `generic`.
 
-    Shared by every `visit` / `visit_expr` entry point in this module —
-    only the fallback (a `generic_visit`-shaped bound method) differs
-    per caller.
+    Shared by statement visitors and ``StmtExprMutator``; ExprFunctor has its
+    own dispatch point so ExprVisitor can memoize it centrally.
     """
     method = getattr(obj, f"visit_{type(node).__name__}", None)
     if method is not None:
@@ -220,7 +316,7 @@ def _generic_expr_rewrite(expr: Expr, visit_fn: Callable[[Expr], Expr]) -> Expr:
     """Rebuild `expr` from `visit_fn`-rewritten children, preserving identity when no child changed.
 
     Rebuild `expr` from `visit_fn`-rewritten children, preserving
-    identity when no child changed. Shared by `ExprMutator.generic_visit`
+    identity when no child changed. Shared by `ExprMutator.default_visit`
     and `StmtExprMutator._expr_generic_visit`.
     """
     children = _expr_children(expr)
@@ -230,7 +326,7 @@ def _generic_expr_rewrite(expr: Expr, visit_fn: Callable[[Expr], Expr]) -> Expr:
     return _rebuild_expr(expr, new_children)
 
 
-class ExprMutator:
+class ExprMutator(ExprFunctor[Expr]):
     """Expr → Expr rewrite with identity preservation.
 
     Invariant: if every child visit returns an `is`-identical object, the
@@ -238,10 +334,7 @@ class ExprMutator:
     lets callers detect "did this pass change anything" via `new is old`.
     """
 
-    def visit(self, expr: Expr) -> Expr:
-        return _dispatch(self, expr, self.generic_visit)
-
-    def generic_visit(self, expr: Expr) -> Expr:
+    def default_visit(self, expr: Expr) -> Expr:
         return _generic_expr_rewrite(expr, self.visit)
 
 

--- a/src/tilefoundry/module.py
+++ b/src/tilefoundry/module.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import inspect
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from types import FrameType
 
 
@@ -29,6 +29,9 @@ UNDECLARED = _Undeclared()
 class _Entry:
     topologies: tuple | None
     frame: FrameType
+    owner_name: str | None = None
+    bound: dict[str, "ParsedFuncKind"] = field(default_factory=dict)
+    owned: set[int] = field(default_factory=set)
 
 
 _DECLARING: list[_Entry] = []
@@ -45,6 +48,7 @@ def enclosing_declaration(frame: FrameType | None) -> _Entry | None:
         if "__qualname__" in frame.f_locals:
             for entry in reversed(_DECLARING):
                 if entry.frame is frame.f_back:
+                    entry.owner_name = frame.f_locals["__qualname__"].rsplit(".", 1)[-1]
                     return entry
         elif frame.f_code.co_name == "<module>":
             return None
@@ -62,32 +66,34 @@ def _retarget_module_calls(owner: str, functions, attached: dict) -> None:
     and collecting it would leave the call pointing outside the tree being built.
     """
     from tilefoundry.ir.core import (  # noqa: PLC0415 — avoid import cycle
+        Expr,
         FunctionScope,
         TypeInferContext,
         get_metadata,
     )
     from tilefoundry.ir.core.expr import (  # noqa: PLC0415 — avoid import cycle
         Call,
-        child_exprs,
     )
     from tilefoundry.ir.hir.function import Function as HirFunction  # noqa: PLC0415
     from tilefoundry.ir.hir.function import elaborate  # noqa: PLC0415
+    from tilefoundry.ir.visitor import ExprWalker  # noqa: PLC0415
     from tilefoundry.parser.base import _ModuleCallee  # noqa: PLC0415
 
-    seen: set[int] = set()
     unattached: list[str] = []
 
-    def visit(expr) -> None:
-        if expr is None or id(expr) in seen:
-            return
-        seen.add(id(expr))
-        if isinstance(expr, Call) and isinstance(expr.target, HirFunction):
+    class _RetargetVisitor(ExprWalker[None]):
+        def visit(self, expr):
+            if expr is None or not isinstance(expr, Expr):
+                return None
+            return super().visit(expr)
+
+        def visit_Call(self, expr: Call) -> None:
             record = get_metadata(expr, _ModuleCallee)
-            if record is None:
-                visit(expr.target)
-            elif record.binding not in attached:
+            if isinstance(expr.target, HirFunction) and record is None:
+                self.visit(expr.target)
+            elif isinstance(expr.target, HirFunction) and record.binding not in attached:
                 unattached.append(record.binding)
-            else:
+            elif isinstance(expr.target, HirFunction):
                 child = attached[record.binding]
                 entry = child.entry_function()
                 object.__setattr__(
@@ -115,14 +121,19 @@ def _retarget_module_calls(owner: str, functions, attached: dict) -> None:
                     "metadata",
                     tuple(m for m in expr.metadata if not isinstance(m, _ModuleCallee)),
                 )
-            for arg in expr.args:
-                visit(arg)
-            return
-        for child in child_exprs(expr):
-            visit(child)
+            self.visit_operands(expr)
 
+        def visit_Function(self, fn) -> None:
+            self.visit_operands(fn)
+            for variant in fn.variants:
+                self.visit(variant)
+            for converter in fn.converters:
+                if isinstance(converter, tuple):
+                    self.visit(converter[-1])
+
+    visitor = _RetargetVisitor()
     for fn in functions:
-        visit(fn)
+        visitor.visit(fn)
     if unattached:
         raise ValueError(
             f"@module {owner!r}: call(s) to Module(s) {sorted(set(unattached))} that "
@@ -218,12 +229,9 @@ def module(
                 f"@module class body may contain only these three member kinds"
             )
 
-        converter_fns = {
-            conv for fn in functions for _, conv in getattr(fn, "converters", ())
-        }
         functions = [
             fn for fn in functions
-            if not getattr(fn, "specializations", ()) and fn not in converter_fns
+            if id(fn) not in mine.owned and not getattr(fn, "specializations", ())
         ]
         if not functions and not child_modules and not methods:
             raise TypeError(

--- a/src/tilefoundry/passes/transforms/hir_to_tir.py
+++ b/src/tilefoundry/passes/transforms/hir_to_tir.py
@@ -12,7 +12,6 @@ from dataclasses import dataclass, replace
 from typing import Union
 
 from tilefoundry.ir.core import Call, Constant, Expr, Tuple, Var
-from tilefoundry.ir.core.expr import child_exprs
 from tilefoundry.ir.core.module import Module
 from tilefoundry.ir.core.pattern import DimVarRangePat, locate_dim_var
 from tilefoundry.ir.hir.cuda.nn.mma import (
@@ -91,7 +90,7 @@ from tilefoundry.ir.types.shard.shard_layout import (
     layout_axis_to_tensor_axis as _layout_axis_to_tensor_axis,
 )
 from tilefoundry.ir.types.storage import StorageKind
-from tilefoundry.ir.visitor import ExprVisitor
+from tilefoundry.ir.visitor import ExprFunctor, ExprVisitor, ExprWalker
 from tilefoundry.passes.pass_base import ModulePass
 from tilefoundry.target import CudaTarget, Target, default_target
 from tilefoundry.visitor_registry.registries import (
@@ -100,27 +99,57 @@ from tilefoundry.visitor_registry.registries import (
 )
 
 
+class _InductionSliceVisitor(ExprVisitor[bool]):
+    def __init__(self, induction_var: Var) -> None:
+        super().__init__()
+        self.induction_var = induction_var
+
+    def visit_Call(self, expr: Call) -> bool:
+        if isinstance(expr.target, HirSlice):
+            starts = expr.args[1]
+            if isinstance(starts, Tuple) and any(
+                window_base(start)[0] is self.induction_var for start in starts.elements
+            ):
+                return True
+        target = expr.target
+        return any(
+            self.visit(child)
+            for child in ((*target,) if isinstance(target, HirFunction) else ())
+            + expr.args
+        )
+
+    def visit_Function(self, expr: HirFunction) -> bool:
+        children = () if expr.body is None else (expr.body,)
+        children += expr.variants
+        children += tuple(converter for _, converter in expr.converters)
+        return any(self.visit(child) for child in children)
+
+    def visit_Tuple(self, expr: Tuple) -> bool:
+        return any(self.visit(element) for element in expr.elements)
+
+    def visit_GridRegionExpr(self, expr: GridRegionExpr) -> bool:
+        return any(
+            self.visit(value)
+            for value in (*expr.init_args, expr.body, *expr.yield_values, *expr.carried_args)
+        )
+
+    def visit_Var(self, expr: Var) -> bool:
+        return False
+
+    def visit_Constant(self, expr: Constant) -> bool:
+        return False
+
+    def default_visit(self, expr) -> bool:
+        return False
+
+
 def _has_induction_slice(root: Expr, induction_var: Var) -> bool:
     """Whether ``root`` contains a Slice starting at ``induction_var``.
 
     A window moved by a compile-time offset is still that loop's window, so a
     tail it cannot read is still that loop's tail.
     """
-    seen: set[int] = set()
-
-    def visit(expr: Expr) -> bool:
-        if id(expr) in seen:
-            return False
-        seen.add(id(expr))
-        if isinstance(expr, Call) and isinstance(expr.target, HirSlice):
-            starts = expr.args[1]
-            if isinstance(starts, Tuple) and any(
-                window_base(start)[0] is induction_var for start in starts.elements
-            ):
-                return True
-        return any(visit(child) for child in child_exprs(expr))
-
-    return visit(root)
+    return _InductionSliceVisitor(induction_var).visit(root)
 
 
 def _reject_partial_window(region: GridRegionExpr) -> None:
@@ -635,23 +664,46 @@ class _Lowerer:
         (the gmem alias root), or ``None``. Used by the cross-CTA
         sync-then-reshard rule in ``_lower_reshard``.
         """
-        if _depth > 64:
-            return None
-        if isinstance(expr, Var):
-            if id(expr) in self._carry_init:
-                return self._param_alias_root(
-                    self._carry_init[id(expr)], _depth + 1
-                )
-            return expr if self._cache.get(id(expr)) is expr else None
-        if isinstance(expr, GridRegionExpr):
-            for a in expr.init_args:
-                r = self._param_alias_root(a, _depth + 1)
-                if r is not None:
-                    return r
-            return None
-        if isinstance(getattr(expr, "target", None), Reshard):
-            return self._param_alias_root(expr.args[0], _depth + 1)
-        return None
+        class _AliasVisitor(ExprVisitor[Var | None]):
+            def __init__(self, owner) -> None:
+                super().__init__()
+                self.owner = owner
+                self.depth = _depth
+
+            def _recurse(self, value):
+                self.depth += 1
+                try:
+                    return self.visit(value)
+                finally:
+                    self.depth -= 1
+
+            def dispatch_visit(self, value):
+                if self.depth > 64:
+                    return None
+                return ExprFunctor.dispatch_visit(self, value)
+
+            def visit_Var(self, value: Var) -> Var | None:
+                initial = self.owner._carry_init.get(id(value))
+                if initial is not None:
+                    return self._recurse(initial)
+                return value if self.owner._cache.get(id(value)) is value else None
+
+            def visit_GridRegionExpr(self, value: GridRegionExpr) -> Var | None:
+                for initial in value.init_args:
+                    result = self._recurse(initial)
+                    if result is not None:
+                        return result
+                return None
+
+            def visit_Call(self, value: Call) -> Var | None:
+                if isinstance(value.target, Reshard):
+                    return self._recurse(value.args[0])
+                return None
+
+            def default_visit(self, value) -> Var | None:
+                return None
+
+        return _AliasVisitor(self).visit(expr) if expr is not None else None
 
 
     def _lower_hir_call(self, call: Call, callee_hir: HirFunction) -> Var:
@@ -1216,6 +1268,20 @@ def _insert_slice_coord(ctx: "_Lowerer", off_expr):
     return ctx.lower(off_expr)
 
 
+class _CoordinateArithmeticVisitor(ExprVisitor[bool]):
+    def visit_Constant(self, expr: Constant) -> bool:
+        return True
+
+    def visit_Var(self, expr: Var) -> bool:
+        return True
+
+    def visit_Call(self, expr: Call) -> bool:
+        return is_dim_op_call(expr) and all(self.visit(arg) for arg in expr.args)
+
+    def default_visit(self, expr) -> bool:
+        return False
+
+
 def _is_coordinate_arithmetic(expr) -> bool:
     """Whether *expr* is dim arithmetic over literals and scalar Vars.
 
@@ -1224,10 +1290,9 @@ def _is_coordinate_arithmetic(expr) -> bool:
     """
     if not is_dim_op_call(expr):
         return False
-    return all(
-        isinstance(arg, (Constant, Var)) or _is_coordinate_arithmetic(arg)
-        for arg in expr.args
-    )
+    if isinstance(expr, Call):
+        return _CoordinateArithmeticVisitor().visit(expr)
+    return False
 
 
 @register_hir_lowering(HirSlice)
@@ -1737,7 +1802,7 @@ def _build_dispatch_entry(
     )
 
 
-class _MeshDeriver(ExprVisitor[None]):
+class _MeshDeriver(ExprWalker[None]):
     """Walk a HIR expression to find meshes, keyed by topology name.
 
     ``cta_mesh`` / ``thread_mesh`` hold the first mesh found for each
@@ -1746,6 +1811,7 @@ class _MeshDeriver(ExprVisitor[None]):
     """
 
     def __init__(self) -> None:
+        super().__init__()
         self.cta_mesh: Mesh | None = None
         self.thread_mesh: Mesh | None = None
 
@@ -1772,7 +1838,7 @@ class _MeshDeriver(ExprVisitor[None]):
 
 
                 self.thread_mesh = m
-        self.generic_visit(call)
+        self.visit_operands(call)
 
 
 def _derive_meshes_from_body(expr) -> tuple[Mesh | None, Mesh | None]:
@@ -1786,17 +1852,18 @@ def _derive_meshes_from_body(expr) -> tuple[Mesh | None, Mesh | None]:
     return deriver.cta_mesh, deriver.thread_mesh
 
 
-class _CalleeCollector(ExprVisitor[None]):
+class _CalleeCollector(ExprWalker[None]):
     """Collect the set of HIR function names called anywhere in an Expr."""
 
     def __init__(self) -> None:
+        super().__init__()
         self.found: set[str] = set()
 
     def visit_Call(self, call: Call) -> None:
         tgt = call.target
         if isinstance(tgt, HirFunction):
             self.found.add(tgt.name)
-        self.generic_visit(call)
+        self.visit_operands(call)
 
 
 def _collect_hir_callee_names(expr) -> set[str]:

--- a/src/tilefoundry/schedule/partition/problem.py
+++ b/src/tilefoundry/schedule/partition/problem.py
@@ -41,6 +41,7 @@ from tilefoundry.ir.types.shard import (
     try_c_order_strides,
 )
 from tilefoundry.ir.types.storage import StorageKind
+from tilefoundry.ir.visitor import ExprMutator
 from tilefoundry.visitor_registry.contexts import (
     Cost,
     CostContext,
@@ -357,18 +358,27 @@ class _Closer:
                 )
 
     def _retag(self, expr: Expr, types: "itertools.chain | object") -> Expr:
-        if isinstance(expr, Tuple):
-            new_elements = tuple(self._retag(element, types) for element in expr.elements)
-            if new_elements == expr.elements:
-                return expr
-            return replace(expr, elements=new_elements)
-        if isinstance(expr.type, TensorType):
-            try:
-                type = next(types)  # type: ignore[call-overload]
-            except StopIteration:
-                return expr
-            return replace(expr, type=type)
-        return expr
+        class _RetagMutator(ExprMutator):
+            def __init__(self, type_iter) -> None:
+                super().__init__()
+                self.type_iter = type_iter
+
+            def visit_Tuple(self, value: Tuple) -> Expr:
+                new_elements = tuple(self.visit(element) for element in value.elements)
+                if new_elements == value.elements:
+                    return value
+                return replace(value, elements=new_elements)
+
+            def default_visit(self, value: Expr) -> Expr:
+                if isinstance(value.type, TensorType):
+                    try:
+                        type = next(self.type_iter)  # type: ignore[call-overload]
+                    except StopIteration:
+                        return value
+                    return replace(value, type=type)
+                return value
+
+        return _RetagMutator(types).visit(expr)
 
     def _candidate_call(
         self, site: OperationSite, input_types: tuple[Type, ...]

--- a/src/tilefoundry/schedule/partition/program.py
+++ b/src/tilefoundry/schedule/partition/program.py
@@ -33,6 +33,7 @@ from tilefoundry.ir.types import TensorType, TupleType, Type
 from tilefoundry.ir.types.shape_helpers import static_dim_value
 from tilefoundry.ir.types.shard import Mesh, ShardLayout, Split
 from tilefoundry.ir.types.storage import StorageKind
+from tilefoundry.ir.visitor import ExprVisitor, ExprWalker
 
 from .facts import PartitionFactsQuery
 
@@ -41,6 +42,125 @@ ValueRole = Literal["normal", "carry", "yield", "result"]
 
 class PartitionProgramError(ValueError):
     """The authored program cannot be extracted into a partition program."""
+
+
+class _ProcessExprVisitor(ExprVisitor[tuple[int, ...]]):
+    """Process one Expr context while the owner keeps partition side effects."""
+
+    def __init__(self, owner, function, function_path, env) -> None:
+        super().__init__()
+        self.owner = owner
+        self.function = function
+        self.function_path = function_path
+        self.env = env
+
+    def _key(self, expr: Expr) -> tuple[tuple[int, ...], int]:
+        return self.function_path, id(expr)
+
+    def visit(self, expr: Expr) -> tuple[int, ...]:
+        cached = self.owner._expr_values.get(self._key(expr))
+        if cached is not None:
+            return cached
+        return super().visit(expr)
+
+    def visit_Var(self, expr: Var) -> tuple[int, ...]:
+        key = self._key(expr)
+        refs = self.env.get(id(expr))
+        if refs is None:
+            refs = self.owner._param_values.get(key, ())
+        self.owner._expr_values[key] = refs
+        return refs
+
+    def visit_Constant(self, expr: Constant) -> tuple[int, ...]:
+        self.owner._expr_values[self._key(expr)] = ()
+        return ()
+
+    def visit_Tuple(self, expr: Tuple) -> tuple[int, ...]:
+        refs = tuple(ref for element in expr.elements for ref in self.visit(element))
+        key = self._key(expr)
+        self.owner._expr_values[key] = refs
+        self.owner._record_requirement(refs, expr)
+        return refs
+
+    def visit_GridRegionExpr(self, expr: GridRegionExpr) -> tuple[int, ...]:
+        refs = self.owner._process_region(
+            expr, self.function, self.function_path, self.env
+        )
+        key = self._key(expr)
+        self.owner._expr_values[key] = refs
+        self.owner._record_requirement(refs, expr)
+        return refs
+
+    def visit_Call(self, expr: Call) -> tuple[int, ...]:
+        key = self._key(expr)
+        arg_refs = tuple(self.visit(arg) for arg in expr.args)
+        target = expr.target
+        if isinstance(target, Function):
+            call_path = self.function_path + (len(self.owner.function_instances),)
+            helper_env = dict(zip((id(param) for param in target.params), arg_refs))
+            self.owner._process_function(target, call_path, helper_env, parent_call=expr)
+            refs = self.owner._process_expr(target.body, target, call_path, helper_env)
+            self.owner._expr_values[key] = refs
+            self.owner._record_requirement(refs, expr)
+            return refs
+        if isinstance(target, (PrimFunction, Launch, SymbolRef)):
+            raise PartitionProgramError(
+                f"kernel boundary {type(target).__name__} at "
+                f"{expr_location(expr)} is not a partitioned operation"
+            )
+        if is_induction_var_singleton_reshape(expr):
+            refs = arg_refs[0] if arg_refs else ()
+            self.owner._expr_values[key] = refs
+            self.owner._record_requirement(refs, expr)
+            return refs
+        if isinstance(target, TupleGetItem):
+            source_refs = arg_refs[0] if arg_refs else ()
+            fields = tensor_leaves(expr.args[0].type)
+            index = target.index
+            if index < 0 or index >= len(fields):
+                raise PartitionProgramError(
+                    f"TupleGetItem index {index} is out of range at "
+                    f"{expr_location(expr)}"
+                )
+            start = sum(
+                len(tensor_leaves(field))
+                for field in expr.args[0].type.fields[:index]  # type: ignore[union-attr]
+            )
+            refs = source_refs[
+                start : start
+                + len(tensor_leaves(expr.args[0].type.fields[index]))  # type: ignore[union-attr]
+            ]
+            self.owner._expr_values[key] = refs
+            self.owner._record_requirement(refs, expr)
+            return refs
+        site_id = self.owner._next_site
+        self.owner._next_site += 1
+        output_refs = tuple(
+            self.owner._new_value(
+                expr, type, path, self.function_path, producer_site_id=site_id
+            )
+            for path, type in tensor_leaves(expr.type)
+        )
+        self.owner.sites.append(
+            OperationSite(site_id, expr, self.function_path, arg_refs, output_refs)
+        )
+        self.owner.site_order.append(site_id)
+        self.owner.site_enclosing_regions[site_id] = (
+            self.owner._active_regions[-1] if self.owner._active_regions else None
+        )
+        if self.owner._active_regions:
+            region_id = self.owner._active_regions[-1]
+            info = self.owner.regions[region_id]
+            self.owner.regions[region_id] = replace(
+                info, operation_site_ids=(*info.operation_site_ids, site_id)
+            )
+        self.owner._expr_values[key] = output_refs
+        self.owner._record_requirement(output_refs, expr)
+        return output_refs
+
+    def default_visit(self, expr: Expr) -> tuple[int, ...]:
+        self.owner._expr_values[self._key(expr)] = ()
+        return ()
 
 
 def expr_location(expr: Expr) -> str:
@@ -193,14 +313,21 @@ class _Extractor:
                         ):
                             record(tensor.layout.layout.shape[attr.axis])
                     for dim in tensor.layout.mesh.layout.shape:
-                        record(dim)
+                            record(dim)
 
-        def visit_expr(expr: Expr | None) -> None:
-            if expr is None:
-                return
-            visit_type(expr.type)
-            metadata = constraint_metadata(expr)
-            if metadata is not None:
+        owner = self
+
+        class _ExtentVisitor(ExprWalker[None]):
+            def visit(self, expr):
+                if expr is not None and not isinstance(expr, Function):
+                    self._record_expr(expr)
+                return super().visit(expr)
+
+            def _record_expr(self, expr: Expr) -> None:
+                visit_type(expr.type)
+                metadata = constraint_metadata(expr)
+                if metadata is None:
+                    return
                 for constraint in metadata.constraints:
                     if isinstance(constraint, LayoutConstraint):
                         for _, attr in constraint.bindings:
@@ -209,30 +336,46 @@ class _Extractor:
                             ):
                                 record(constraint.layout.shape[attr.axis])
                     elif isinstance(constraint, MeshConstraint) and constraint.mesh is not None:
-                        self.required_meshes.append(constraint.mesh)
+                        owner.required_meshes.append(constraint.mesh)
                         for dim in constraint.mesh.layout.shape:
                             record(dim)
-            if isinstance(expr, Call):
+
+            def visit_function(self, function: Function) -> None:
+                if id(function) in seen_functions:
+                    return
+                seen_functions.add(id(function))
+                for param in function.params:
+                    self.visit(param)
+                if function.body is not None:
+                    self.visit(function.body)
+
+            def visit_Call(self, expr: Call) -> None:
                 if isinstance(expr.target, Function):
-                    visit_function(expr.target)
-                for arg in expr.args:
-                    visit_expr(arg)
-            elif isinstance(expr, Tuple):
-                for element in expr.elements:
-                    visit_expr(element)
-            elif isinstance(expr, GridRegionExpr):
-                for value in (*expr.init_args, expr.body, *expr.yield_values):
-                    visit_expr(value)
+                    self.visit_function(expr.target)
+                self.visit_operands(expr)
 
-        def visit_function(function: Function) -> None:
-            if id(function) in seen_functions:
-                return
-            seen_functions.add(id(function))
-            for param in function.params:
-                visit_expr(param)
-            visit_expr(function.body)
+            def visit_Tuple(self, expr: Tuple) -> None:
+                self.visit_operands(expr)
 
-        visit_function(self.root)
+            def visit_GridRegionExpr(self, expr: GridRegionExpr) -> None:
+                self.visit_operands(expr)
+
+            def visit_Function(self, expr: Function) -> None:
+                self.visit_function(expr)
+
+            def visit_Var(self, expr: Var) -> None:
+                return None
+
+            def visit_Constant(self, expr: Constant) -> None:
+                return None
+
+            def visit_SymbolRef(self, expr: SymbolRef) -> None:
+                return None
+
+            def visit_ShapeOf(self, expr: Expr) -> None:
+                return None
+
+        _ExtentVisitor().visit_function(self.root)
         return tuple(sorted(extents))
 
     def _new_value(
@@ -296,96 +439,7 @@ class _Extractor:
         cached = self._expr_values.get(key)
         if cached is not None:
             return cached
-        if isinstance(expr, Var):
-            refs = env.get(id(expr))
-            if refs is None:
-                refs = self._param_values.get((function_path, id(expr)), ())
-            self._expr_values[key] = refs
-            return refs
-        if isinstance(expr, Constant):
-            self._expr_values[key] = ()
-            return ()
-        if isinstance(expr, Tuple):
-            refs = tuple(
-                ref
-                for element in expr.elements
-                for ref in self._process_expr(element, function, function_path, env)
-            )
-            self._expr_values[key] = refs
-            self._record_requirement(refs, expr)
-            return refs
-        if isinstance(expr, GridRegionExpr):
-            refs = self._process_region(expr, function, function_path, env)
-            self._expr_values[key] = refs
-            self._record_requirement(refs, expr)
-            return refs
-        if not isinstance(expr, Call):
-            self._expr_values[key] = ()
-            return ()
-        arg_refs = tuple(
-            self._process_expr(arg, function, function_path, env) for arg in expr.args
-        )
-        target = expr.target
-        if isinstance(target, Function):
-            call_path = function_path + (len(self.function_instances),)
-            helper_env = dict(zip((id(param) for param in target.params), arg_refs))
-            self._process_function(target, call_path, helper_env, parent_call=expr)
-            refs = self._process_expr(target.body, target, call_path, helper_env)
-            self._expr_values[key] = refs
-            self._record_requirement(refs, expr)
-            return refs
-        if isinstance(target, (PrimFunction, Launch, SymbolRef)):
-            raise PartitionProgramError(
-                f"kernel boundary {type(target).__name__} at "
-                f"{expr_location(expr)} is not a partitioned operation"
-            )
-        if is_induction_var_singleton_reshape(expr):
-            refs = arg_refs[0] if arg_refs else ()
-            self._expr_values[key] = refs
-            self._record_requirement(refs, expr)
-            return refs
-        if isinstance(target, TupleGetItem):
-            source_refs = arg_refs[0] if arg_refs else ()
-            fields = tensor_leaves(expr.args[0].type)
-            index = target.index
-            if index < 0 or index >= len(fields):
-                raise PartitionProgramError(
-                    f"TupleGetItem index {index} is out of range at "
-                    f"{expr_location(expr)}"
-                )
-            start = sum(
-                len(tensor_leaves(field))
-                for field in expr.args[0].type.fields[:index]  # type: ignore[union-attr]
-            )
-            refs = source_refs[
-                start : start
-                + len(tensor_leaves(expr.args[0].type.fields[index]))  # type: ignore[union-attr]
-            ]
-            self._expr_values[key] = refs
-            self._record_requirement(refs, expr)
-            return refs
-        site_id = self._next_site
-        self._next_site += 1
-        output_refs = tuple(
-            self._new_value(expr, type, path, function_path, producer_site_id=site_id)
-            for path, type in tensor_leaves(expr.type)
-        )
-        self.sites.append(
-            OperationSite(site_id, expr, function_path, arg_refs, output_refs)
-        )
-        self.site_order.append(site_id)
-        self.site_enclosing_regions[site_id] = (
-            self._active_regions[-1] if self._active_regions else None
-        )
-        if self._active_regions:
-            region_id = self._active_regions[-1]
-            info = self.regions[region_id]
-            self.regions[region_id] = replace(
-                info, operation_site_ids=(*info.operation_site_ids, site_id)
-            )
-        self._expr_values[key] = output_refs
-        self._record_requirement(output_refs, expr)
-        return output_refs
+        return _ProcessExprVisitor(self, function, function_path, env).visit(expr)
 
     def _process_region(
         self,

--- a/src/tilefoundry/script.py
+++ b/src/tilefoundry/script.py
@@ -7,7 +7,9 @@ returns the parsed and verified IR node, not the original Python function.
 from __future__ import annotations
 
 import sys
-from typing import Any
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any, Callable, ClassVar, Literal
 
 from tilefoundry.ir.core.module import Module
 from tilefoundry.ir.core.pattern import DimVarRangePat, Pattern
@@ -16,10 +18,143 @@ from tilefoundry.ir.hir.specialize import DISPLAY_NAME
 from tilefoundry.ir.hir.verify import verify_function
 from tilefoundry.ir.tir.intrinsic import intrinsic as _intrinsic
 from tilefoundry.ir.tir.verify import verify_prim_function
-from tilefoundry.module import UNDECLARED, enclosing_declaration
+from tilefoundry.module import UNDECLARED, _Entry, enclosing_declaration
 from tilefoundry.parser import parse_prim_func
 from tilefoundry.parser.hir_parser import _parse_func
 from tilefoundry.target.base import target_instance
+
+
+class ParsedFuncKind(StrEnum):
+    """The three parser-time Function roles."""
+
+    KERNEL = "kernel"
+    VARIANT = "variant"
+    CONVERTER = "converter"
+
+
+@dataclass(frozen=True)
+class NamingRule:
+    """Binding-name constraints for one parser-time Function role."""
+
+    binding_unique: bool
+    allow_underscore: bool
+
+    def check(
+        self,
+        binding_name: str,
+        entry: _Entry | None,
+        *,
+        kind: ParsedFuncKind,
+        base_name: str | None = None,
+    ) -> None:
+        scope = _binding_scope(kind, entry, base_name)
+        if not self.allow_underscore and binding_name == "_":
+            raise ValueError(f"{scope}: a {kind.value} binding may not be named '_'")
+        if self.binding_unique and entry is not None and binding_name in entry.bound:
+            raise ValueError(f"{scope}: duplicate {kind.value} binding {binding_name!r}")
+
+
+@dataclass(frozen=True)
+class HandleRule:
+    """Handle construction and uniqueness scope for one Function role."""
+
+    of: Callable[[object, object], str]
+    unique_within: Literal["module", "base"]
+
+    def check(
+        self,
+        kind: ParsedFuncKind,
+        fn: object,
+        key: object,
+        entry: _Entry | None,
+        base: object | None,
+    ) -> None:
+        if self.unique_within == "module":
+            handle = self.of(fn, key)
+            if entry is not None and entry.bound.get(handle) is kind:
+                scope = _binding_scope(kind, entry, None)
+                raise ValueError(f"{scope}: duplicate {kind.value} binding {handle!r}")
+            return
+        if base is None:
+            return
+        handle = self.of(base, key)
+        if kind is ParsedFuncKind.VARIANT:
+            keys = (variant.specializations[0] for variant in getattr(base, "variants", ()))
+        else:
+            keys = (weight_name for weight_name, _ in getattr(base, "converters", ()))
+        if any(self.of(base, existing_key) == handle for existing_key in keys):
+            scope = _binding_scope(kind, entry, base.name)
+            raise ValueError(f"{scope}: duplicate {kind.value} handle {handle!r}")
+
+
+class ParsedFuncRules:
+    """Parser-time naming and handle rules for parsed Functions."""
+
+    NAMING: ClassVar[dict[ParsedFuncKind, NamingRule]] = {
+        ParsedFuncKind.KERNEL: NamingRule(binding_unique=True, allow_underscore=False),
+        ParsedFuncKind.VARIANT: NamingRule(binding_unique=True, allow_underscore=False),
+        ParsedFuncKind.CONVERTER: NamingRule(binding_unique=False, allow_underscore=True),
+    }
+
+    HANDLE: ClassVar[dict[ParsedFuncKind, HandleRule]] = {
+        ParsedFuncKind.KERNEL: HandleRule(lambda fn, key: fn.name, "module"),
+        ParsedFuncKind.VARIANT: HandleRule(
+            lambda fn, key: f"{fn.name}${key.dim_var}${key.lo}_{key.hi}", "base"
+        ),
+        ParsedFuncKind.CONVERTER: HandleRule(
+            lambda fn, key: f"{fn.name}.converter[{key}]", "base"
+        ),
+    }
+
+    @classmethod
+    def check(
+        cls,
+        kind: ParsedFuncKind,
+        ir: object,
+        binding_name: str,
+        key: object,
+        *,
+        entry: _Entry | None,
+        base: object | None = None,
+    ) -> None:
+        cls.HANDLE[kind].check(kind, ir, key, entry, base)
+        cls.NAMING[kind].check(
+            binding_name,
+            entry,
+            kind=kind,
+            base_name=getattr(base, "name", None),
+        )
+
+
+def _binding_scope(
+    kind: ParsedFuncKind, entry: _Entry | None, base_name: str | None
+) -> str:
+    if entry is not None:
+        module_name = entry.owner_name or "<module>"
+        if kind is ParsedFuncKind.VARIANT:
+            return f"@module {module_name!r} base {base_name!r}"
+        return f"@module {module_name!r}"
+    if kind is ParsedFuncKind.VARIANT:
+        return f"base {base_name!r}"
+    return "standalone @func"
+
+
+def _register(
+    kind: ParsedFuncKind,
+    ir: HirFunction,
+    binding_name: str,
+    key: object,
+    *,
+    base: HirFunction | None = None,
+) -> None:
+    """Validate and record a parser-time Function in its enclosing Module."""
+    entry = _enclosing_declaration()
+    ParsedFuncRules.check(kind, ir, binding_name, key, entry=entry, base=base)
+    if entry is None:
+        return
+    entry.bound[binding_name] = kind
+    if kind is not ParsedFuncKind.KERNEL:
+        entry.owned.add(id(ir))
 
 
 def _validate_one_pattern(pattern: Any) -> Pattern:
@@ -103,6 +238,11 @@ def func(fn=None, *, topologies=UNDECLARED, target=None):
     declared_topologies = None if topologies is UNDECLARED else tuple(topologies)
 
     def _wrap(fn_inner):
+        ParsedFuncRules.NAMING[ParsedFuncKind.KERNEL].check(
+            fn_inner.__name__,
+            _enclosing_declaration(),
+            kind=ParsedFuncKind.KERNEL,
+        )
         extra_closure = _definition_namespace()
         parse_topologies = declared_topologies
         if parse_topologies is None:
@@ -113,6 +253,7 @@ def func(fn=None, *, topologies=UNDECLARED, target=None):
             in_module_body=_enclosing_declaration() is not None,
         )
         verify_function(ir)
+        _register(ParsedFuncKind.KERNEL, ir, fn_inner.__name__, None)
         if not declares_context:
             return ir
         return Module(
@@ -132,13 +273,19 @@ def _specialize(self: HirFunction, pattern: Any):
     """``@base.specialize(DimVarRangePat(...))`` — register a shape variant.
 
     Parses the decorated ``def`` into a variant ``hir.Function`` and appends it to
-    ``base.variants``. The identifier becomes the variant's display label, or
-    nothing when it is ``_``; the variant's ``name`` is the base's either way.
+    ``base.variants``. The identifier becomes the variant's display label and the
+    variant's ``name`` is the base's either way.
     Legal only before ``base`` enters a ``Module`` (a later call raises).
     """
     pat = _validate_one_pattern(pattern)
 
     def _wrap_variant(fn_inner):
+        ParsedFuncRules.NAMING[ParsedFuncKind.VARIANT].check(
+            fn_inner.__name__,
+            _enclosing_declaration(),
+            kind=ParsedFuncKind.VARIANT,
+            base_name=self.name,
+        )
         extra_closure = _definition_namespace()
         ir = _parse_func(
             fn_inner, topologies=_enclosing_topologies() or (),
@@ -151,10 +298,16 @@ def _specialize(self: HirFunction, pattern: Any):
                 "`pass` (only the base prototype declares a `pass` body)"
             )
 
-        if fn_inner.__name__ != "_":
-            object.__setattr__(ir, DISPLAY_NAME, fn_inner.__name__)
+        object.__setattr__(ir, DISPLAY_NAME, fn_inner.__name__)
         object.__setattr__(ir, "name", self.name)
         verify_function(ir)
+        _register(
+            ParsedFuncKind.VARIANT,
+            ir,
+            fn_inner.__name__,
+            pat,
+            base=self,
+        )
         self.add_variant(ir)
         return ir
 
@@ -187,6 +340,13 @@ def _converter(self: HirFunction, weight_name: str):
 
         object.__setattr__(ir, "name", f"{self.name}.converter[{weight_name}]")
         verify_function(ir)
+        _register(
+            ParsedFuncKind.CONVERTER,
+            ir,
+            fn_inner.__name__,
+            weight_name,
+            base=self,
+        )
         self.add_converter(weight_name, ir)
         return ir
 

--- a/src/tilefoundry/visitor_registry/visitors.py
+++ b/src/tilefoundry/visitor_registry/visitors.py
@@ -17,7 +17,7 @@ from tilefoundry.ir.tir.stmt import Stmt
 from tilefoundry.ir.tir.stmts import Evaluate, MeshScope
 from tilefoundry.ir.types.substitute import canonicalize_dims
 from tilefoundry.ir.types.tensor_type import TupleType, Type, UnitType
-from tilefoundry.ir.visitor import ExprVisitor, StmtVisitor
+from tilefoundry.ir.visitor import ExprVisitor, ExprWalker, StmtVisitor
 
 from .contexts import Cost, CostContext, TypeInferContext, VerifyContext, _constant_type
 from .registries import (
@@ -37,11 +37,12 @@ class TypeInferVisitor(ExprVisitor[Type]):
     ``TypeInferContext.type_of`` is the caller-facing cache + dispatch
     entry; it constructs one of these per lookup and delegates to
     ``visit(expr)``. There is no ``isinstance`` fallback — an ``Expr``
-    subclass with no ``visit_<Kind>`` here raises via ``generic_visit``
+    subclass with no ``visit_<Kind>`` here raises via ``default_visit``
     rather than trusting a possibly-stale ``expr.type`` field.
     """
 
     def __init__(self, ctx: TypeInferContext) -> None:
+        super().__init__()
         self.ctx = ctx
 
     def visit(self, expr: Expr) -> Type:
@@ -95,7 +96,7 @@ class TypeInferVisitor(ExprVisitor[Type]):
         """
         return shape_of.type
 
-    def generic_visit(self, expr: Expr) -> Type:
+    def default_visit(self, expr: Expr) -> Type:
         self.ctx.error(expr, f"no typeinfer rule for Expr subclass {type(expr).__name__}")
 
 
@@ -168,6 +169,7 @@ class CodegenVisitor:
         *,
         backend: str,
     ) -> None:
+        super().__init__()
         self.ctx = ctx
         self.backend = backend
         self.registry = registry
@@ -199,7 +201,7 @@ class CodegenVisitor:
         )
 
 
-class CostEvaluator(ExprVisitor[Cost]):
+class CostEvaluator(ExprWalker[Cost]):
     """Dispatch the registered recursive-local Cost Evaluator per Op class.
 
     A missing evaluator fails closed — it is a construction error, not a
@@ -211,6 +213,7 @@ class CostEvaluator(ExprVisitor[Cost]):
         ctx: CostContext,
         registry: AnalysisRegistry = cost_evaluator_registry,
     ) -> None:
+        super().__init__()
         self.ctx = ctx
         self.registry = registry
 
@@ -221,7 +224,6 @@ class CostEvaluator(ExprVisitor[Cost]):
                 call, f"no cost evaluator registered for {type(call.target).__name__}"
             )
         return fn(call, self.ctx)
-
 
 __all__ = [
     "TypeInferVisitor",

--- a/tests/analysis/test_analyze_at_a_size.py
+++ b/tests/analysis/test_analyze_at_a_size.py
@@ -19,6 +19,7 @@ import pytest
 from tests.fixtures.placed.flash_split_k_decode import BLOCK, HEADS, WORKERS, FlashSplitKDecode
 from tests.fixtures.placed.gqa_decode import MAX_CTX, GqaOnline
 from tests.fixtures.placed.prefill_decode_attention import PrefillDecodeAttention
+from tests.fixtures.placed.qwen3_1_7b_pd import PrefillLayer
 from tests.models.qwen3_1_7b.case import CASE as QWEN3_1_7B
 from tilefoundry.analysis import (
     ComputeCostMetadata,
@@ -65,6 +66,7 @@ from tilefoundry.target import CudaTarget
 CONTEXT = 32
 DIMS = {"ctx_len": CONTEXT}
 FAMILIES = ("compute-cost", "memory", "roofline", "timeline")
+QWEN3_PD_FAMILIES = ("compute-cost", "memory", "roofline")
 
 
 SOLVER = ScheduleOptions(timeout_seconds=60, workers=4, random_seed=0, stop_at_first_solution=True)
@@ -91,6 +93,29 @@ def test_every_analysis_runs_at_a_stated_size(family: str) -> None:
 
     assert result.metadata_types
     assert result.module is module
+
+
+@pytest.mark.parametrize(
+    ("dims", "expected_bound"),
+    (({"seq": 512}, "compute"), ({"seq": 1}, "memory")),
+    ids=["qwen3-pd-seq-512", "qwen3-pd-seq-1"],
+)
+def test_qwen3_pd_fixture_runs_all_analysis_families(
+    dims: dict[str, int], expected_bound: str
+) -> None:
+    result = analyze(
+        PrefillLayer,
+        PrefillLayer.entry_function(),
+        analysis=QWEN3_PD_FAMILIES,
+        dims=dims,
+    )
+
+    assert ComputeCostMetadata in result.metadata_types
+    assert MemoryMetadata in result.metadata_types
+    assert RooflineMetadata in result.metadata_types
+    assert result.module is PrefillLayer
+    roofline = get_metadata(result.function, RooflineMetadata)
+    assert roofline is not None and roofline.bound_by == expected_bound
 
 
 @pytest.mark.parametrize(

--- a/tests/analysis/test_analyze_at_a_size.py
+++ b/tests/analysis/test_analyze_at_a_size.py
@@ -97,8 +97,16 @@ def test_every_analysis_runs_at_a_stated_size(family: str) -> None:
 
 @pytest.mark.parametrize(
     ("dims", "expected_bound"),
-    (({"seq": 512}, "compute"), ({"seq": 1}, "memory")),
-    ids=["qwen3-pd-seq-512", "qwen3-pd-seq-1"],
+    (
+        ({"ctx_len": 0, "seq": 512}, "compute"),
+        ({"ctx_len": 512, "seq": 512}, "compute"),
+        ({"ctx_len": 4608, "seq": 1}, "memory"),
+    ),
+    ids=[
+        "qwen3-pd-prefill-no-context",
+        "qwen3-pd-prefill-with-context",
+        "qwen3-pd-decode-context",
+    ],
 )
 def test_qwen3_pd_fixture_runs_all_analysis_families(
     dims: dict[str, int], expected_bound: str

--- a/tests/dsl/test_dsl_surface.py
+++ b/tests/dsl/test_dsl_surface.py
@@ -62,7 +62,7 @@ def sub(x: Tensor[(_S,), "f32"]) -> Tensor[(_S,), "f32"]:
 
 
 @sub.specialize(DimVarRangePat("S", 1, 3))
-def _(x: Tensor[(_S,), "f32"]) -> Tensor[(_S,), "f32"]:
+def narrow_s(x: Tensor[(_S,), "f32"]) -> Tensor[(_S,), "f32"]:
     return x
 
 
@@ -80,12 +80,12 @@ def test_func_specializations_parse_to_variants() -> None:
     assert variants[0].specializations == (DimVarRangePat("S", 1, 3),)
     assert variants[1].specializations == (DimVarRangePat("S", 4, 7),)
 
-    assert display_name(variants[0]) is None
+    assert display_name(variants[0]) == "narrow_s"
     assert display_name(variants[1]) == "wide_s"
 
     printed = as_script(sub)
     assert "def wide_s(" in printed
-    assert "def _(" in printed
+    assert "def narrow_s(" in printed
 
     for v in variants:
         (param,) = v.params

--- a/tests/evaluator/test_eval_core.py
+++ b/tests/evaluator/test_eval_core.py
@@ -177,7 +177,7 @@ def test_a_variant_body_reaches_its_child_the_same_way() -> None:
             pass
 
         @dispatch.specialize(DimVarRangePat("N_eval", 1, 8))
-        def _(x: Tensor[(_N_EVAL,), "f32"]) -> Tensor[(_N_EVAL,), "f32"]:
+        def dynamic_variant(x: Tensor[(_N_EVAL,), "f32"]) -> Tensor[(_N_EVAL,), "f32"]:
             return scaled(x)  # noqa: F821
 
     (child,) = _Dispatch.modules

--- a/tests/fixtures/placed/qwen3_1_7b_pd.py
+++ b/tests/fixtures/placed/qwen3_1_7b_pd.py
@@ -1,0 +1,587 @@
+"""Qwen3-1.7B prefill and decode layer fixture."""
+
+from __future__ import annotations
+
+from tilefoundry import func, module
+from tilefoundry.dsl import ConstTensor, DimVar, DimVarRangePat, Mesh, Tensor, tf
+from tilefoundry.dsl.tf import *  # noqa: F401,F403
+from tilefoundry.ir.types.shard import Topology
+from tilefoundry.target import CudaTarget
+
+SEQ = DimVar("seq", 1, 8193)
+
+CAP = 4608
+
+HID = 2048
+HQ, HKV, D = 16, 8, 128
+G = HQ // HKV
+QN, KN = HQ * D, HKV * D
+QKV_N = QN + 2 * KN
+FFN = 6144
+L = 28
+V = 151936
+CTAS = 128
+THREADS = 256
+
+ROWS = 128
+BN, BK = 128, 64
+BKV = 128
+
+DN_QKV, DN_O, DN_FFN, DN_DOWN = 32, 16, 48, 16
+
+_H200 = CudaTarget("nvidia.h200_sxm")
+
+@module(
+    entry="model",
+    target=_H200,
+    topologies=(Topology("cta", CTAS), Topology("thread", THREADS)),
+)
+class PrefillLayer:
+    @func
+    def layer_prefill(
+        x: Tensor[(SEQ, HID), "bf16"],
+        w_qkv: ConstTensor[(HID, QKV_N), "bf16"],
+        w_o: ConstTensor[(QN, HID), "bf16"],
+        w_gu: ConstTensor[(HID, 2, FFN), "bf16"],
+        w_down: ConstTensor[(FFN, HID), "bf16"],
+        g_in: ConstTensor[(HID,), "bf16"],
+        g_q: ConstTensor[(D,), "bf16"],
+        g_k: ConstTensor[(D,), "bf16"],
+        g_post: ConstTensor[(HID,), "bf16"],
+        kc: Tensor[(1, CAP, HKV, D), "bf16"],
+        vc: Tensor[(1, CAP, HKV, D), "bf16"],
+        cur: Tensor[(), "i32"],
+        cos: Tensor[(ROWS, D), "f32"],
+        sin: Tensor[(ROWS, D), "f32"],
+        pos: Tensor[(ROWS,), "i32"],
+        xn: Tensor[(SEQ, HID), "bf16"],
+        qkv: Tensor[(SEQ, QKV_N), "f32"],
+        q: Tensor[(SEQ, HKV, G, D), "bf16"],
+        attn: Tensor[(SEQ, HKV, G, D), "bf16"],
+        h1: Tensor[(SEQ, HID), "bf16"],
+        gu: Tensor[(SEQ, 2, FFN), "f32"],
+        act: Tensor[(SEQ, FFN), "bf16"],
+        out: Tensor[(SEQ, HID), "bf16"],
+    ) -> Tensor[(SEQ, HID), "bf16"]:
+        with Mesh(("cta",), layout=(CTAS,), names=("cta",)) as cta:
+            xb = xn
+            for m in tile(SEQ, ROWS):  # noqa: F405
+                xr = tf.rms_norm(x[m, 0:HID], g_in)
+                xb = tf.insert_slice(xb, tf.reshard(xr, (ROWS, HID), "gmem"), (m, 0))
+
+        with Mesh(("cta",), layout=(CTAS,), names=("cta",)) as cta:
+            p = qkv
+            for m in tile(SEQ, ROWS):  # noqa: F405
+                for n in tile(QKV_N, BN):  # noqa: F405
+                    acc = tf.reshard(tf.zeros((ROWS, BN), dtype="f32"), (ROWS, BN), "rmem")
+                    for k in tile(HID, BK):  # noqa: F405
+                        xt = tf.reshard(xb[m, k], (ROWS, BK), "smem")
+                        wt = tf.reshard(
+                            tf.reshape(w_qkv[k, n], (BK, BN)),
+                            (BK, BN),
+                            "smem",
+                        )
+                        mm = tf.cast(tf.matmul(xt, wt), dtype="f32")
+                        acc = acc + tf.reshard(mm, (ROWS, BN), "rmem")
+                    p = tf.insert_slice(p, tf.reshard(acc, (ROWS, BN), "gmem"), (m, n))
+
+        with Mesh(("cta",), layout=(CTAS,), names=("cta",)) as cta:
+            qb = q
+            kc2 = kc
+            vc2 = vc
+            for m in tile(SEQ, ROWS):  # noqa: F405
+                q4 = tf.reshape(tf.cast(p[m, 0:QN], dtype="bf16"), (1, ROWS, HQ, D))
+                k4 = tf.reshape(tf.cast(p[m, QN : QN + KN], dtype="bf16"), (1, ROWS, HKV, D))
+                v4 = tf.reshape(
+                    tf.cast(p[m, QN + KN : QKV_N], dtype="bf16"),
+                    (1, ROWS, HKV, D),
+                )
+                qr, kr = tf.rope(tf.rms_norm(q4, g_q), tf.rms_norm(k4, g_k), cos, sin, pos)
+                width = tf.reshape(cur, ())
+                kc2 = tf.cache_update(kc2, cur, width, kr)
+                vc2 = tf.cache_update(vc2, cur, width, v4)
+                qb = tf.insert_slice(qb, tf.reshape(qr, (ROWS, HKV, G, D)), (m, 0, 0, 0))
+
+        with Mesh(("cta",), layout=(CTAS,), names=("cta",)) as cta:
+            ab = attn
+            for m in tile(SEQ, ROWS):  # noqa: F405
+                for kv in tile(HKV, 1):  # noqa: F405
+                    for g in tile(G, 1):  # noqa: F405
+                        qh = tf.reshard(tf.reshape(qb[m, kv, g, 0:D], (ROWS, D)), (ROWS, D), "smem")
+                        mx = tf.reshard(
+                            tf.zeros((ROWS, 1), dtype="f32") - 30000.0,
+                            (ROWS, 1),
+                            "rmem",
+                        )
+                        lr = tf.reshard(tf.zeros((ROWS, 1), dtype="f32"), (ROWS, 1), "rmem")
+                        acc = tf.reshard(tf.zeros((ROWS, D), dtype="f32"), (ROWS, D), "rmem")
+                        for c in tile(CAP, BKV):  # noqa: F405
+                            khb = tf.reshard(
+                                tf.reshape(kc2[0:1, c, kv, 0:D], (BKV, D)), (BKV, D), "smem"
+                            )
+                            kh = tf.transpose(khb, perm=(1, 0))
+                            vh = tf.reshard(
+                                tf.reshape(vc2[0:1, c, kv, 0:D], (BKV, D)),
+                                (BKV, D),
+                                "smem",
+                            )
+                            sc = tf.reshard(
+                                tf.cast(tf.matmul(qh, kh), dtype="f32"),
+                                (ROWS, BKV),
+                                "rmem",
+                            )
+                            mn = tf.maximum(mx, tf.reduce(sc, axes=(1,), keepdim=True, kind="max"))
+                            scale = tf.exp(mx - mn)
+                            pr = tf.exp(sc - mn)
+                            lr = lr * scale + tf.reduce(pr, axes=(1,), keepdim=True, kind="sum")
+                            pb = tf.reshard(tf.cast(pr, dtype="bf16"), (ROWS, BKV), "smem")
+                            pv = tf.cast(tf.matmul(pb, vh), dtype="f32")
+                            acc = acc * scale + tf.reshard(pv, (ROWS, D), "rmem")
+                            mx = mn
+                        ah = tf.reshard(tf.cast(tf.div(acc, lr), dtype="bf16"), (ROWS, D), "gmem")
+                        ab = tf.insert_slice(ab, tf.reshape(ah, (ROWS, 1, 1, D)), (m, kv, g, 0))
+
+        with Mesh(("cta",), layout=(CTAS,), names=("cta",)) as cta:
+            af = tf.reshape(ab, (SEQ, QN))
+            hb = h1
+            for m in tile(SEQ, ROWS):  # noqa: F405
+                for n in tile(HID, BN):  # noqa: F405
+                    op = tf.reshard(tf.zeros((ROWS, BN), dtype="f32"), (ROWS, BN), "rmem")
+                    for k in tile(QN, BK):  # noqa: F405
+                        xt = tf.reshard(af[m, k], (ROWS, BK), "smem")
+                        wt = tf.reshard(
+                            tf.reshape(w_o[k, n], (BK, BN)),
+                            (BK, BN),
+                            "smem",
+                        )
+                        mm = tf.cast(tf.matmul(xt, wt), dtype="f32")
+                        op = op + tf.reshard(mm, (ROWS, BN), "rmem")
+                    xr = tf.reshard(x[m, n], (ROWS, BN), "rmem")
+                    sm = tf.cast(tf.cast(xr, dtype="f32") + op, dtype="bf16")
+                    hb = tf.insert_slice(hb, tf.reshard(sm, (ROWS, BN), "gmem"), (m, n))
+
+        with Mesh(("cta",), layout=(CTAS,), names=("cta",)) as cta:
+            gb = gu
+            for m in tile(SEQ, ROWS):  # noqa: F405
+                xn1 = tf.rms_norm(hb[m, 0:HID], g_post)
+                for n in tile(FFN, BN):  # noqa: F405
+                    gv = tf.reshard(tf.zeros((ROWS, BN), dtype="f32"), (ROWS, BN), "rmem")
+                    for k in tile(HID, BK):  # noqa: F405
+                        wk = tf.reshape(w_gu[k, 0:1, n], (BK, BN))
+                        xt = tf.reshard(xn1[0:ROWS, k], (ROWS, BK), "smem")
+                        wt = tf.reshard(wk, (BK, BN), "smem")
+                        mm = tf.cast(tf.matmul(xt, wt), dtype="f32")
+                        gv = gv + tf.reshard(mm, (ROWS, BN), "rmem")
+                    gb = tf.insert_slice(
+                        gb,
+                        tf.reshape(tf.reshard(gv, (ROWS, BN), "gmem"), (ROWS, 1, BN)),
+                        (m, 0, n),
+                    )
+                for n in tile(FFN, BN):  # noqa: F405
+                    gv = tf.reshard(tf.zeros((ROWS, BN), dtype="f32"), (ROWS, BN), "rmem")
+                    for k in tile(HID, BK):  # noqa: F405
+                        wk = tf.reshape(w_gu[k, 1:2, n], (BK, BN))
+                        xt = tf.reshard(xn1[0:ROWS, k], (ROWS, BK), "smem")
+                        wt = tf.reshard(wk, (BK, BN), "smem")
+                        mm = tf.cast(tf.matmul(xt, wt), dtype="f32")
+                        gv = gv + tf.reshard(mm, (ROWS, BN), "rmem")
+                    gb = tf.insert_slice(
+                        gb,
+                        tf.reshape(tf.reshard(gv, (ROWS, BN), "gmem"), (ROWS, 1, BN)),
+                        (m, 1, n),
+                    )
+
+        with Mesh(("cta",), layout=(CTAS,), names=("cta",)) as cta:
+            acb = act
+            for m in tile(SEQ, ROWS):  # noqa: F405
+                for n in tile(FFN, BN):  # noqa: F405
+                    gate = tf.reshard(tf.reshape(gb[m, 0:1, n], (ROWS, BN)), (ROWS, BN), "rmem")
+                    up = tf.reshard(tf.reshape(gb[m, 1:2, n], (ROWS, BN)), (ROWS, BN), "rmem")
+                    sw = tf.cast(tf.silu(gate) * up, dtype="bf16")
+                    acb = tf.insert_slice(acb, tf.reshard(sw, (ROWS, BN), "gmem"), (m, n))
+
+        with Mesh(("cta",), layout=(CTAS,), names=("cta",)) as cta:  # noqa: F841
+            o = out
+            for m in tile(SEQ, ROWS):  # noqa: F405
+                for n in tile(HID, BN):  # noqa: F405
+                    dp = tf.reshard(tf.zeros((ROWS, BN), dtype="f32"), (ROWS, BN), "rmem")
+                    for k in tile(FFN, BK):  # noqa: F405
+                        xt = tf.reshard(acb[m, k], (ROWS, BK), "smem")
+                        wt = tf.reshard(
+                            tf.reshape(w_down[k, n], (BK, BN)),
+                            (BK, BN),
+                            "smem",
+                        )
+                        mm = tf.cast(tf.matmul(xt, wt), dtype="f32")
+                        dp = dp + tf.reshard(mm, (ROWS, BN), "rmem")
+                    hr = tf.reshard(hb[m, n], (ROWS, BN), "rmem")
+                    sm = tf.cast(tf.cast(hr, dtype="f32") + dp, dtype="bf16")
+                    o = tf.insert_slice(o, tf.reshard(sm, (ROWS, BN), "gmem"), (m, n))
+        return o
+
+
+    @func
+    def layer_decode(
+        x: Tensor[(SEQ, HID), "bf16"],
+        w_qkv: ConstTensor[(HID, QKV_N), "bf16"],
+        w_o: ConstTensor[(QN, HID), "bf16"],
+        w_gu: ConstTensor[(HID, 2, FFN), "bf16"],
+        w_down: ConstTensor[(FFN, HID), "bf16"],
+        g_in: ConstTensor[(HID,), "bf16"],
+        g_q: ConstTensor[(D,), "bf16"],
+        g_k: ConstTensor[(D,), "bf16"],
+        g_post: ConstTensor[(HID,), "bf16"],
+        kc: Tensor[(1, CAP, HKV, D), "bf16"],
+        vc: Tensor[(1, CAP, HKV, D), "bf16"],
+        cur: Tensor[(), "i32"],
+        cos: Tensor[(ROWS, D), "f32"],
+        sin: Tensor[(ROWS, D), "f32"],
+        pos: Tensor[(ROWS,), "i32"],
+        xn: Tensor[(SEQ, HID), "bf16"],
+        qkv: Tensor[(SEQ, QKV_N), "f32"],
+        q: Tensor[(SEQ, HKV, G, D), "bf16"],
+        attn: Tensor[(SEQ, HKV, G, D), "bf16"],
+        h1: Tensor[(SEQ, HID), "bf16"],
+        gu: Tensor[(SEQ, 2, FFN), "f32"],
+        act: Tensor[(SEQ, FFN), "bf16"],
+        out: Tensor[(SEQ, HID), "bf16"],
+    ) -> Tensor[(SEQ, HID), "bf16"]:
+        with Mesh(("cta",), layout=(CTAS,), names=("cta",)) as cta:
+            xr = tf.rms_norm(x[0:1, 0:HID], g_in)
+            xb = tf.insert_slice(xn, tf.reshard(xr, (1, HID), "gmem"), (0, 0))
+
+        with Mesh(("cta",), layout=(CTAS,), names=("cta",)) as cta:
+            p = qkv
+            for n in tile(QKV_N, DN_QKV):  # noqa: F405
+                acc = tf.reshard(tf.zeros((1, DN_QKV), dtype="f32"), (1, DN_QKV), "rmem")
+                for k in tile(HID, BK):  # noqa: F405
+                    xt = tf.reshard(xb[0:1, k], (1, BK), "smem")
+                    wt = tf.reshard(
+                        tf.reshape(w_qkv[k, n], (BK, DN_QKV)),
+                        (BK, DN_QKV),
+                        "smem",
+                    )
+                    mm = tf.cast(tf.matmul(xt, wt), dtype="f32")
+                    acc = acc + tf.reshard(mm, (1, DN_QKV), "rmem")
+                p = tf.insert_slice(p, tf.reshard(acc, (1, DN_QKV), "gmem"), (0, n))
+
+        with Mesh(("cta",), layout=(CTAS,), names=("cta",)) as cta:
+            q4 = tf.reshape(tf.cast(p[0:1, 0:QN], dtype="bf16"), (1, 1, HQ, D))
+            k4 = tf.reshape(tf.cast(p[0:1, QN : QN + KN], dtype="bf16"), (1, 1, HKV, D))
+            v4 = tf.reshape(tf.cast(p[0:1, QN + KN : QKV_N], dtype="bf16"), (1, 1, HKV, D))
+            qr, kr = tf.rope(
+                tf.rms_norm(q4, g_q),
+                tf.rms_norm(k4, g_k),
+                cos[0:1, 0:D],
+                sin[0:1, 0:D],
+                pos[0:1],
+            )
+            width = tf.reshape(cur, ())
+            kc2 = tf.cache_update(kc, cur, width, kr)
+            vc2 = tf.cache_update(vc, cur, width, v4)
+            qb = tf.insert_slice(q, tf.reshape(qr, (1, HKV, G, D)), (0, 0, 0, 0))
+
+        with Mesh(("cta",), layout=(CTAS,), names=("cta",)) as cta:
+            ab = attn
+            for kv in tile(HKV, 1):  # noqa: F405
+                for g in tile(G, 1):  # noqa: F405
+                    qh = tf.reshard(tf.reshape(qb[0:1, kv, g, 0:D], (1, D)), (1, D), "smem")
+                    mx = tf.reshard(tf.zeros((1, 1), dtype="f32") - 30000.0, (1, 1), "rmem")
+                    lr = tf.reshard(tf.zeros((1, 1), dtype="f32"), (1, 1), "rmem")
+                    acc = tf.reshard(tf.zeros((1, D), dtype="f32"), (1, D), "rmem")
+                    for c in tile(CAP, BKV):  # noqa: F405
+                        khb = tf.reshard(
+                            tf.reshape(kc2[0:1, c, kv, 0:D], (BKV, D)), (BKV, D), "smem"
+                        )
+                        kh = tf.transpose(khb, perm=(1, 0))
+                        vh = tf.reshard(
+                            tf.reshape(vc2[0:1, c, kv, 0:D], (BKV, D)), (BKV, D), "smem"
+                        )
+                        sc = tf.reshard(tf.cast(tf.matmul(qh, kh), dtype="f32"), (1, BKV), "rmem")
+                        mn = tf.maximum(mx, tf.reduce(sc, axes=(1,), keepdim=True, kind="max"))
+                        scale = tf.exp(mx - mn)
+                        pr = tf.exp(sc - mn)
+                        lr = lr * scale + tf.reduce(pr, axes=(1,), keepdim=True, kind="sum")
+                        pb = tf.reshard(tf.cast(pr, dtype="bf16"), (1, BKV), "smem")
+                        pv = tf.cast(tf.matmul(pb, vh), dtype="f32")
+                        acc = acc * scale + tf.reshard(pv, (1, D), "rmem")
+                        mx = mn
+                    ah = tf.reshard(tf.cast(tf.div(acc, lr), dtype="bf16"), (1, D), "gmem")
+                    ab = tf.insert_slice(ab, tf.reshape(ah, (1, 1, 1, D)), (0, kv, g, 0))
+
+        with Mesh(("cta",), layout=(CTAS,), names=("cta",)) as cta:
+            af = tf.reshape(ab, (SEQ, QN))
+            hb = h1
+            for n in tile(HID, DN_O):  # noqa: F405
+                op = tf.reshard(tf.zeros((1, DN_O), dtype="f32"), (1, DN_O), "rmem")
+                for k in tile(QN, BK):  # noqa: F405
+                    xt = tf.reshard(af[0:1, k], (1, BK), "smem")
+                    wt = tf.reshard(
+                        tf.reshape(w_o[k, n], (BK, DN_O)),
+                        (BK, DN_O),
+                        "smem",
+                    )
+                    mm = tf.cast(tf.matmul(xt, wt), dtype="f32")
+                    op = op + tf.reshard(mm, (1, DN_O), "rmem")
+                xr = tf.reshard(x[0:1, n], (1, DN_O), "rmem")
+                sm = tf.cast(tf.cast(xr, dtype="f32") + op, dtype="bf16")
+                hb = tf.insert_slice(hb, tf.reshard(sm, (1, DN_O), "gmem"), (0, n))
+
+        with Mesh(("cta",), layout=(CTAS,), names=("cta",)) as cta:
+            gb = gu
+            xn1 = tf.rms_norm(hb[0:1, 0:HID], g_post)
+            for n in tile(FFN, DN_FFN):  # noqa: F405
+                gv = tf.reshard(tf.zeros((1, DN_FFN), dtype="f32"), (1, DN_FFN), "rmem")
+                for k in tile(HID, BK):  # noqa: F405
+                    xt = tf.reshard(xn1[0:1, k], (1, BK), "smem")
+                    wt = tf.reshard(
+                        tf.reshape(w_gu[k, 0:1, n], (BK, DN_FFN)),
+                        (BK, DN_FFN),
+                        "smem",
+                    )
+                    mm = tf.cast(tf.matmul(xt, wt), dtype="f32")
+                    gv = gv + tf.reshard(mm, (1, DN_FFN), "rmem")
+                gb = tf.insert_slice(
+                    gb,
+                    tf.reshape(tf.reshard(gv, (1, DN_FFN), "gmem"), (1, 1, DN_FFN)),
+                    (0, 0, n),
+                )
+            for n in tile(FFN, DN_FFN):  # noqa: F405
+                uv = tf.reshard(tf.zeros((1, DN_FFN), dtype="f32"), (1, DN_FFN), "rmem")
+                for k in tile(HID, BK):  # noqa: F405
+                    xt = tf.reshard(xn1[0:1, k], (1, BK), "smem")
+                    wt = tf.reshard(
+                        tf.reshape(w_gu[k, 1:2, n], (BK, DN_FFN)),
+                        (BK, DN_FFN),
+                        "smem",
+                    )
+                    mm = tf.cast(tf.matmul(xt, wt), dtype="f32")
+                    uv = uv + tf.reshard(mm, (1, DN_FFN), "rmem")
+                gb = tf.insert_slice(
+                    gb,
+                    tf.reshape(tf.reshard(uv, (1, DN_FFN), "gmem"), (1, 1, DN_FFN)),
+                    (0, 1, n),
+                )
+
+        with Mesh(("cta",), layout=(CTAS,), names=("cta",)) as cta:
+            acb = act
+            for n in tile(FFN, DN_FFN):  # noqa: F405
+                gate = tf.reshard(tf.reshape(gb[0:1, 0:1, n], (1, DN_FFN)), (1, DN_FFN), "rmem")
+                up = tf.reshard(tf.reshape(gb[0:1, 1:2, n], (1, DN_FFN)), (1, DN_FFN), "rmem")
+                sw = tf.cast(tf.silu(gate) * up, dtype="bf16")
+                acb = tf.insert_slice(acb, tf.reshard(sw, (1, DN_FFN), "gmem"), (0, n))
+
+        with Mesh(("cta",), layout=(CTAS,), names=("cta",)) as cta:  # noqa: F841
+            o = out
+            for n in tile(HID, DN_DOWN):  # noqa: F405
+                dp = tf.reshard(tf.zeros((1, DN_DOWN), dtype="f32"), (1, DN_DOWN), "rmem")
+                for k in tile(FFN, BK):  # noqa: F405
+                    xt = tf.reshard(acb[0:1, k], (1, BK), "smem")
+                    wt = tf.reshard(
+                        tf.reshape(w_down[k, n], (BK, DN_DOWN)),
+                        (BK, DN_DOWN),
+                        "smem",
+                    )
+                    mm = tf.cast(tf.matmul(xt, wt), dtype="f32")
+                    dp = dp + tf.reshard(mm, (1, DN_DOWN), "rmem")
+                xr = tf.reshard(hb[0:1, n], (1, DN_DOWN), "rmem")
+                sm = tf.cast(tf.cast(xr, dtype="f32") + dp, dtype="bf16")
+                o = tf.insert_slice(o, tf.reshard(sm, (1, DN_DOWN), "gmem"), (0, n))
+        return o
+
+    @func
+    def model(
+        ids: Tensor[(SEQ,), "i32"],
+        w_embed: ConstTensor[(V, HID), "bf16"],
+        w_qkv: ConstTensor[(L, HID, QKV_N), "bf16"],
+        w_o: ConstTensor[(L, QN, HID), "bf16"],
+        w_gu: ConstTensor[(L, HID, 2, FFN), "bf16"],
+        w_down: ConstTensor[(L, FFN, HID), "bf16"],
+        g_in: ConstTensor[(L, HID), "bf16"],
+        g_q: ConstTensor[(L, D), "bf16"],
+        g_k: ConstTensor[(L, D), "bf16"],
+        g_post: ConstTensor[(L, HID), "bf16"],
+        g_final: ConstTensor[(HID,), "bf16"],
+        w_head: ConstTensor[(HID, V), "bf16"],
+        kc: Tensor[(L, CAP, HKV, D), "bf16"],
+        vc: Tensor[(L, CAP, HKV, D), "bf16"],
+        cur: Tensor[(), "i32"],
+        cos: Tensor[(ROWS, D), "f32"],
+        sin: Tensor[(ROWS, D), "f32"],
+        pos: Tensor[(ROWS,), "i32"],
+        x: Tensor[(SEQ, HID), "bf16"],
+        xn: Tensor[(SEQ, HID), "bf16"],
+        qkv: Tensor[(SEQ, QKV_N), "f32"],
+        q: Tensor[(SEQ, HKV, G, D), "bf16"],
+        attn: Tensor[(SEQ, HKV, G, D), "bf16"],
+        h1: Tensor[(SEQ, HID), "bf16"],
+        gu: Tensor[(SEQ, 2, FFN), "f32"],
+        act: Tensor[(SEQ, FFN), "bf16"],
+        out: Tensor[(SEQ, HID), "bf16"],
+        logits: Tensor[(SEQ, V), "f32"],
+    ) -> Tensor[(SEQ, V), "f32"]:
+        pass
+
+    @model.specialize(DimVarRangePat("seq", 2, 8193))  # noqa: F821
+    def prefill(
+        ids: Tensor[(SEQ,), "i32"],
+        w_embed: ConstTensor[(V, HID), "bf16"],
+        w_qkv: ConstTensor[(L, HID, QKV_N), "bf16"],
+        w_o: ConstTensor[(L, QN, HID), "bf16"],
+        w_gu: ConstTensor[(L, HID, 2, FFN), "bf16"],
+        w_down: ConstTensor[(L, FFN, HID), "bf16"],
+        g_in: ConstTensor[(L, HID), "bf16"],
+        g_q: ConstTensor[(L, D), "bf16"],
+        g_k: ConstTensor[(L, D), "bf16"],
+        g_post: ConstTensor[(L, HID), "bf16"],
+        g_final: ConstTensor[(HID,), "bf16"],
+        w_head: ConstTensor[(HID, V), "bf16"],
+        kc: Tensor[(L, CAP, HKV, D), "bf16"],
+        vc: Tensor[(L, CAP, HKV, D), "bf16"],
+        cur: Tensor[(), "i32"],
+        cos: Tensor[(ROWS, D), "f32"],
+        sin: Tensor[(ROWS, D), "f32"],
+        pos: Tensor[(ROWS,), "i32"],
+        x: Tensor[(SEQ, HID), "bf16"],
+        xn: Tensor[(SEQ, HID), "bf16"],
+        qkv: Tensor[(SEQ, QKV_N), "f32"],
+        q: Tensor[(SEQ, HKV, G, D), "bf16"],
+        attn: Tensor[(SEQ, HKV, G, D), "bf16"],
+        h1: Tensor[(SEQ, HID), "bf16"],
+        gu: Tensor[(SEQ, 2, FFN), "f32"],
+        act: Tensor[(SEQ, FFN), "bf16"],
+        out: Tensor[(SEQ, HID), "bf16"],
+        logits: Tensor[(SEQ, V), "f32"],
+    ) -> Tensor[(SEQ, V), "f32"]:
+        with Mesh(("cta",), layout=(CTAS,), names=("cta",)) as cta:
+            h = x
+            for m in tile(SEQ, ROWS):  # noqa: F405
+                h = tf.insert_slice(
+                    h,
+                    tf.reshard(
+                        tf.index_select(w_embed, ids[m], dim=0),
+                        (ROWS, HID),
+                        "gmem",
+                    ),
+                    (m, 0),
+                )
+
+        for i in tile(L, 1):  # noqa: F405
+            h = layer_prefill(  # noqa: F405
+                h,
+                tf.reshape(w_qkv[i, 0:HID, 0:QKV_N], (HID, QKV_N)),
+                tf.reshape(w_o[i, 0:QN, 0:HID], (QN, HID)),
+                tf.reshape(w_gu[i, 0:HID, 0:2, 0:FFN], (HID, 2, FFN)),
+                tf.reshape(w_down[i, 0:FFN, 0:HID], (FFN, HID)),
+                tf.reshape(g_in[i, 0:HID], (HID,)),
+                tf.reshape(g_q[i, 0:D], (D,)),
+                tf.reshape(g_k[i, 0:D], (D,)),
+                tf.reshape(g_post[i, 0:HID], (HID,)),
+                kc[i, 0:CAP, 0:HKV, 0:D],
+                vc[i, 0:CAP, 0:HKV, 0:D],
+                cur,
+                cos,
+                sin,
+                pos,
+                xn,
+                qkv,
+                q,
+                attn,
+                h1,
+                gu,
+                act,
+                out,
+            )
+
+        with Mesh(("cta",), layout=(CTAS,), names=("cta",)) as cta:  # noqa: F841
+            lg = logits
+            for m in tile(SEQ, ROWS):  # noqa: F405
+                hf = tf.rms_norm(h[m, 0:HID], g_final)
+                for n in tile(V, BN):  # noqa: F405
+                    acc = tf.reshard(tf.zeros((ROWS, BN), dtype="f32"), (ROWS, BN), "rmem")
+                    for k in tile(HID, BK):  # noqa: F405
+                        xt = tf.reshard(hf[0:ROWS, k], (ROWS, BK), "smem")
+                        wt = tf.reshard(
+                            w_head[k, n],
+                            (BK, BN),
+                            "smem",
+                        )
+                        mm = tf.cast(tf.matmul(xt, wt), dtype="f32")
+                        acc = acc + tf.reshard(mm, (ROWS, BN), "rmem")
+                    lg = tf.insert_slice(lg, tf.reshard(acc, (ROWS, BN), "gmem"), (m, n))
+        return lg
+
+    @model.specialize(DimVarRangePat("seq", 1, 2))  # noqa: F821
+    def decode(
+        ids: Tensor[(SEQ,), "i32"],
+        w_embed: ConstTensor[(V, HID), "bf16"],
+        w_qkv: ConstTensor[(L, HID, QKV_N), "bf16"],
+        w_o: ConstTensor[(L, QN, HID), "bf16"],
+        w_gu: ConstTensor[(L, HID, 2, FFN), "bf16"],
+        w_down: ConstTensor[(L, FFN, HID), "bf16"],
+        g_in: ConstTensor[(L, HID), "bf16"],
+        g_q: ConstTensor[(L, D), "bf16"],
+        g_k: ConstTensor[(L, D), "bf16"],
+        g_post: ConstTensor[(L, HID), "bf16"],
+        g_final: ConstTensor[(HID,), "bf16"],
+        w_head: ConstTensor[(HID, V), "bf16"],
+        kc: Tensor[(L, CAP, HKV, D), "bf16"],
+        vc: Tensor[(L, CAP, HKV, D), "bf16"],
+        cur: Tensor[(), "i32"],
+        cos: Tensor[(ROWS, D), "f32"],
+        sin: Tensor[(ROWS, D), "f32"],
+        pos: Tensor[(ROWS,), "i32"],
+        x: Tensor[(SEQ, HID), "bf16"],
+        xn: Tensor[(SEQ, HID), "bf16"],
+        qkv: Tensor[(SEQ, QKV_N), "f32"],
+        q: Tensor[(SEQ, HKV, G, D), "bf16"],
+        attn: Tensor[(SEQ, HKV, G, D), "bf16"],
+        h1: Tensor[(SEQ, HID), "bf16"],
+        gu: Tensor[(SEQ, 2, FFN), "f32"],
+        act: Tensor[(SEQ, FFN), "bf16"],
+        out: Tensor[(SEQ, HID), "bf16"],
+        logits: Tensor[(SEQ, V), "f32"],
+    ) -> Tensor[(SEQ, V), "f32"]:
+        with Mesh(("cta",), layout=(CTAS,), names=("cta",)) as cta:
+            e = tf.reshard(tf.index_select(w_embed, ids[0:1], dim=0), (1, HID), "gmem")
+            h = tf.insert_slice(x, e, (0, 0))
+
+        for i in tile(L, 1):  # noqa: F405
+            h = layer_decode(  # noqa: F405
+                h,
+                tf.reshape(w_qkv[i, 0:HID, 0:QKV_N], (HID, QKV_N)),
+                tf.reshape(w_o[i, 0:QN, 0:HID], (QN, HID)),
+                tf.reshape(w_gu[i, 0:HID, 0:2, 0:FFN], (HID, 2, FFN)),
+                tf.reshape(w_down[i, 0:FFN, 0:HID], (FFN, HID)),
+                tf.reshape(g_in[i, 0:HID], (HID,)),
+                tf.reshape(g_q[i, 0:D], (D,)),
+                tf.reshape(g_k[i, 0:D], (D,)),
+                tf.reshape(g_post[i, 0:HID], (HID,)),
+                kc[i, 0:CAP, 0:HKV, 0:D],
+                vc[i, 0:CAP, 0:HKV, 0:D],
+                cur,
+                cos,
+                sin,
+                pos,
+                xn,
+                qkv,
+                q,
+                attn,
+                h1,
+                gu,
+                act,
+                out,
+            )
+
+        with Mesh(("cta",), layout=(CTAS,), names=("cta",)) as cta:  # noqa: F841
+            lg = logits
+            hf = tf.rms_norm(h[0:1, 0:HID], g_final)
+            for n in tile(V, BN):  # noqa: F405
+                acc = tf.reshard(tf.zeros((1, BN), dtype="f32"), (1, BN), "rmem")
+                for k in tile(HID, BK):  # noqa: F405
+                    xt = tf.reshard(hf[0:1, k], (1, BK), "smem")
+                    wt = tf.reshard(w_head[k, n], (BK, BN), "smem")
+                    mm = tf.cast(tf.matmul(xt, wt), dtype="f32")
+                    acc = acc + tf.reshard(mm, (1, BN), "rmem")
+                lg = tf.insert_slice(lg, tf.reshard(acc, (1, BN), "gmem"), (0, n))
+        return lg

--- a/tests/fixtures/placed/qwen3_1_7b_pd.py
+++ b/tests/fixtures/placed/qwen3_1_7b_pd.py
@@ -1,6 +1,17 @@
-"""Qwen3-1.7B prefill and decode layer fixture."""
+"""Qwen3-1.7B prefill and decode layer fixture.
+
+The context bound comes from the ``max_position_embeddings`` scalar in the
+model config; importing the executable model during test collection would
+build a second IR program. ``SEQ`` is bounded by this fixture's 8192-row
+prefill chunk envelope, not by the model limit. ``CAP`` is the independently
+allocated 4608-position cache depth, while attention scans the prior context
+plus the current sequence through ``CTX + SEQ``.
+"""
 
 from __future__ import annotations
+
+import json
+from pathlib import Path
 
 from tilefoundry import func, module
 from tilefoundry.dsl import ConstTensor, DimVar, DimVarRangePat, Mesh, Tensor, tf
@@ -8,7 +19,11 @@ from tilefoundry.dsl.tf import *  # noqa: F401,F403
 from tilefoundry.ir.types.shard import Topology
 from tilefoundry.target import CudaTarget
 
+_CONFIG = Path(__file__).parents[2] / "models" / "qwen3_1_7b" / "config.json"
+MAX_POSITION_EMBEDDINGS = json.loads(_CONFIG.read_text(encoding="utf-8"))["max_position_embeddings"]
+
 SEQ = DimVar("seq", 1, 8193)
+CTX = DimVar("ctx_len", 0, MAX_POSITION_EMBEDDINGS)
 
 CAP = 4608
 
@@ -63,13 +78,12 @@ class PrefillLayer:
         act: Tensor[(SEQ, FFN), "bf16"],
         out: Tensor[(SEQ, HID), "bf16"],
     ) -> Tensor[(SEQ, HID), "bf16"]:
-        with Mesh(("cta",), layout=(CTAS,), names=("cta",)) as cta:
+        with Mesh(("cta",), layout=(CTAS,), names=("cta",)) as _cta:
             xb = xn
             for m in tile(SEQ, ROWS):  # noqa: F405
                 xr = tf.rms_norm(x[m, 0:HID], g_in)
                 xb = tf.insert_slice(xb, tf.reshard(xr, (ROWS, HID), "gmem"), (m, 0))
 
-        with Mesh(("cta",), layout=(CTAS,), names=("cta",)) as cta:
             p = qkv
             for m in tile(SEQ, ROWS):  # noqa: F405
                 for n in tile(QKV_N, BN):  # noqa: F405
@@ -85,7 +99,6 @@ class PrefillLayer:
                         acc = acc + tf.reshard(mm, (ROWS, BN), "rmem")
                     p = tf.insert_slice(p, tf.reshard(acc, (ROWS, BN), "gmem"), (m, n))
 
-        with Mesh(("cta",), layout=(CTAS,), names=("cta",)) as cta:
             qb = q
             kc2 = kc
             vc2 = vc
@@ -102,7 +115,6 @@ class PrefillLayer:
                 vc2 = tf.cache_update(vc2, cur, width, v4)
                 qb = tf.insert_slice(qb, tf.reshape(qr, (ROWS, HKV, G, D)), (m, 0, 0, 0))
 
-        with Mesh(("cta",), layout=(CTAS,), names=("cta",)) as cta:
             ab = attn
             for m in tile(SEQ, ROWS):  # noqa: F405
                 for kv in tile(HKV, 1):  # noqa: F405
@@ -115,7 +127,7 @@ class PrefillLayer:
                         )
                         lr = tf.reshard(tf.zeros((ROWS, 1), dtype="f32"), (ROWS, 1), "rmem")
                         acc = tf.reshard(tf.zeros((ROWS, D), dtype="f32"), (ROWS, D), "rmem")
-                        for c in tile(CAP, BKV):  # noqa: F405
+                        for c in tile(CTX + SEQ, BKV):  # noqa: F405
                             khb = tf.reshard(
                                 tf.reshape(kc2[0:1, c, kv, 0:D], (BKV, D)), (BKV, D), "smem"
                             )
@@ -141,7 +153,6 @@ class PrefillLayer:
                         ah = tf.reshard(tf.cast(tf.div(acc, lr), dtype="bf16"), (ROWS, D), "gmem")
                         ab = tf.insert_slice(ab, tf.reshape(ah, (ROWS, 1, 1, D)), (m, kv, g, 0))
 
-        with Mesh(("cta",), layout=(CTAS,), names=("cta",)) as cta:
             af = tf.reshape(ab, (SEQ, QN))
             hb = h1
             for m in tile(SEQ, ROWS):  # noqa: F405
@@ -160,7 +171,6 @@ class PrefillLayer:
                     sm = tf.cast(tf.cast(xr, dtype="f32") + op, dtype="bf16")
                     hb = tf.insert_slice(hb, tf.reshard(sm, (ROWS, BN), "gmem"), (m, n))
 
-        with Mesh(("cta",), layout=(CTAS,), names=("cta",)) as cta:
             gb = gu
             for m in tile(SEQ, ROWS):  # noqa: F405
                 xn1 = tf.rms_norm(hb[m, 0:HID], g_post)
@@ -191,7 +201,6 @@ class PrefillLayer:
                         (m, 1, n),
                     )
 
-        with Mesh(("cta",), layout=(CTAS,), names=("cta",)) as cta:
             acb = act
             for m in tile(SEQ, ROWS):  # noqa: F405
                 for n in tile(FFN, BN):  # noqa: F405
@@ -200,7 +209,6 @@ class PrefillLayer:
                     sw = tf.cast(tf.silu(gate) * up, dtype="bf16")
                     acb = tf.insert_slice(acb, tf.reshard(sw, (ROWS, BN), "gmem"), (m, n))
 
-        with Mesh(("cta",), layout=(CTAS,), names=("cta",)) as cta:  # noqa: F841
             o = out
             for m in tile(SEQ, ROWS):  # noqa: F405
                 for n in tile(HID, BN):  # noqa: F405
@@ -246,11 +254,10 @@ class PrefillLayer:
         act: Tensor[(SEQ, FFN), "bf16"],
         out: Tensor[(SEQ, HID), "bf16"],
     ) -> Tensor[(SEQ, HID), "bf16"]:
-        with Mesh(("cta",), layout=(CTAS,), names=("cta",)) as cta:
+        with Mesh(("cta",), layout=(CTAS,), names=("cta",)) as _cta:
             xr = tf.rms_norm(x[0:1, 0:HID], g_in)
             xb = tf.insert_slice(xn, tf.reshard(xr, (1, HID), "gmem"), (0, 0))
 
-        with Mesh(("cta",), layout=(CTAS,), names=("cta",)) as cta:
             p = qkv
             for n in tile(QKV_N, DN_QKV):  # noqa: F405
                 acc = tf.reshard(tf.zeros((1, DN_QKV), dtype="f32"), (1, DN_QKV), "rmem")
@@ -265,7 +272,6 @@ class PrefillLayer:
                     acc = acc + tf.reshard(mm, (1, DN_QKV), "rmem")
                 p = tf.insert_slice(p, tf.reshard(acc, (1, DN_QKV), "gmem"), (0, n))
 
-        with Mesh(("cta",), layout=(CTAS,), names=("cta",)) as cta:
             q4 = tf.reshape(tf.cast(p[0:1, 0:QN], dtype="bf16"), (1, 1, HQ, D))
             k4 = tf.reshape(tf.cast(p[0:1, QN : QN + KN], dtype="bf16"), (1, 1, HKV, D))
             v4 = tf.reshape(tf.cast(p[0:1, QN + KN : QKV_N], dtype="bf16"), (1, 1, HKV, D))
@@ -281,7 +287,6 @@ class PrefillLayer:
             vc2 = tf.cache_update(vc, cur, width, v4)
             qb = tf.insert_slice(q, tf.reshape(qr, (1, HKV, G, D)), (0, 0, 0, 0))
 
-        with Mesh(("cta",), layout=(CTAS,), names=("cta",)) as cta:
             ab = attn
             for kv in tile(HKV, 1):  # noqa: F405
                 for g in tile(G, 1):  # noqa: F405
@@ -289,7 +294,7 @@ class PrefillLayer:
                     mx = tf.reshard(tf.zeros((1, 1), dtype="f32") - 30000.0, (1, 1), "rmem")
                     lr = tf.reshard(tf.zeros((1, 1), dtype="f32"), (1, 1), "rmem")
                     acc = tf.reshard(tf.zeros((1, D), dtype="f32"), (1, D), "rmem")
-                    for c in tile(CAP, BKV):  # noqa: F405
+                    for c in tile(CTX + SEQ, BKV):  # noqa: F405
                         khb = tf.reshard(
                             tf.reshape(kc2[0:1, c, kv, 0:D], (BKV, D)), (BKV, D), "smem"
                         )
@@ -309,7 +314,6 @@ class PrefillLayer:
                     ah = tf.reshard(tf.cast(tf.div(acc, lr), dtype="bf16"), (1, D), "gmem")
                     ab = tf.insert_slice(ab, tf.reshape(ah, (1, 1, 1, D)), (0, kv, g, 0))
 
-        with Mesh(("cta",), layout=(CTAS,), names=("cta",)) as cta:
             af = tf.reshape(ab, (SEQ, QN))
             hb = h1
             for n in tile(HID, DN_O):  # noqa: F405
@@ -327,7 +331,6 @@ class PrefillLayer:
                 sm = tf.cast(tf.cast(xr, dtype="f32") + op, dtype="bf16")
                 hb = tf.insert_slice(hb, tf.reshard(sm, (1, DN_O), "gmem"), (0, n))
 
-        with Mesh(("cta",), layout=(CTAS,), names=("cta",)) as cta:
             gb = gu
             xn1 = tf.rms_norm(hb[0:1, 0:HID], g_post)
             for n in tile(FFN, DN_FFN):  # noqa: F405
@@ -363,7 +366,6 @@ class PrefillLayer:
                     (0, 1, n),
                 )
 
-        with Mesh(("cta",), layout=(CTAS,), names=("cta",)) as cta:
             acb = act
             for n in tile(FFN, DN_FFN):  # noqa: F405
                 gate = tf.reshard(tf.reshape(gb[0:1, 0:1, n], (1, DN_FFN)), (1, DN_FFN), "rmem")
@@ -371,7 +373,6 @@ class PrefillLayer:
                 sw = tf.cast(tf.silu(gate) * up, dtype="bf16")
                 acb = tf.insert_slice(acb, tf.reshard(sw, (1, DN_FFN), "gmem"), (0, n))
 
-        with Mesh(("cta",), layout=(CTAS,), names=("cta",)) as cta:  # noqa: F841
             o = out
             for n in tile(HID, DN_DOWN):  # noqa: F405
                 dp = tf.reshard(tf.zeros((1, DN_DOWN), dtype="f32"), (1, DN_DOWN), "rmem")
@@ -453,7 +454,7 @@ class PrefillLayer:
         out: Tensor[(SEQ, HID), "bf16"],
         logits: Tensor[(SEQ, V), "f32"],
     ) -> Tensor[(SEQ, V), "f32"]:
-        with Mesh(("cta",), layout=(CTAS,), names=("cta",)) as cta:
+        with Mesh(("cta",), layout=(CTAS,), names=("cta",)) as _cta:
             h = x
             for m in tile(SEQ, ROWS):  # noqa: F405
                 h = tf.insert_slice(
@@ -466,34 +467,33 @@ class PrefillLayer:
                     (m, 0),
                 )
 
-        for i in tile(L, 1):  # noqa: F405
-            h = layer_prefill(  # noqa: F405
-                h,
-                tf.reshape(w_qkv[i, 0:HID, 0:QKV_N], (HID, QKV_N)),
-                tf.reshape(w_o[i, 0:QN, 0:HID], (QN, HID)),
-                tf.reshape(w_gu[i, 0:HID, 0:2, 0:FFN], (HID, 2, FFN)),
-                tf.reshape(w_down[i, 0:FFN, 0:HID], (FFN, HID)),
-                tf.reshape(g_in[i, 0:HID], (HID,)),
-                tf.reshape(g_q[i, 0:D], (D,)),
-                tf.reshape(g_k[i, 0:D], (D,)),
-                tf.reshape(g_post[i, 0:HID], (HID,)),
-                kc[i, 0:CAP, 0:HKV, 0:D],
-                vc[i, 0:CAP, 0:HKV, 0:D],
-                cur,
-                cos,
-                sin,
-                pos,
-                xn,
-                qkv,
-                q,
-                attn,
-                h1,
-                gu,
-                act,
-                out,
-            )
+            for i in tile(L, 1):  # noqa: F405
+                h = layer_prefill(  # noqa: F405
+                    h,
+                    tf.reshape(w_qkv[i, 0:HID, 0:QKV_N], (HID, QKV_N)),
+                    tf.reshape(w_o[i, 0:QN, 0:HID], (QN, HID)),
+                    tf.reshape(w_gu[i, 0:HID, 0:2, 0:FFN], (HID, 2, FFN)),
+                    tf.reshape(w_down[i, 0:FFN, 0:HID], (FFN, HID)),
+                    tf.reshape(g_in[i, 0:HID], (HID,)),
+                    tf.reshape(g_q[i, 0:D], (D,)),
+                    tf.reshape(g_k[i, 0:D], (D,)),
+                    tf.reshape(g_post[i, 0:HID], (HID,)),
+                    kc[i, 0:CAP, 0:HKV, 0:D],
+                    vc[i, 0:CAP, 0:HKV, 0:D],
+                    cur,
+                    cos,
+                    sin,
+                    pos,
+                    xn,
+                    qkv,
+                    q,
+                    attn,
+                    h1,
+                    gu,
+                    act,
+                    out,
+                )
 
-        with Mesh(("cta",), layout=(CTAS,), names=("cta",)) as cta:  # noqa: F841
             lg = logits
             for m in tile(SEQ, ROWS):  # noqa: F405
                 hf = tf.rms_norm(h[m, 0:HID], g_final)
@@ -542,38 +542,37 @@ class PrefillLayer:
         out: Tensor[(SEQ, HID), "bf16"],
         logits: Tensor[(SEQ, V), "f32"],
     ) -> Tensor[(SEQ, V), "f32"]:
-        with Mesh(("cta",), layout=(CTAS,), names=("cta",)) as cta:
+        with Mesh(("cta",), layout=(CTAS,), names=("cta",)) as _cta:
             e = tf.reshard(tf.index_select(w_embed, ids[0:1], dim=0), (1, HID), "gmem")
             h = tf.insert_slice(x, e, (0, 0))
 
-        for i in tile(L, 1):  # noqa: F405
-            h = layer_decode(  # noqa: F405
-                h,
-                tf.reshape(w_qkv[i, 0:HID, 0:QKV_N], (HID, QKV_N)),
-                tf.reshape(w_o[i, 0:QN, 0:HID], (QN, HID)),
-                tf.reshape(w_gu[i, 0:HID, 0:2, 0:FFN], (HID, 2, FFN)),
-                tf.reshape(w_down[i, 0:FFN, 0:HID], (FFN, HID)),
-                tf.reshape(g_in[i, 0:HID], (HID,)),
-                tf.reshape(g_q[i, 0:D], (D,)),
-                tf.reshape(g_k[i, 0:D], (D,)),
-                tf.reshape(g_post[i, 0:HID], (HID,)),
-                kc[i, 0:CAP, 0:HKV, 0:D],
-                vc[i, 0:CAP, 0:HKV, 0:D],
-                cur,
-                cos,
-                sin,
-                pos,
-                xn,
-                qkv,
-                q,
-                attn,
-                h1,
-                gu,
-                act,
-                out,
-            )
+            for i in tile(L, 1):  # noqa: F405
+                h = layer_decode(  # noqa: F405
+                    h,
+                    tf.reshape(w_qkv[i, 0:HID, 0:QKV_N], (HID, QKV_N)),
+                    tf.reshape(w_o[i, 0:QN, 0:HID], (QN, HID)),
+                    tf.reshape(w_gu[i, 0:HID, 0:2, 0:FFN], (HID, 2, FFN)),
+                    tf.reshape(w_down[i, 0:FFN, 0:HID], (FFN, HID)),
+                    tf.reshape(g_in[i, 0:HID], (HID,)),
+                    tf.reshape(g_q[i, 0:D], (D,)),
+                    tf.reshape(g_k[i, 0:D], (D,)),
+                    tf.reshape(g_post[i, 0:HID], (HID,)),
+                    kc[i, 0:CAP, 0:HKV, 0:D],
+                    vc[i, 0:CAP, 0:HKV, 0:D],
+                    cur,
+                    cos,
+                    sin,
+                    pos,
+                    xn,
+                    qkv,
+                    q,
+                    attn,
+                    h1,
+                    gu,
+                    act,
+                    out,
+                )
 
-        with Mesh(("cta",), layout=(CTAS,), names=("cta",)) as cta:  # noqa: F841
             lg = logits
             hf = tf.rms_norm(h[0:1, 0:HID], g_final)
             for n in tile(V, BN):  # noqa: F405

--- a/tests/inspection/test_module_tree_roundtrip.py
+++ b/tests/inspection/test_module_tree_roundtrip.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from tests._source import import_dsl
 from tests.fixtures.logical import module_context as context_fixture
+from tests.fixtures.logical.gqa_static import static_online_attend
 from tests.fixtures.logical.hir_composition import Expert
 from tests.fixtures.placed.derived_prefill import DerivedPrefill
 from tests.fixtures.placed.flash_split_k_decode import FlashSplitKDecode
@@ -26,6 +27,7 @@ from tilefoundry.dsl import (  # noqa: F401
     tf,
 )
 from tilefoundry.inspection import as_script
+from tilefoundry.inspection.dot import hir_function_to_dot
 from tilefoundry.ir.core import Call
 from tilefoundry.ir.core.module import Module
 from tilefoundry.ir.hir.specialize import origin_of
@@ -308,7 +310,7 @@ class _Dispatching:
         pass
 
     @dispatch.specialize(DimVarRangePat("n_print", 1, 9))
-    def _(x: Tensor[(_N, 8), "f32"]) -> Tensor[(_N, 8), "f32"]:
+    def child_dispatch(x: Tensor[(_N, 8), "f32"]) -> Tensor[(_N, 8), "f32"]:
         return leaf(x)  # noqa: F821
 
 
@@ -330,3 +332,12 @@ def test_a_child_call_in_a_specialization_body_survives_the_round_trip() -> None
     assert variant.body.target is imported_child.entry_function()
     assert len(variant.body.args) == 1
     assert [param.is_const for param in variant.body.target.params] == [False, True]
+
+
+def test_hir_function_dot_keeps_grid_regions_as_opaque_leaves() -> None:
+    """The public DOT form keeps structured regions as white leaf boxes."""
+    dot = hir_function_to_dot(static_online_attend.entry_function())
+
+    assert len(dot.splitlines()) == 29
+    assert 'label="GridRegionExpr", fillcolor="#ffffff"' in dot
+    assert "TupleType(" not in dot

--- a/tests/inspection/test_specialization_print.py
+++ b/tests/inspection/test_specialization_print.py
@@ -42,7 +42,7 @@ def test_prototype_prints_pass_base_and_specialize_blocks() -> None:
     """Test prototype prints pass base and specialize blocks.
 
     The base is a pass-bodied prototype and each variant a ``.specialize`` block
-    over a throwaway ``def _``. The ``@module``-wrapped form must emit the same
+    over a generated binding. The ``@module``-wrapped form must emit the same
     ``DimVarRangePat`` import as the standalone form — module and standalone output
     share one header emitter, so a construct requiring an extra import in one mode
     requires it in both.
@@ -52,7 +52,8 @@ def test_prototype_prints_pass_base_and_specialize_blocks() -> None:
 
     for src in (standalone, in_module):
         assert "    pass" in src
-        assert "def _(" in src
+        assert "def variant_S_1_3(" in src
+        assert "def variant_S_4_7(" in src
         assert '@main.specialize(DimVarRangePat("S", 1, 3))' in src
         assert '@main.specialize(DimVarRangePat("S", 4, 7))' in src
 

--- a/tests/integration/test_dynamic_shape_dispatch.py
+++ b/tests/integration/test_dynamic_shape_dispatch.py
@@ -26,11 +26,11 @@ class Dispatch:
         pass
 
     @main.specialize(DimVarRangePat("S", 1, 4))
-    def _(x: Tensor[(_S,), "f32"]) -> Tensor[(_S,), "f32"]:
+    def small_shape(x: Tensor[(_S,), "f32"]) -> Tensor[(_S,), "f32"]:
         return mul(x, x)  # noqa: F821  (bound via ``from tilefoundry.dsl.tf import *``)
 
     @main.specialize(DimVarRangePat("S", 4, 8))
-    def _(x: Tensor[(_S,), "f32"]) -> Tensor[(_S,), "f32"]:
+    def large_shape(x: Tensor[(_S,), "f32"]) -> Tensor[(_S,), "f32"]:
         return add(x, x)  # noqa: F821
 
 

--- a/tests/ir/test_visitor.py
+++ b/tests/ir/test_visitor.py
@@ -1,20 +1,28 @@
 """``tilefoundry.ir.visitor`` — Expr / Stmt visitor + mutator contract.
 
-Every pass is written against these four guarantees, and a break in any of them
+Every pass is written against these six guarantees, and a break in any of them
 shows up in a pass's output rather than at its cause: class-name dispatch, an
 untouched child stays *the same object* (so a pass rewriting one node cannot
 silently deep-copy the tree), binding-site Vars are never handed to a generic
 mutator, and a Stmt subclass missing from the rebuild tables is caught here
-instead of dropping statements downstream.
+instead of dropping statements downstream; Expr dispatch and memoization are
+separate, and unhandled Expr nodes fail explicitly.
 """
 
 from __future__ import annotations
 
+import gc
+
+import pytest
+
+from tilefoundry.analysis.walk import postorder
 from tilefoundry.ir.core import Call, Constant, Expr, Op, Var
+from tilefoundry.ir.hir.function import Function
 from tilefoundry.ir.hir.grid_region import GridRegionExpr
 from tilefoundry.ir.tir.cuda.nn.mma import Mma
 from tilefoundry.ir.tir.memory import Copy, Fill
 from tilefoundry.ir.tir.prim_function import PrimFunction
+from tilefoundry.ir.tir.shape import ShapeOf
 from tilefoundry.ir.tir.stmts import (
     Evaluate,
     For,
@@ -31,8 +39,10 @@ from tilefoundry.ir.types.shard import make_mesh
 from tilefoundry.ir.types.shard.mesh import Topology
 from tilefoundry.ir.types.storage import StorageKind
 from tilefoundry.ir.visitor import (
+    ExprFunctor,
     ExprMutator,
     ExprVisitor,
+    ExprWalker,
     StmtExprMutator,
     StmtMutator,
     StmtVisitor,
@@ -91,12 +101,129 @@ def test_expr_visitor_dispatches_by_class_name_and_shares_unchanged_branches() -
 
         def visit_Call(self, call):
             visits.append(("Call", type(call.target).__name__))
-            self.generic_visit(call)
+            self.visit_operands(call)
 
     tree = _call(_OpA(), _var("x"), _const(1.0))
     V().visit(tree)
     assert visits == [("Call", "_OpA"), ("Var", "x"), ("Constant", 1.0)]
     assert ExprMutator().visit(tree) is tree
+
+
+def test_expr_functor_and_visitor_split_memo_from_rewrite() -> None:
+    assert issubclass(ExprVisitor, ExprFunctor)
+    assert issubclass(ExprWalker, ExprVisitor)
+    assert issubclass(ExprMutator, ExprFunctor)
+
+    shared = _var("shared")
+    tree = _call(_OpA(), shared, shared)
+
+    class FreshVars(ExprMutator):
+        def visit_Var(self, var: Var) -> Var:
+            return _var(var.name)
+
+    rewritten = FreshVars().visit(tree)
+    assert rewritten.args[0] is not shared
+    assert rewritten.args[1] is not shared
+    assert rewritten.args[0] is not rewritten.args[1]
+
+
+def test_expr_visitor_memo_visits_shared_dag_once_and_returns_same_result() -> None:
+    shared = _call(_OpA(), _var("shared"))
+    tree = _call(_OpB(), shared, shared)
+
+    class CountingVisitor(ExprVisitor[object]):
+        def __init__(self) -> None:
+            super().__init__()
+            self.counts: dict[str, int] = {}
+
+        def _count(self, expr: Expr) -> None:
+            name = type(expr).__name__
+            self.counts[name] = self.counts.get(name, 0) + 1
+
+        def visit_Var(self, var: Var) -> str:
+            self._count(var)
+            return var.name
+
+        def visit_Call(self, call: Call) -> tuple[str, tuple[object, ...]]:
+            self._count(call)
+            return (type(call.target).__name__, tuple(self.visit(arg) for arg in call.args))
+
+    class CountingFunctor(ExprFunctor[object]):
+        def __init__(self) -> None:
+            super().__init__()
+            self.counts: dict[str, int] = {}
+
+        def _count(self, expr: Expr) -> None:
+            name = type(expr).__name__
+            self.counts[name] = self.counts.get(name, 0) + 1
+
+        def visit_Var(self, var: Var) -> str:
+            self._count(var)
+            return var.name
+
+        def visit_Call(self, call: Call) -> tuple[str, tuple[object, ...]]:
+            self._count(call)
+            return (type(call.target).__name__, tuple(self.visit(arg) for arg in call.args))
+
+    visitor = CountingVisitor()
+    functor = CountingFunctor()
+    assert visitor.visit(tree) == functor.visit(tree)
+    assert visitor.counts == {"Call": 2, "Var": 1}
+    assert functor.counts == {"Call": 3, "Var": 2}
+    assert visitor.visit(shared) == ("_OpA", ("shared",))
+    assert visitor.counts == {"Call": 2, "Var": 1}
+
+
+def test_collected_postorder_visits_each_shared_expression_once() -> None:
+    """The collected analysis path witnesses identity-DAG traversal directly."""
+    shared = _call(_OpA(), _var("shared"))
+    root = _call(_OpB(), shared, shared)
+
+    ordered = postorder(root)
+
+    assert [type(expr).__name__ for expr in ordered] == ["Var", "Call", "Call"]
+    assert ordered[1] is shared
+    assert ordered[2] is root
+
+
+def test_expr_visitor_pins_memo_expr_and_uses_explicit_function_root() -> None:
+    expr = _var("pinned")
+    key = id(expr)
+    marker = object()
+
+    class V(ExprVisitor[object]):
+        def visit_Var(self, var: Var) -> object:
+            return marker
+
+    visitor = V()
+    assert visitor.visit(expr) is marker
+    del expr
+    gc.collect()
+    for i in range(64):
+        _var(f"replacement_{i}")
+
+    pinned, result = visitor._memo[key]
+    assert id(pinned) == key
+    assert visitor.visit(pinned) is result is marker
+
+    body = _var("body")
+    root = Function.build(name="root", params=(), body=body, return_type=body.type)
+    other_body = _var("other_body")
+    other = Function.build(name="other", params=(), body=other_body, return_type=other_body.type)
+    rooted = V(root_function=root)
+    assert rooted.can_visit_function_body(root)
+    assert not rooted.can_visit_function_body(other)
+    assert rooted.visit_function_body(root) is marker
+    assert rooted.visit_function_body(other) is None
+    other_enabled = V(visit_other_functions=True, root_function=root)
+    assert other_enabled.can_visit_function_body(other)
+    assert other_enabled.visit_function_body(other) is marker
+
+
+def test_expr_functor_requires_explicit_handler_for_unknown_expr() -> None:
+    shape = ShapeOf(type=_i32(), param=_var("x"), axis=0)
+    with pytest.raises(NotImplementedError, match="ShapeOf"):
+        ExprVisitor().visit(shape)
 
     x = _var("x")
     y = _var("y")

--- a/tests/ir/test_visitor.py
+++ b/tests/ir/test_visitor.py
@@ -42,7 +42,6 @@ from tilefoundry.ir.visitor import (
     ExprFunctor,
     ExprMutator,
     ExprVisitor,
-    ExprWalker,
     StmtExprMutator,
     StmtMutator,
     StmtVisitor,
@@ -109,11 +108,7 @@ def test_expr_visitor_dispatches_by_class_name_and_shares_unchanged_branches() -
     assert ExprMutator().visit(tree) is tree
 
 
-def test_expr_functor_and_visitor_split_memo_from_rewrite() -> None:
-    assert issubclass(ExprVisitor, ExprFunctor)
-    assert issubclass(ExprWalker, ExprVisitor)
-    assert issubclass(ExprMutator, ExprFunctor)
-
+def test_expr_mutator_does_not_share_rewrite_results() -> None:
     shared = _var("shared")
     tree = _call(_OpA(), shared, shared)
 

--- a/tests/parser/error_cases.py
+++ b/tests/parser/error_cases.py
@@ -843,6 +843,68 @@ _CALL_BOUNDARY: tuple[ParseErrorCase, ...] = (
 )
 
 
+_FUNCTION_BINDINGS: tuple[ParseErrorCase, ...] = (
+    ParseErrorCase(
+        id="kernel-binding-underscore",
+        subject="""
+            from tilefoundry import func, module
+            from tilefoundry.dsl import Tensor
+
+            @module()
+            class _KernelUnderscore:
+                @func
+                def _(x: Tensor[(8,), "f32"]) -> Tensor[(8,), "f32"]:
+                    return x
+        """,
+        raises=ValueError,
+        match=r"@module '_KernelUnderscore': a kernel binding may not be named '_'",
+    ),
+    ParseErrorCase(
+        id="variant-binding-underscore",
+        subject="""
+            from tilefoundry import func, module
+            from tilefoundry.dsl import DimVar, DimVarRangePat, Tensor
+
+            _N = DimVar("N", 1, 8)
+
+            @module()
+            class _VariantUnderscore:
+                @func
+                def dispatch(x: Tensor[(_N,), "f32"]) -> Tensor[(_N,), "f32"]:
+                    pass
+
+                @dispatch.specialize(DimVarRangePat("N", 1, 4))
+                def _(x: Tensor[(_N,), "f32"]) -> Tensor[(_N,), "f32"]:
+                    return x
+        """,
+        raises=ValueError,
+        match=(
+            r"@module '_VariantUnderscore' base 'dispatch': "
+            r"a variant binding may not be named '_'"
+        ),
+    ),
+    ParseErrorCase(
+        id="duplicate-kernel-binding",
+        subject="""
+            from tilefoundry import func, module
+            from tilefoundry.dsl import Tensor
+
+            @module()
+            class _DuplicateKernel:
+                @func
+                def run(x: Tensor[(8,), "f32"]) -> Tensor[(8,), "f32"]:
+                    return x
+
+                @func
+                def run(x: Tensor[(8,), "f32"]) -> Tensor[(8,), "f32"]:
+                    return x
+        """,
+        raises=ValueError,
+        match=r"@module '_DuplicateKernel': duplicate kernel binding 'run'",
+    ),
+)
+
+
 _SUBSCRIPTS: tuple[ParseErrorCase, ...] = (
     ParseErrorCase(
         id="tile-with-too-many-args",
@@ -1324,6 +1386,7 @@ ERROR_CASES: tuple[ParseErrorCase, ...] = (
     *_OP_CALL_SURFACE,
     *_DIM_OPERANDS,
     *_CALL_BOUNDARY,
+    *_FUNCTION_BINDINGS,
     *_SUBSCRIPTS,
     *_GRID_LOOPS,
     *_SHARD_SUGAR,

--- a/tests/parser/golden/hir_module.py
+++ b/tests/parser/golden/hir_module.py
@@ -152,7 +152,7 @@ class HirModule:
         pass
 
     @dispatches_to_a_variant.specialize(DimVarRangePat("N", 1, 64))
-    def _(
+    def scaled_variant(
         x: Tensor[(N,), "f32"]
     ) -> Tensor[(N,), "f32"]:
         v0 = variant_leaf(x)

--- a/tests/parser/programs.py
+++ b/tests/parser/programs.py
@@ -455,7 +455,7 @@ class HirModule:
         pass
 
     @dispatches_to_a_variant.specialize(DimVarRangePat("N", 1, 64))  # noqa: F821
-    def _(x: Tensor[(N_SCALED,), "f32"]) -> Tensor[(N_SCALED,), "f32"]:
+    def scaled_variant(x: Tensor[(N_SCALED,), "f32"]) -> Tensor[(N_SCALED,), "f32"]:
         return variant_leaf(x)  # noqa: F821
 
     @func

--- a/tests/parser/test_programs.py
+++ b/tests/parser/test_programs.py
@@ -18,6 +18,7 @@ import torch
 
 from tests._source import import_dsl
 from tests.fixtures.placed.mma_tile import MatmulModule
+from tests.fixtures.placed.qwen3_1_7b_pd import PrefillLayer
 from tests.parser.conftest import GoldenFiles
 from tests.parser.error_cases import literal_reshard_func, mesh_dims_reshard_func
 from tests.parser.programs import (
@@ -37,8 +38,10 @@ from tests.parser.programs import (
     doubles_a_constant,
     returns_a_pair,
 )
+from tilefoundry import func, module
 from tilefoundry.analysis.preflight import infer_authored_types
 from tilefoundry.analysis.walk import postorder
+from tilefoundry.dsl import ConstTensor, DimVarRangePat, Tensor
 from tilefoundry.dsl._stub_gen import regen_stubs
 from tilefoundry.evaluator import evaluate
 from tilefoundry.evaluator.dim import resolve_dim
@@ -68,6 +71,40 @@ def test_a_feature_dense_program_parses_to_its_golden(
 ) -> None:
     """Parsing the program yields exactly the recorded IR, printed back as source."""
     golden.check(f"{program.name}.py", as_script(program.parsed))
+
+
+def test_the_qwen3_pd_fixture_parses_with_two_regime_variants() -> None:
+    """The 28-layer prefill/decode fixture is accepted by the parser."""
+    model = PrefillLayer.lookup("model")
+    assert len(model.variants) == 2
+
+
+def test_converter_declared_before_variants_is_retained() -> None:
+    seq = DimVar("converter_before_variant", 1, 8)
+
+    @module()
+    class ConverterThenVariants:
+        @func
+        def dispatch(
+            x: Tensor[(seq,), "f32"], w: ConstTensor[(8,), "f32"]
+        ) -> Tensor[(seq,), "f32"]:
+            pass
+
+        @dispatch.converter("w")
+        def convert(w: ConstTensor[(8,), "f32"]) -> Tensor[(8,), "f32"]:
+            return w
+
+        @dispatch.specialize(DimVarRangePat("converter_before_variant", 1, 4))
+        def small(x: Tensor[(seq,), "f32"], w: ConstTensor[(8,), "f32"]) -> Tensor[(seq,), "f32"]:
+            return x
+
+        @dispatch.specialize(DimVarRangePat("converter_before_variant", 4, 8))
+        def large(x: Tensor[(seq,), "f32"], w: ConstTensor[(8,), "f32"]) -> Tensor[(seq,), "f32"]:
+            return x
+
+    dispatch = ConverterThenVariants.lookup("dispatch")
+    assert len(dispatch.converters) == 1
+    assert len(dispatch.variants) == 2
 
 
 def test_annotation_sugar_lands_on_the_hand_written_layout() -> None:

--- a/tests/parser/test_programs.py
+++ b/tests/parser/test_programs.py
@@ -18,7 +18,6 @@ import torch
 
 from tests._source import import_dsl
 from tests.fixtures.placed.mma_tile import MatmulModule
-from tests.fixtures.placed.qwen3_1_7b_pd import PrefillLayer
 from tests.parser.conftest import GoldenFiles
 from tests.parser.error_cases import literal_reshard_func, mesh_dims_reshard_func
 from tests.parser.programs import (
@@ -71,12 +70,6 @@ def test_a_feature_dense_program_parses_to_its_golden(
 ) -> None:
     """Parsing the program yields exactly the recorded IR, printed back as source."""
     golden.check(f"{program.name}.py", as_script(program.parsed))
-
-
-def test_the_qwen3_pd_fixture_parses_with_two_regime_variants() -> None:
-    """The 28-layer prefill/decode fixture is accepted by the parser."""
-    model = PrefillLayer.lookup("model")
-    assert len(model.variants) == 2
 
 
 def test_converter_declared_before_variants_is_retained() -> None:

--- a/tests/runtime/test_child_module_resources.py
+++ b/tests/runtime/test_child_module_resources.py
@@ -133,11 +133,11 @@ def test_a_variant_this_dispatch_did_not_select_has_no_say() -> None:
             pass
 
         @dispatch.specialize(DimVarRangePat("n_resource", 1, 5))
-        def _(x: Tensor[(_N,), "f32"]) -> Tensor[(_N,), "f32"]:
+        def near_dispatch(x: Tensor[(_N,), "f32"]) -> Tensor[(_N,), "f32"]:
             return near(x)  # noqa: F821
 
         @dispatch.specialize(DimVarRangePat("n_resource", 5, 9))
-        def _(x: Tensor[(_N,), "f32"]) -> Tensor[(_N,), "f32"]:
+        def far_dispatch(x: Tensor[(_N,), "f32"]) -> Tensor[(_N,), "f32"]:
             return far(x)  # noqa: F821
 
     reading = _Dispatch.load(
@@ -201,11 +201,11 @@ class _Nested:
         pass
 
     @pick.specialize(DimVarRangePat("n_resource", 1, 5))
-    def _(x: Tensor[(_N,), "f32"]) -> Tensor[(_N,), "f32"]:
+    def near_dispatch(x: Tensor[(_N,), "f32"]) -> Tensor[(_N,), "f32"]:
         return near(x)  # noqa: F821
 
     @pick.specialize(DimVarRangePat("n_resource", 5, 9))
-    def _(x: Tensor[(_N,), "f32"]) -> Tensor[(_N,), "f32"]:
+    def far_dispatch(x: Tensor[(_N,), "f32"]) -> Tensor[(_N,), "f32"]:
         return far(x)  # noqa: F821
 
 


### PR DESCRIPTION
## Why

- The complete 28-layer Qwen3 fixture exceeded the 240-second baseline import timeout (exit 124). The repaired traversal parses it in 1.86 seconds and now analyzes prefill from `ctx_len=0`, prefill from `ctx_len=512`, and decode at `ctx_len=4608`.

## What

- Adds memoized Expr DAG traversal infrastructure and adopts it across the audited expression walkers and mutators.
- Keeps `CAP` for cache allocation and uses `ctx_len + seq` for the attention scan, so the fixture models both prefill contexts and decode. Consolidates identical lexical `Mesh` wrappers and keeps per-function layer boundaries for analysis.

## Contract

- Adds the three parsed Function naming and classification rules to `docs/spec/hir.md`; `docs/spec/parser.md` section 1.1 references them (`def _` is invalid for kernels and variants but remains valid for converters). The three new refusals are table-driven in `tests/parser/error_cases.py`.
- Defines the `ExprFunctor` / `ExprVisitor` / `ExprWalker` layers and `default_visit` behavior in `docs/spec/visitor-mutator.md`, and specifies synthetic bindings for unlabeled variant printing in `docs/spec/inspection.md`.
- The Qwen3 witness now lives under `tests/fixtures/placed/` rather than `tests/fixtures/logical/`; its context bound is read from the model config JSON without importing the executable model.

## Risk

- TIR Stmt traversal is an independent decision and is not changed by this PR.
- Authoritative verification `expr_dag_m3_authoritative_20260815g` completed with 1036 tests, 0 failures, 0 errors, and 4 skips; coverage was 85.3% lines / 72.7% branches. JUnit and artifacts are in `docs/plans/expr-dag-traversal/evidence/m3-authoritative-20260815e/`.
