### PR TITLE
fix(docs): close the tutorial diagram's feedback edges

### DIFF
--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -7,8 +7,8 @@ implementation is source code, and either can be pointed at any command.
 ```text
   step one — describe it, until it agrees
 
-        ┌────────── fix the HIR ◄────────── not yet ──────────┐
-        ▼                                                     │
+        ┌────────── fix the HIR ◄────────── not yet ───────────┐
+        ▼                                                      │
    authored HIR ─────► check ─────► agrees? ───────────────────┘
    the reference                       │
         ▲                             yes
@@ -17,8 +17,8 @@ implementation is source code, and either can be pointed at any command.
 
   step two — make it fast; both roads lead back to the same source
 
-        ┌────── change the HIR ◄────── not yet ──────┐
-        ▼                                            │
+        ┌────── change the HIR ◄────── not yet ───────────────────┐
+        ▼                                                         │
    authored HIR ─────► analyze ─────► predicted performance ok? ──┘
         ▲                                     │
         │                                    yes


### PR DESCRIPTION
## Why
- Both `not yet` edges in `docs/tutorial/index.md` turned down at a column no
  corner stood in, so neither feedback loop closed.
- Step one missed by one column, which is invisible unless measured. Step two
  missed by thirteen, and the column it turned down in falls inside `predicted
  performance ok?`: the edge left the decision, ran down under its own label and
  stopped, while a corner sat unattached at the end of the row. The rendered page
  shows a line that starts nowhere and a corner that closes nothing.

## What
- The dashes on each `not yet` row run out to the corner that row's edge meets,
  putting the corner, the vertical and the closing corner in one column -- 63 in
  step one, 66 in step two.
- Nothing else about either diagram moves; the change is four lines, dashes and
  spaces only.

## Contract
- None.

## Risk
- Nothing checks these diagrams. A corner check over fenced blocks -- each of
  `┐ ┌ ┘ └` must meet a vertical in the adjacent row at its own column -- reports
  exactly these two and nothing else across `docs`, so it would hold as a hook.
  Not in this PR.
