### PR TITLE
docs(tutorial): repair the index diagram and stop listing the pages twice

### DIFF
--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -7,33 +7,30 @@ implementation is source code, and either can be pointed at any command.
 ```text
   step one — describe it, until it agrees
 
-                                 ┌──── not yet ───── ----------─┐
-                                 ▼                              │
-      published model ─────► authored HIR ─────► check ok ? ────┘
-                             the reference          │
-                                                 agrees    
+        ┌────────── fix the HIR ◄────────── not yet ──────────┐
+        ▼                                                     │
+   authored HIR ─────► check ─────► agrees? ───────────────────┘
+   the reference                       │
+        ▲                             yes
+        │                              ▼
+   published model            the reference is finished
 
   step two — make it fast; both roads lead back to the same source
 
-        ┌────── change the HIR ◄────── not yet ─────-------------─┐
-        ▼                                                         │
+        ┌────── change the HIR ◄────── not yet ──────┐
+        ▼                                            │
    authored HIR ─────► analyze ─────► predicted performance ok? ──┘
         ▲                                     │
         │                                    yes
         │                                     ▼
-        │                            write a runtime twin ─────► check ─────► measure
-        │                                                                       │
-        └────────────────── no ◄────────────────────────----------measured performance ok?
-                                                                                |
-                                                                                └─────────► ship
+        │          write a runtime twin ─────► check ─────► measure
+        │                                                     │
+        │                                       measured performance ok?
+        │                                             ┌───────┴───────┐
+        └─────────────────── no ◄─────────────────────┘               └──► ship
 ```
 
 ## Where the other answers are
 
-- `tilefoundry tutorial migrate` — describe a published step as authored HIR, and
-  make `check` agree with the implementation that shipped.
-- `tilefoundry tutorial optimize` — price a placement decision with `analyze`, then
-  hold a runtime twin to the authored program.
-- `tilefoundry tutorial authoring` — one kernel through six analyze-driven stages.
 - `tilefoundry tutorial orchestrator causal_lm` — the shipped autoregressive decode
   loop.


### PR DESCRIPTION
## Why
- `index.md`'s flow diagram shipped with broken box drawing: ASCII hyphen runs
  spliced into the line work (`───── ----------─`), an ASCII `|` among the box
  glyphs, a label welded onto a return arrow (`no ◄────----------measured
  performance ok?`), a stray space in `check ok ?`, trailing whitespace, and a
  step-one loop that never closes — `agrees` points at nothing and the `fix`
  edge is missing.
- The page also lists `migrate` / `optimize` / `authoring` itself, while
  `render_index` already builds "The pages:" from `PAGES`. `tilefoundry
  tutorial` prints both lists back to back.

## What
- Redraw both steps in one grammar: the return edge on top, the decision on the
  main line, the branch below. Step one now closes (`agrees? → yes → the
  reference is finished`, `not yet → fix the HIR`) and step two keeps both roads
  returning to the authored HIR — the predicted one from `analyze`, the measured
  one from the twin.
- Drop the three page entries from "Where the other answers are"; keep the
  `tutorial orchestrator causal_lm` pointer, which the generated list does not
  cover.

## Contract
- None. `docs/spec/cli.md` already says a page's own list is the parser's to
  render; this makes the page obey it.

## Risk
- None. `index.md` is hand-written, not rendered from a notebook, so
  `scripts/render_tutorial.py` does not overwrite it. Installed suite: 168
  tests, 0 failures.
