### PR TITLE
fix(spec-refs): anchor a page's reference beside the page

### DIFF
--- a/docs/SPEC-RULES.md
+++ b/docs/SPEC-RULES.md
@@ -77,11 +77,12 @@ Every reference to a spec section is a markdown link:
 
     [<doc> §<number>](<path>#<github-anchor>)
 
-*path* is relative inside `docs/spec` (`./runtime.md`), repository-root
-everywhere else (`docs/spec/runtime.md`). The anchor MUST name the section the
-display text numbers, never a heading nested under it. A bare `§2.3` records
-which section was true once; the link breaks when the heading moves, which is
-the point.
+*path* is relative inside a page (`./runtime.md`) and repository-root from
+code (`docs/spec/runtime.md`): a renderer resolves a page's links beside the
+page, and a source file has no anchor but the root. The anchor MUST name the
+section the display text numbers, never a heading nested under it. A bare
+`§2.3` records which section was true once; the link breaks when the heading
+moves, which is the point.
 
 `scripts/spec_refs_lint.py` enforces this over `docs/spec/*.md`, `src/`,
 `tests/` and `include/`; a `§` inside a fenced block is example text.

--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -180,7 +180,7 @@ bounds the caller stated.
     run happens. Omitted, it is the device the selection's Target declares. Given,
     it is honoured as stated: a Target declaring CUDA no longer refuses a machine
     without one, because the caller has said where to run. The evaluator picks no
-    device of its own ([evaluator §2](docs/spec/evaluator.md#2-parameters-and-inputs)).
+    device of its own ([evaluator §2](./evaluator.md#2-parameters-and-inputs)).
   - A FAIL with `--inputs random` MUST state that the draw makes each activation
     independently; a target that relies on semantic relationships between
     activations MAY differ at ulp scale without either implementation being wrong,

--- a/scripts/spec_refs_lint.py
+++ b/scripts/spec_refs_lint.py
@@ -67,16 +67,16 @@ def anchors(document: Path) -> dict[str, str | None]:
 def _target_document(source: Path, path: str) -> Path | None:
     """The document a reference's target names, or None if it names none.
 
-    A repository-root path is read from the root, anything else from beside the
-    referring file. Which of the two a reference uses is a matter of where it is
-    written -- relative inside `docs/spec`, root-relative from code -- but both
-    resolve the same way wherever they appear, so the check does not need to know
-    the convention to enforce the link. An empty path is the same document, which
-    only means anything in markdown.
+    Where a path is anchored follows from what reads it. A reference in code is
+    read from the repository root, the only anchor a `.py` or `.h` file has, so
+    it spells the root path. A reference in a page is read by a renderer, which
+    resolves every link beside the page holding it, so the root path is not a
+    path a page can use at all -- `_why` refuses it before this. An empty path
+    is the same document, which only means anything in markdown.
     """
     if not path:
         return source if source.suffix == ".md" else None
-    if path.startswith("docs/"):
+    if path.startswith("docs/") and source.suffix != ".md":
         return (_ROOT / path).resolve()
     return (source.parent / path).resolve()
 
@@ -149,7 +149,10 @@ def _why(source: Path, display: str, target: str) -> str:
     if "#" not in target:
         return "names no heading; the target needs a `#<anchor>`"
     path, _, fragment = target.partition("#")
-    document = _target_document(source, path.strip())
+    path = path.strip()
+    if source.suffix == ".md" and path.startswith("docs/"):
+        return f"{path!r} is a repository-root path; a page's links resolve beside the page"
+    document = _target_document(source, path)
     if document is None or not document.is_file():
         return f"target document {path!r} does not exist"
     named = spelled.group("doc")
@@ -185,7 +188,7 @@ def main(argv: list[str]) -> int:
             "\nA reference to a spec section MUST be written "
             "`[<doc> §<number>](<path>#<github-anchor>)`, with the anchor naming "
             "the very section the display text numbers -- `./<doc>.md` from "
-            "inside docs/spec, `docs/spec/<doc>.md` from anywhere else. Ask "
+            "inside a page, `docs/spec/<doc>.md` from code. Ask "
             "`tilefoundry spec <topic>` for the sections a document has.",
             file=sys.stderr,
         )

--- a/tests/scripts/test_spec_refs_lint.py
+++ b/tests/scripts/test_spec_refs_lint.py
@@ -1,0 +1,129 @@
+"""The spec-reference checker, held to the anchoring each kind of file reads.
+
+A renderer resolves a page's links beside the page; a source file has no anchor
+but the repository root. A checker that takes both spellings everywhere passes a
+page whose link renders dead, which is how one reached `main`. So both
+directions are asserted here: the spelling each kind of file must use, and the
+spelling it must refuse.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "spec_refs_lint.py"
+
+
+_COVERED = re.compile(r"^(docs/spec/.*\.md|src/.*\.py|tests/.*\.py|include/.*\.(h|cuh))$")
+
+
+_SECTION = "§" + "2"
+
+
+_ANCHOR = "#2-parameters-and-inputs"
+
+
+def _lint():
+    """The checker, loaded from the script the hook runs."""
+    spec = importlib.util.spec_from_file_location("spec_refs_lint", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _reference(path: str) -> str:
+    """One whole reference to the fixture's numbered section, assembled not written.
+
+    The hook reads `tests/*.py`, so a reference spelled out here would be a
+    reference the checker resolves against this repository rather than against
+    the fixture tree, and this file would be reported for a fixture's spelling.
+    A section mark left standing in prose is a bare reference to the same hook,
+    so the mark is assembled too.
+    """
+    return f"[runtime {_SECTION}]({path}{_ANCHOR})"
+
+
+@pytest.fixture
+def lint(tmp_path, monkeypatch):
+    """The checker over a fixture tree holding one spec page with a section 2."""
+    module = _lint()
+    monkeypatch.setattr(module, "_ROOT", tmp_path)
+    page = tmp_path / "docs" / "spec" / "runtime.md"
+    page.parent.mkdir(parents=True)
+    page.write_text("# Runtime\n\n## 2. Parameters and inputs\n\nProse.\n", encoding="utf-8")
+    return module
+
+
+def _page(tmp_path, text: str) -> Path:
+    target = tmp_path / "docs" / "spec" / "cli.md"
+    target.write_text(text, encoding="utf-8")
+    return target
+
+
+def _source(tmp_path, text: str) -> Path:
+    target = tmp_path / "src" / "tilefoundry" / "runtime.py"
+    target.parent.mkdir(parents=True)
+    target.write_text(text, encoding="utf-8")
+    return target
+
+
+def test_a_page_links_beside_itself(lint, tmp_path) -> None:
+    assert lint.findings(_page(tmp_path, _reference("./runtime.md"))) == []
+
+
+def test_a_page_refuses_the_repository_root_path(lint, tmp_path) -> None:
+    """The form that resolves from the root and renders dead from the page."""
+    found = lint.findings(_page(tmp_path, _reference("docs/spec/runtime.md")))
+
+    assert len(found) == 1
+    assert "repository-root path" in found[0][1]
+
+
+def test_code_links_from_the_repository_root(lint, tmp_path) -> None:
+    """The root path is what a source file has, and stays accepted there."""
+    assert lint.findings(_source(tmp_path, f"# {_reference('docs/spec/runtime.md')}\n")) == []
+
+
+def test_a_page_naming_a_missing_document_is_still_reported(lint, tmp_path) -> None:
+    """Refusing the root path did not swallow the check it used to fail."""
+    found = lint.findings(_page(tmp_path, _reference("./gone.md")))
+
+    assert len(found) == 1
+    assert "does not exist" in found[0][1]
+
+
+def test_the_exit_status_and_the_report_name_the_line(lint, tmp_path, capsys) -> None:
+    """The hook's own contract: non-zero, and enough on stdout to go fix it."""
+    target = _page(tmp_path, f"Prose.\n\nA run says so ({_reference('docs/spec/runtime.md')}).\n")
+
+    status = lint.main([str(target)])
+
+    assert status == 1
+    assert f"{target}:3:" in capsys.readouterr().out
+
+
+def test_this_repository_is_clean() -> None:
+    """Every path the spec-refs-lint hook reads, mirroring its `files:`.
+
+    So the guard is a fact about the tree and not only about the commit in
+    flight. A reference that resolves for the checker and not for the renderer
+    is only visible from the whole tree: the page holding it passes on its own,
+    and the site build that reports it runs in another repository.
+    """
+    lint = _lint()
+    root = _SCRIPT.parent.parent
+    tracked = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.split("\0")
+
+    offenders = {name: lint.findings(root / name) for name in tracked if _COVERED.match(name)}
+    assert not {name: found for name, found in offenders.items() if found}


### PR DESCRIPTION
## Why
- `scripts/spec_refs_lint.py` resolved a `docs/`-prefixed reference path from the
  repository root wherever it was written, so a page could spell the root path and
  pass the hook. A renderer resolves a page's links beside the page, so that
  spelling renders dead: `docs/spec/evaluator.md` written in `docs/spec/cli.md` is
  looked for at `spec/docs/spec/evaluator.md` -- a 404 on GitHub and a `--strict`
  failure in the Pages site build.
- One had reached `main` (`docs/spec/cli.md:183`): the only cross-document
  reference in `docs/spec` not written relative to its page, 1 of 181.

## What
- `_why` refuses a repository-root path written in a page and names the reason;
  `_target_document` anchors the root path only for a source file, which has no
  other anchor. Its docstring had claimed both spellings resolve the same way
  wherever they appear, which is what let this through.
- `docs/spec/cli.md:183` uses the relative form its 180 siblings use.
- `docs/SPEC-RULES.md` states the rule by what reads the path rather than by
  directory, and the hook's usage message follows.
- `tests/scripts/test_spec_refs_lint.py` is new: both directions, plus a tree-wide
  check over every path the hook reads. That check fails on the reference this PR
  removes, and the directional test fails against the old resolver.

## Contract
- The reference convention narrows: a page MUST link relative to itself, code keeps
  the repository-root path. `docs/SPEC-RULES.md` is updated to match. No page in the
  tree used the root form except the one fixed here.

## Risk
- The hook's `files:` still omits `docs/develop.md` and `docs/tutorial/*.md`, so a
  root path written in those pages is not linted. Follow-up, not this PR.
