### PR TITLE
feat(runtime): add the warp, mbarrier and TMA op surfaces

### DIFF
--- a/CLAUDE.local.md
+++ b/CLAUDE.local.md
@@ -1,0 +1,1 @@
+/home/qihang.zheng/TileFoundry/CLAUDE.local.md

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -1036,3 +1036,142 @@ __device__ void copy_async(TSrc const& src, TDst& dst);
     `cp_async_commit` and `cp_async_wait`.
   - Runtime implementation details such as vector width, tail handling, and
     architecture fallback live in code comments, not this spec entry.
+
+### 3.7 `tilefoundry::ops::warp_*` (warp-scoped exchange)
+
+Three ops, one public entry each, and **no tiers**: their operand is a
+register-resident scalar, which carries no `ShardLayout`, so there is nothing
+for a compile-time tier selection to read. The one-entry rule of
+[§3](#3-runtime-ops) requires one entry per op; it does not require every op to
+have more than one implementation.
+
+`warp.cuh` is included before `reduce.cuh` so that `ops::reduce`'s intra-warp
+tier folds through `warp_reduce` rather than spelling the butterfly a second
+time.
+
+```cpp
+/**
+ * @brief Exchange a value with the lane whose id differs by lane_mask.
+ * @param value this lane's contribution
+ * @param lane_mask the lane-id bits exchanged across
+ * @param member_mask the participating lanes
+ */
+template <class T>
+__device__ T shuffle_xor(T value, int lane_mask, unsigned member_mask = 0xFFFFFFFFu);
+
+/**
+ * @brief Select exactly one thread of the leading Width threads of the CTA.
+ * @tparam Width compile-time participating thread count
+ */
+template <int Width>
+__device__ bool shuffle_elect();
+
+/**
+ * @brief Fold value across the warp, leaving the result in every lane.
+ * @tparam Combine functor type supplying a static apply(T, T) -> T
+ * @param value this lane's contribution
+ */
+template <class Combine, class T>
+__device__ T warp_reduce(T value);
+```
+
+- constraints:
+  - `shuffle_elect` elects one thread of the **CTA**, not one lane of each warp.
+    An mbarrier armed for a single arrival is correct only under that reading.
+  - `warp_reduce` is the five-step butterfly and leaves its result in every lane.
+  - Types wider than the shuffle intrinsic's are exchanged word-wise; that
+    choice lives in code comments, not this entry.
+
+### 3.8 `tilefoundry::ops::mbarrier_*` (shared-memory barrier object)
+
+A Hopper mbarrier is a 64-bit shared-memory word carrying an arrival count, a
+transaction-byte count and a phase parity. It is not `ops::sync`
+([§3.4](#34-tilefoundryopssync-mesh-scoped-barrier)): that is a whole-mesh
+rendezvous every participant reaches, while these let a producer signal
+completion of work the consumer did not perform.
+
+`ops::sync` collapses five `SyncKind`s behind one entry because they are five
+ways to spell one op — "barrier for this mesh scope" — with the scope choosing
+the spelling. `mbarrier.init` / `arrive` / `try_wait` are not one op: they are
+three instructions with three meanings and three signatures. The one-entry rule
+forbids exposing the *tiers* of one op separately; it does not ask distinct
+operations to hide behind an enum. **No tiers:** a barrier is a shared-memory
+object, not a sharded tensor, so no operand carries a `ShardLayout`.
+
+```cpp
+/** @brief Arm a barrier so arrive_count arrivals complete a phase. */
+__device__ void mbarrier_init(uint64_t* bar, unsigned arrive_count);
+
+/** @brief Contribute one arrival to the barrier's current phase. */
+__device__ void mbarrier_arrive(uint64_t* bar);
+
+/** @brief Arrive and declare tx_bytes of asynchronous data in one instruction. */
+__device__ void mbarrier_arrive_expect_tx(uint64_t* bar, unsigned tx_bytes);
+
+/** @brief Declare tx_bytes against the current phase without arriving. */
+__device__ void mbarrier_expect_tx(uint64_t* bar, unsigned tx_bytes);
+
+/** @brief Test the phase once without blocking. */
+__device__ bool mbarrier_try_wait_parity(uint64_t* bar, unsigned phase);
+
+/** @brief Block until the barrier's phase parity reaches phase. */
+__device__ void mbarrier_wait_parity(uint64_t* bar, unsigned phase);
+
+/** @brief Release the barrier's shared-memory word. */
+__device__ void mbarrier_invalidate(uint64_t* bar);
+```
+
+- constraints:
+  - `bar` addresses shared memory. One thread calls `mbarrier_init`, and a
+    `sync` covering every thread that will use the barrier separates it from the
+    first arrival or wait.
+  - The parity alternates `0, 1, 0, ...` across successive completions, which is
+    what lets a fixed ring of barriers serve a pipeline of any length: stage `t`
+    of a ring of `n` waits on parity `(t / n) & 1`.
+  - A `tx_bytes` that disagrees with the bytes the paired copy delivers leaves
+    the phase permanently incomplete; the failure presents as a hang, not as a
+    wrong value.
+
+### 3.9 `tilefoundry::ops::tma_bulk_copy` (bulk async gmem→smem staging)
+
+`cp.async.bulk`, and not a tier of `ops::copy_async`
+([§3.6](#36-tilefoundryopscopy_async-async-gmemsmem-staging)): there every
+thread issues its own 4-, 8- or 16-byte load and a commit closes the group; here
+one thread issues a whole contiguous run and an mbarrier signals completion.
+
+**One implementation.** The hardware's two bulk forms are the rank-1
+`cp.async.bulk` implemented here and the tensor forms
+`cp.async.bulk.tensor.Nd`, which take a host-encoded `TensorMap` in place of a
+size. Those differ in their *operands*, not in a tier a trait could pick
+between, and a caller holding one cannot supply the other. A weaker-alignment
+fallback is likewise absent: that is `ops::copy_async`, and this entry refuses
+rather than silently becoming a slower copy.
+
+```cpp
+/**
+ * @brief Stage a contiguous run gmem→smem as one bulk async copy.
+ * @param src_gmem the source run
+ * @param dst_smem the shared destination
+ * @param count elements transferred
+ * @param bar the mbarrier the completion lands on
+ */
+template <class T>
+__device__ void tma_bulk_copy(T const* src_gmem, T* dst_smem, unsigned count, uint64_t* bar);
+
+/**
+ * @brief The byte count tma_bulk_copy transfers, for the arrival that declares it.
+ * @param count elements transferred
+ */
+template <class T>
+__device__ __host__ constexpr unsigned tma_bulk_bytes(unsigned count);
+```
+
+- constraints:
+  - Exactly one thread issues the copy, and nothing blocks: it is in flight when
+    the issuing thread reaches the next statement.
+  - Both addresses are 16-byte aligned and the byte count is a multiple of 16.
+    The instruction has no defined behaviour otherwise.
+  - The issuing thread pairs the copy with
+    `mbarrier_arrive_expect_tx(bar, tma_bulk_bytes<T>(count))`; consumers wait
+    with `mbarrier_wait_parity`. `tma_bulk_bytes` exists so the declared and
+    delivered counts cannot drift.

--- a/docs/spec/tir.md
+++ b/docs/spec/tir.md
@@ -1056,3 +1056,257 @@ class CpAsyncWait(Op):
 - constraints:
   - `n` is a non-negative compile-time count.
   - `n = 0` drains every outstanding committed group.
+
+##### TmaBulkCopy
+
+`cp.async.bulk` is the other asynchronous staging instruction, and it is not a
+tier of `CopyAsync`: there, every thread issues its own 4-, 8- or 16-byte load
+and a commit closes the group; here **one** thread issues a whole contiguous run
+and an mbarrier signals completion. They differ in who issues, in what closes
+them, and in the alignment they demand.
+
+Only the rank-1 form is defined. The tensor forms (`cp.async.bulk.tensor.Nd`)
+take a host-encoded `TensorMap` in place of a size, which is a different operand
+list rather than a different tier.
+
+```python
+class TmaBulkCopy(Op):
+    """Effect form; bulk async gmem→smem copy completing on an mbarrier.
+
+    Attributes:
+        src: input; gmem source, a contiguous run.
+        dst: input; smem destination.
+        barrier: input; smem mbarrier the completion lands on.
+    """
+
+    src: Tensor
+    dst: Tensor
+    barrier: Tensor
+```
+- constraints:
+  - `src` is gmem, `dst` is smem, `barrier` is smem.
+  - `src` and `dst` agree in dtype and shape; the copy moves bytes and does not
+    convert them.
+  - The transfer is a whole number of 16-byte grains. Off the grain the
+    instruction has no defined behaviour, so a static extent that violates this
+    is rejected rather than rounded.
+  - Exactly one thread issues it, and nothing blocks: the copy is in flight when
+    the issuing thread reaches the next statement.
+  - The issuing thread pairs it with `MBarrierArriveExpectTx` naming the same
+    byte count; consumers wait with `MBarrierWaitParity`.
+  - **No CUDA lowering is registered.** The op states the contract; the
+    implementation it corresponds to is
+    `tilefoundry::ops::tma_bulk_copy(src, dst, count, bar)`
+    ([runtime §3](./runtime.md#3-runtime-ops)), reached today only by a
+    hand-written kernel.
+
+#### Barrier object Ops (`tir.sync.mbarrier_*`)
+
+A Hopper mbarrier is a 64-bit shared-memory word carrying an arrival count, a
+transaction-byte count and a phase parity. It is not `Sync`
+([§1.5](#15-sync)): `Sync` is a whole-mesh rendezvous every participant reaches,
+while these let a producer signal completion of work the consumer did not
+perform — which is what an asynchronous copy needs, since the thread that issues
+one is not the thread that waits for it.
+
+**No CUDA lowering is registered for any op in this group.** Each states its
+contract and names the `tilefoundry::ops` entry it corresponds to
+([runtime §3](./runtime.md#3-runtime-ops)).
+
+##### MBarrierInit
+
+```python
+class MBarrierInit(Op):
+    """Effect form; arm a barrier for a fixed number of arrivals.
+
+    Attributes:
+        barrier: input; smem barrier object.
+        arrive_count: attribute; arrivals that complete one phase.
+    """
+
+    barrier: Tensor
+    arrive_count: int
+```
+- constraints:
+  - `barrier` is smem; the instructions take a shared-window address.
+  - `arrive_count` is a positive compile-time count. A phase needing zero
+    arrivals is complete before anything is produced, which makes every
+    consumer's wait a no-op.
+  - One thread initialises, and a `Sync` covering every thread that will use the
+    barrier separates this from the first arrival or wait.
+  - Corresponds to `tilefoundry::ops::mbarrier_init(bar, arrive_count)`.
+
+##### MBarrierArrive
+
+```python
+class MBarrierArrive(Op):
+    """Effect form; contribute one arrival to the barrier's current phase.
+
+    Attributes:
+        barrier: input; smem barrier object.
+    """
+
+    barrier: Tensor
+```
+- constraints:
+  - `barrier` is smem.
+  - The arrival token is not a value here: consumers wait on the phase parity,
+    not on a token handed between threads.
+  - Corresponds to `tilefoundry::ops::mbarrier_arrive(bar)`.
+
+##### MBarrierArriveExpectTx
+
+```python
+class MBarrierArriveExpectTx(Op):
+    """Effect form; arrive and declare asynchronous bytes in one instruction.
+
+    Attributes:
+        barrier: input; smem barrier object.
+        tx_bytes: attribute; bytes the paired copy delivers to this phase.
+    """
+
+    barrier: Tensor
+    tx_bytes: int
+```
+- constraints:
+  - `barrier` is smem and `tx_bytes` is a positive compile-time count.
+  - The phase completes when both the arrivals and the byte count are satisfied,
+    so one wait covers a copy the waiting thread did not issue.
+  - `tx_bytes` MUST equal the bytes the paired copy delivers. A phase expecting a
+    different count never completes, and that failure presents as a hang rather
+    than as a wrong value.
+  - Corresponds to `tilefoundry::ops::mbarrier_arrive_expect_tx(bar, tx_bytes)`.
+
+##### MBarrierExpectTx
+
+```python
+class MBarrierExpectTx(Op):
+    """Effect form; declare asynchronous bytes without arriving.
+
+    Attributes:
+        barrier: input; smem barrier object.
+        tx_bytes: attribute; bytes the paired copy delivers to this phase.
+    """
+
+    barrier: Tensor
+    tx_bytes: int
+```
+- constraints:
+  - `barrier` is smem and `tx_bytes` is a positive compile-time count.
+  - Corresponds to `tilefoundry::ops::mbarrier_expect_tx(bar, tx_bytes)`.
+
+##### MBarrierWaitParity
+
+```python
+class MBarrierWaitParity(Op):
+    """Effect form; block until the barrier's phase parity reaches a value.
+
+    Attributes:
+        barrier: input; smem barrier object.
+        phase: input; the parity waited for.
+    """
+
+    barrier: Tensor
+    phase: Tensor
+```
+- constraints:
+  - `barrier` is smem.
+  - The parity alternates `0, 1, 0, ...` across successive completions, which is
+    what lets a fixed ring of barriers serve a pipeline of any length: stage `t`
+    of a ring of `n` waits on parity `(t // n) & 1`.
+  - Corresponds to `tilefoundry::ops::mbarrier_wait_parity(bar, phase)`.
+
+##### MBarrierInvalidate
+
+```python
+class MBarrierInvalidate(Op):
+    """Effect form; release the barrier's shared-memory word.
+
+    Attributes:
+        barrier: input; smem barrier object.
+    """
+
+    barrier: Tensor
+```
+- constraints:
+  - `barrier` is smem.
+  - Corresponds to `tilefoundry::ops::mbarrier_invalidate(bar)`.
+
+#### Warp Ops (`tir.warp.*`)
+
+Lane-to-lane exchange inside one warp. Every operand is register-resident: a
+shuffle moves a value between lanes' registers, and an operand in shared or
+global memory names a different instruction rather than a slower spelling of
+this one.
+
+**No CUDA lowering is registered for any op in this group.** Each states its
+contract and names the `tilefoundry::ops` entry it corresponds to
+([runtime §3](./runtime.md#3-runtime-ops)).
+
+##### ShuffleXor
+
+```python
+class ShuffleXor(Op):
+    """Effect form; exchange a value with the lane whose id differs by a mask.
+
+    Attributes:
+        src: input; rmem scalar contributed by this lane.
+        dst: input; rmem scalar receiving the partner lane's value.
+        lane_mask: attribute; the lane-id bits exchanged across.
+    """
+
+    src: Tensor
+    dst: Tensor
+    lane_mask: int
+```
+- constraints:
+  - `src` and `dst` are rmem scalars agreeing in dtype.
+  - `lane_mask` is in `1..31`. Zero exchanges a lane with itself and 32 or more
+    names a lane outside this warp; neither is a butterfly step.
+  - `dst` receives the `src` of lane `laneid ^ lane_mask`.
+  - Corresponds to `tilefoundry::ops::shuffle_xor(value, lane_mask)`.
+
+##### ShuffleElect
+
+```python
+class ShuffleElect(Op):
+    """Effect form; select exactly one thread of a leading thread range.
+
+    Attributes:
+        dst: input; rmem scalar, true on the elected thread.
+        width: attribute; participating threads, counted from the CTA's first.
+    """
+
+    dst: Tensor
+    width: int
+```
+- constraints:
+  - `dst` is an rmem scalar and `width` is a positive compile-time count.
+  - The elected thread is one thread of the **CTA**, not one lane of each warp.
+    An mbarrier armed for a single arrival is correct only under that reading.
+  - Corresponds to `tilefoundry::ops::shuffle_elect<Width>()`.
+
+##### WarpReduce
+
+```python
+class WarpReduce(Op):
+    """Effect form; fold a value across the warp, leaving it in every lane.
+
+    Attributes:
+        src: input; rmem scalar contributed by this lane.
+        dst: input; rmem scalar receiving the warp's fold.
+        kind: attribute; the combine — sum, max or min.
+    """
+
+    src: Tensor
+    dst: Tensor
+    kind: WarpReduceKind
+```
+- constraints:
+  - `src` and `dst` are rmem scalars agreeing in dtype.
+  - Defined as five `ShuffleXor` steps with masks `16, 8, 4, 2, 1` and a combine
+    between them — five shuffles and five combines, not a fold over 32 lanes.
+    The count is stated because it is the reason a caller reaches for this rather
+    than a shared-memory fold.
+  - The result is in every lane, not only in lane 0.
+  - Corresponds to `tilefoundry::ops::warp_reduce<Combine>(value)`.

--- a/include/tilefoundry/runtime/cuda/ops/mbarrier.cuh
+++ b/include/tilefoundry/runtime/cuda/ops/mbarrier.cuh
@@ -1,0 +1,72 @@
+/// tilefoundry mbarrier ops — the Hopper shared-memory barrier object.
+///
+/// Included IN-CONTEXT from runtime.cuh inside ``namespace tilefoundry::ops``;
+/// it opens no namespace and pulls in no system headers. The object itself is a
+/// 64-bit word in shared memory, and every entry takes a generic pointer to it
+/// and converts to the shared window address the instructions want.
+
+/// **Why these are separate entries and ``sync`` is one.** ``ops::sync``
+/// collapses five ``SyncKind``s behind one entry because they are five ways to
+/// spell one op — "barrier for this mesh scope" — with the scope choosing the
+/// spelling. ``mbarrier.init`` / ``arrive`` / ``try_wait`` are three
+/// instructions with three meanings and three signatures.
+
+/// [runtime §3](docs/spec/runtime.md#3-runtime-ops)'s one-entry rule forbids
+/// exposing the *tiers* of one op separately; it does not ask distinct
+/// operations to hide behind an enum. **No tiers here:** a barrier is a
+/// shared-memory object, not a sharded tensor, so no operand carries a
+/// ``ShardLayout`` for a trait to read.
+#pragma once
+
+#include "mbarrier/mbarrier_impl.h"
+
+/// Initialise ``bar`` so that ``arrive_count`` arrivals complete a phase.
+///
+/// One thread must call this, and a ``sync`` covering every thread that will
+/// use the barrier must follow it before any of them arrive or wait.
+__device__ inline void mbarrier_init(uint64_t *bar, unsigned arrive_count) {
+    mbarrier_impl::Init{}(bar, arrive_count);
+}
+
+/// Arrive on ``bar``, contributing one of the arrivals its phase is waiting on.
+__device__ inline void mbarrier_arrive(uint64_t *bar) {
+    mbarrier_impl::Arrive{}(bar);
+}
+
+/// Arrive on ``bar`` **and** declare that ``tx_bytes`` of asynchronous data
+/// will land against this phase.
+///
+/// This is the producer half of a bulk copy: the phase completes when both the
+/// arrivals and the byte count are satisfied, so the consumer's wait covers the
+/// copy without a second barrier. One instruction rather than an ``arrive``
+/// plus an ``expect_tx``.
+__device__ inline void mbarrier_arrive_expect_tx(uint64_t *bar,
+                                                 unsigned tx_bytes) {
+    mbarrier_impl::ArriveExpectTx{}(bar, tx_bytes);
+}
+
+/// Declare ``tx_bytes`` of asynchronous data against ``bar``'s current phase
+/// without arriving on it.
+__device__ inline void mbarrier_expect_tx(uint64_t *bar, unsigned tx_bytes) {
+    mbarrier_impl::ExpectTx{}(bar, tx_bytes);
+}
+
+/// Test ``bar``'s phase once, without blocking; true when ``phase`` has
+/// flipped.
+__device__ inline bool mbarrier_try_wait_parity(uint64_t *bar, unsigned phase) {
+    return mbarrier_impl::TryWaitParity{}(bar, phase);
+}
+
+/// Block until ``bar``'s phase parity reaches ``phase``.
+///
+/// ``phase`` alternates 0, 1, 0, ... across successive completions of the same
+/// barrier, which is what lets a pipeline reuse a fixed ring of barriers
+/// instead of allocating one per stage.
+__device__ inline void mbarrier_wait_parity(uint64_t *bar, unsigned phase) {
+    mbarrier_impl::WaitParity{}(bar, phase);
+}
+
+/// Invalidate ``bar``, releasing the shared-memory word for other use.
+__device__ inline void mbarrier_invalidate(uint64_t *bar) {
+    mbarrier_impl::Invalidate{}(bar);
+}

--- a/include/tilefoundry/runtime/cuda/ops/mbarrier/mbarrier_impl.h
+++ b/include/tilefoundry/runtime/cuda/ops/mbarrier/mbarrier_impl.h
@@ -1,0 +1,100 @@
+/// mbarrier op implementations — one per entry in ``ops/mbarrier.cuh``.
+///
+/// Included in-context from ``ops/mbarrier.cuh``. Every struct here is the
+/// single implementation of its entry; nothing selects a tier.
+///
+/// The instructions are ``.shared::cta`` throughout: this runtime does not
+/// place a barrier in a cluster's distributed shared memory, and naming the
+/// window explicitly keeps the generic-to-shared conversion from being redone
+/// by the assembler on every use.
+#pragma once
+
+namespace mbarrier_impl {
+
+/// The shared-window address of a generic pointer, which is what every
+/// ``mbarrier.*`` instruction takes.
+__device__ inline uint32_t smem_addr(void const *ptr) {
+    return static_cast<uint32_t>(__cvta_generic_to_shared(ptr));
+}
+
+/// ``mbarrier.init`` — arm the object for ``arrive_count`` arrivals.
+struct Init {
+    __device__ void operator()(uint64_t *bar, unsigned arrive_count) const {
+        asm volatile(
+            "mbarrier.init.shared::cta.b64 [%0], %1;\n" ::"r"(smem_addr(bar)),
+            "r"(arrive_count));
+    }
+};
+
+/// ``mbarrier.arrive`` — the arrival token is discarded: this runtime's
+/// consumers wait on the phase parity, not on a token handed between threads.
+struct Arrive {
+    __device__ void operator()(uint64_t *bar) const {
+        asm volatile("{\n"
+                     "  .reg .b64 state;\n"
+                     "  mbarrier.arrive.shared::cta.b64 state, [%0];\n"
+                     "}\n" ::"r"(smem_addr(bar)));
+    }
+};
+
+/// ``mbarrier.arrive.expect_tx`` — arrive and declare the bytes in one go.
+struct ArriveExpectTx {
+    __device__ void operator()(uint64_t *bar, unsigned tx_bytes) const {
+        asm volatile(
+            "{\n"
+            "  .reg .b64 state;\n"
+            "  mbarrier.arrive.expect_tx.shared::cta.b64 state, [%0], %1;\n"
+            "}\n" ::"r"(smem_addr(bar)),
+            "r"(tx_bytes));
+    }
+};
+
+/// ``mbarrier.expect_tx`` — declare bytes without contributing an arrival.
+struct ExpectTx {
+    __device__ void operator()(uint64_t *bar, unsigned tx_bytes) const {
+        asm volatile("mbarrier.expect_tx.shared::cta.b64 [%0], %1;\n" ::"r"(
+                         smem_addr(bar)),
+                     "r"(tx_bytes));
+    }
+};
+
+/// ``mbarrier.try_wait.parity`` — one non-blocking test of the phase.
+///
+/// Spelled as a single test with the loop in C++ rather than as a PTX loop with
+/// its own labels: a label inside inline asm is emitted once per instantiation
+/// and collides as soon as two instantiations land in one translation unit.
+struct TryWaitParity {
+    __device__ bool operator()(uint64_t *bar, unsigned phase) const {
+        unsigned ready = 0u;
+        asm volatile(
+            "{\n"
+            "  .reg .pred complete;\n"
+            "  mbarrier.try_wait.parity.shared::cta.b64 complete, [%1], %2;\n"
+            "  selp.b32 %0, 1, 0, complete;\n"
+            "}\n"
+            : "=r"(ready)
+            : "r"(smem_addr(bar)), "r"(phase));
+        return ready != 0u;
+    }
+};
+
+/// Spin on ``try_wait`` until the phase flips.
+///
+/// ``try_wait`` already parks the warp in hardware for a bounded interval, so
+/// this loop is not a busy spin on the issue pipe.
+struct WaitParity {
+    __device__ void operator()(uint64_t *bar, unsigned phase) const {
+        while (!TryWaitParity{}(bar, phase)) {
+        }
+    }
+};
+
+/// ``mbarrier.inval`` — release the word.
+struct Invalidate {
+    __device__ void operator()(uint64_t *bar) const {
+        asm volatile(
+            "mbarrier.inval.shared::cta.b64 [%0];\n" ::"r"(smem_addr(bar)));
+    }
+};
+
+}

--- a/include/tilefoundry/runtime/cuda/ops/reduce/reduce_common_impl.h
+++ b/include/tilefoundry/runtime/cuda/ops/reduce/reduce_common_impl.h
@@ -103,14 +103,23 @@ __device__ float local_fold(SrcT const &s, int j, int step) {
     return acc;
 }
 
+/// Adapt ``reduce_traits<Op>::combine`` to the functor shape
+/// ``ops::warp_reduce`` takes.
+template <class Op> struct combine_fn {
+    __device__ static float apply(float a, float b) {
+        return reduce_traits<Op>::combine(a, b);
+    }
+};
+
 /// Intra-warp butterfly reduction (32 lanes → broadcast combine), using
 /// ``Op``'s combine (``+`` for sum/mean, ``fmaxf`` for absmax).
+///
+/// The shuffles themselves are ``ops::warp_reduce`` (ops/warp.cuh), which is
+/// where this file's ``__shfl_xor_sync`` used to be written out: one spelling
+/// of the butterfly, so a change to it cannot reach reduce and the warp op
+/// differently.
 template <class Op> __device__ float warp_butterfly(float val) {
-    for (int delta = 16; delta > 0; delta >>= 1) {
-        val = reduce_traits<Op>::combine(
-            val, __shfl_xor_sync(0xFFFFFFFFu, val, delta));
-    }
-    return val;
+    return warp_reduce<combine_fn<Op>>(val);
 }
 
 /// Cross-warp SUM aggregation via a shared-memory workspace.

--- a/include/tilefoundry/runtime/cuda/ops/tma.cuh
+++ b/include/tilefoundry/runtime/cuda/ops/tma.cuh
@@ -1,0 +1,49 @@
+/// tilefoundry TMA ops — the Hopper bulk asynchronous copy.
+///
+/// Included IN-CONTEXT from runtime.cuh inside ``namespace tilefoundry::ops``;
+/// it opens no namespace and pulls in no system headers.
+
+/// **One implementation, and why there is no tier.** The hardware's two bulk
+/// forms are the rank-1 ``cp.async.bulk`` (a contiguous byte run, no
+/// descriptor) and the tensor forms ``cp.async.bulk.tensor.Nd`` (a
+/// ``TensorMap`` encoded on the host). Those differ in their *operands* — a
+/// size against a descriptor plus coordinates — not in a tier a trait could
+/// pick between, and a caller holding one cannot supply the other.
+
+/// This header implements the rank-1 form, the one the address shapes in this
+/// repository can use. The tensor form is absent because nothing calls it: an
+/// implementation with no caller and no test is a guess, not a contract.
+
+/// A weaker-alignment fallback is likewise absent on purpose — that is
+/// ``ops::copy_async``. This op is the bulk instruction, and it says so by
+/// refusing rather than by silently becoming a slower copy. Both addresses
+/// must be 16-byte aligned and the byte count a multiple of 16; the
+/// instruction has no defined behaviour otherwise.
+#pragma once
+
+#include "tma/tma_impl.h"
+
+/// Stage ``count`` elements from global memory into shared memory as one bulk
+/// asynchronous copy, completing against ``bar``.
+///
+/// Exactly **one** thread issues this. Completion is signalled on ``bar``'s
+/// current phase, so the issuing thread pairs it with
+/// ``mbarrier_arrive_expect_tx(bar, bytes)`` and every consumer waits with
+/// ``mbarrier_wait_parity``. Nothing here blocks: the point of the op is that
+/// the copy is still in flight when the issuing thread reaches the next one.
+template <class T>
+__device__ inline void tma_bulk_copy(T const *src_gmem, T *dst_smem,
+                                     unsigned count, uint64_t *bar) {
+    tma_impl::BulkG2S<T>{}(src_gmem, dst_smem, count, bar);
+}
+
+/// The byte count ``tma_bulk_copy`` will transfer, for the
+/// ``mbarrier_arrive_expect_tx`` that must declare it.
+///
+/// Spelled as its own function so the two numbers cannot drift: a phase that
+/// expects a different byte count than the copy delivers never completes, and
+/// that failure looks like a hang rather than like a wrong answer.
+template <class T>
+__device__ __host__ inline constexpr unsigned tma_bulk_bytes(unsigned count) {
+    return count * unsigned(sizeof(T));
+}

--- a/include/tilefoundry/runtime/cuda/ops/tma/tma_impl.h
+++ b/include/tilefoundry/runtime/cuda/ops/tma/tma_impl.h
@@ -1,0 +1,28 @@
+/// TMA op implementation — the single implementation of ``tma_bulk_copy``.
+///
+/// Included in-context from ``ops/tma.cuh``.
+#pragma once
+
+namespace tma_impl {
+
+/// ``cp.async.bulk`` global→shared with mbarrier completion.
+///
+/// ``.shared::cluster`` names the destination window even though this runtime
+/// does not distribute a tile across a cluster: that is the operand form the
+/// instruction takes, and a single-CTA cluster is the degenerate case of it.
+template <class T> struct BulkG2S {
+    __device__ void operator()(T const *src_gmem, T *dst_smem, unsigned count,
+                               uint64_t *bar) const {
+        static_assert(sizeof(T) <= 16,
+                      "tma_bulk_copy: element wider than the 16-byte grain");
+        const unsigned bytes = count * unsigned(sizeof(T));
+        asm volatile(
+            "cp.async.bulk.shared::cluster.global"
+            ".mbarrier::complete_tx::bytes [%0], [%1], %2, [%3];\n" ::"r"(
+                mbarrier_impl::smem_addr(dst_smem)),
+            "l"(src_gmem), "r"(bytes), "r"(mbarrier_impl::smem_addr(bar))
+            : "memory");
+    }
+};
+
+}

--- a/include/tilefoundry/runtime/cuda/ops/warp.cuh
+++ b/include/tilefoundry/runtime/cuda/ops/warp.cuh
@@ -1,0 +1,60 @@
+/// tilefoundry warp ops — the warp-scoped exchange primitives.
+///
+/// Included IN-CONTEXT from runtime.cuh, inside ``namespace
+/// tilefoundry::ops``: it opens no namespace and pulls in no system headers.
+/// Included **before** ``ops/reduce.cuh`` so reduce's intra-warp tier folds
+/// through ``warp_reduce`` rather than spelling the butterfly a second time.
+
+/// Three ops, one public entry each, and no tiers: the operand is a
+/// register-resident scalar and carries no ``ShardLayout``, so a compile-time
+/// tier selection would have nothing to read. [runtime
+/// §3](docs/spec/runtime.md#3-runtime-ops) asks for one entry per op, not for
+/// every op to have more than one implementation.
+#pragma once
+
+#include "warp/warp_impl.h"
+
+/// Exchange ``value`` with the lane whose id differs from this one in the bits
+/// of ``lane_mask``; ``member_mask`` names the lanes that participate.
+///
+/// A butterfly step: after ``k`` steps with masks 1, 2, ... 2^(k-1) every lane
+/// holds the combination of its 2^k-lane block.
+template <class T>
+__device__ inline T shuffle_xor(T value, int lane_mask,
+                                unsigned member_mask = 0xFFFFFFFFu) {
+    return warp_impl::ShuffleXor<T>{}(value, lane_mask, member_mask);
+}
+
+/// True on exactly **one** thread of the leading ``Width`` threads of the CTA.
+///
+/// ``Width`` is the participating thread count, not a lane mask: a whole block
+/// still yields one thread, in the first warp. That is what an mbarrier whose
+/// arrive-count is 1 needs — one arriver, chosen without a ballot round-trip.
+template <int Width> __device__ inline bool shuffle_elect() {
+    return warp_impl::Elect<Width>{}();
+}
+
+/// Fold ``value`` across the 32 lanes with ``Combine``, leaving the result in
+/// **every** lane.
+///
+/// ``Combine`` is a functor type with a static ``apply(T, T) -> T``. The fold
+/// is the five-step butterfly, so the instruction count to expect is five
+/// shuffles and five combines, not a loop over 32 lanes.
+template <class Combine, class T> __device__ inline T warp_reduce(T value) {
+    return warp_impl::Butterfly<Combine, T>{}(value);
+}
+
+/// Sum combine for ``warp_reduce``.
+struct warp_sum {
+    __device__ static float apply(float a, float b) { return a + b; }
+};
+
+/// Max combine for ``warp_reduce``.
+struct warp_max {
+    __device__ static float apply(float a, float b) { return fmaxf(a, b); }
+};
+
+/// Min combine for ``warp_reduce``.
+struct warp_min {
+    __device__ static float apply(float a, float b) { return fminf(a, b); }
+};

--- a/include/tilefoundry/runtime/cuda/ops/warp/warp_impl.h
+++ b/include/tilefoundry/runtime/cuda/ops/warp/warp_impl.h
@@ -1,0 +1,88 @@
+/// warp op implementations — one per entry in ``ops/warp.cuh``.
+///
+/// Included in-context from ``ops/warp.cuh`` (see reduce_common_impl.h for the
+/// in-context include contract). No tier selection lives here: each struct is
+/// the single implementation of its entry.
+#pragma once
+
+namespace warp_impl {
+
+/// Whether ``__shfl_xor_sync`` takes ``T`` directly. Everything else goes
+/// through the word-wise path below.
+template <class T>
+inline constexpr bool is_shuffle_native_v =
+    std::is_same_v<T, float> || std::is_same_v<T, double> ||
+    std::is_same_v<T, int> || std::is_same_v<T, unsigned int> ||
+    std::is_same_v<T, long long> || std::is_same_v<T, unsigned long long>;
+
+/// ``__shfl_xor_sync`` for the types the intrinsic accepts, and a word-wise
+/// exchange for anything else (a bf16 pair, a small aggregate).
+template <class T> struct ShuffleXor {
+    __device__ T operator()(T value, int lane_mask,
+                            unsigned member_mask) const {
+        if constexpr (is_shuffle_native_v<T>) {
+            return __shfl_xor_sync(member_mask, value, lane_mask);
+        } else {
+            static_assert(
+                sizeof(T) % sizeof(unsigned) == 0,
+                "shuffle_xor: type size must be a multiple of 4 bytes");
+            constexpr int kWords = int(sizeof(T) / sizeof(unsigned));
+            T out = value;
+            unsigned *dst = reinterpret_cast<unsigned *>(&out);
+            for (int i = 0; i < kWords; ++i)
+                dst[i] = __shfl_xor_sync(member_mask, dst[i], lane_mask);
+            return out;
+        }
+    }
+};
+
+/// Elect exactly one thread among the leading ``Width`` threads of the CTA.
+///
+/// On sm_90 the elected lane comes from ``elect.sync``: one instruction, where
+/// a ballot plus a find-first would be three and would make every lane read a
+/// value it does not use. Below sm_90 lane 0 is the elected thread — the same
+/// guarantee (exactly one) with a different choice of which.
+///
+/// Threads outside the first warp answer false without executing the
+/// warp-scoped instruction at all: ``elect.sync``'s result is defined only for
+/// the lanes named in its member mask.
+template <int Width> struct Elect {
+    __device__ bool operator()() const {
+        static_assert(Width > 0, "shuffle_elect: Width must be positive");
+        /// The elected thread is always in the first warp, so every thread past
+        /// it answers false. ``Width`` therefore only discriminates below 32.
+        constexpr unsigned kParticipants = Width < 32 ? unsigned(Width) : 32u;
+        if (threadIdx.x >= kParticipants)
+            return false;
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+        constexpr unsigned kMask =
+            Width >= 32 ? 0xFFFFFFFFu : ((1u << unsigned(Width & 31)) - 1u);
+        unsigned pred = 0u;
+        asm volatile("{\n"
+                     "  .reg .b32 elected_lane;\n"
+                     "  .reg .pred is_elected;\n"
+                     "  elect.sync elected_lane|is_elected, %1;\n"
+                     "  selp.b32 %0, 1, 0, is_elected;\n"
+                     "}\n"
+                     : "=r"(pred)
+                     : "n"(kMask));
+        return pred != 0u;
+#else
+        return (threadIdx.x & 31u) == 0u;
+#endif
+    }
+};
+
+/// The five-step butterfly: after step ``k`` every lane holds the combination
+/// of its ``2^(k+1)``-lane block, so after five steps every lane holds the
+/// warp's. The result is in every lane, not only in lane 0.
+template <class Combine, class T> struct Butterfly {
+    __device__ T operator()(T value) const {
+        for (int delta = 16; delta > 0; delta >>= 1)
+            value = Combine::apply(value,
+                                   ShuffleXor<T>{}(value, delta, 0xFFFFFFFFu));
+        return value;
+    }
+};
+
+}

--- a/include/tilefoundry/runtime/cuda/runtime.cuh
+++ b/include/tilefoundry/runtime/cuda/runtime.cuh
@@ -77,6 +77,12 @@ namespace ops {
 #include "ops/unary.cuh"
 #include "ops/copy.cuh"
 #include "ops/binary.cuh"
+/// warp before reduce: reduce's intra-warp tier folds through warp_reduce.
+#include "ops/warp.cuh"
+#include "ops/mbarrier.cuh"
+/// tma after mbarrier: a bulk copy completes on an mbarrier and reuses its
+/// generic-to-shared conversion.
+#include "ops/tma.cuh"
 #include "ops/reduce.cuh"
 #include "ops/cast.cuh"
 #include "ops/clamp.cuh"

--- a/src/tilefoundry/ir/tir/cuda/memory/__init__.py
+++ b/src/tilefoundry/ir/tir/cuda/memory/__init__.py
@@ -1,0 +1,1 @@
+"""CUDA memory-movement instructions (the Hopper bulk asynchronous copy)."""

--- a/src/tilefoundry/ir/tir/cuda/memory/tma.py
+++ b/src/tilefoundry/ir/tir/cuda/memory/tma.py
@@ -1,0 +1,90 @@
+"""Effect-form TIR Op for the CUDA bulk asynchronous copy (TMA).
+
+``CopyAsync`` is ``cp.async``: every thread issues its own load and a commit
+closes the group. This is ``cp.async.bulk`` -- **one** thread issues a whole
+run, an mbarrier signals completion -- and is not a tier of the other. Only the
+rank-1 form is defined; the tensor forms take a host-encoded ``TensorMap`` in
+place of a size, a different operand list rather than a tier. **Defined but not
+lowered**: no CUDA emit; the implementation is in ``ops/tma.cuh``.
+
+See [tir §2.3](docs/spec/tir.md#23-tir-ops).
+"""
+
+from __future__ import annotations
+
+from tilefoundry.ir.core import Op
+from tilefoundry.ir.core.param_def import ParamDef
+from tilefoundry.ir.core.pattern import Tensor
+from tilefoundry.ir.core.register import register_op
+from tilefoundry.ir.types import UnitType
+from tilefoundry.ir.types.storage import StorageKind
+from tilefoundry.visitor_registry import register_typeinfer, register_verify_stmt
+
+__all__ = ["TmaBulkCopy"]
+
+_GRAIN_BYTES = 16
+
+
+@register_op(dialect="T", category="async", name="tma_bulk_copy")
+class TmaBulkCopy(Op):
+    """Stage a contiguous run from global to shared memory as one bulk copy.
+
+    Exactly one thread issues it and nothing blocks: the copy is still in flight
+    when the issuing thread reaches the next statement. Completion lands on
+    ``barrier``'s current phase, so the issuing thread pairs this with an
+    ``MBarrierArriveExpectTx`` naming the same byte count and every consumer
+    waits with ``MBarrierWaitParity``.
+    """
+
+    src = ParamDef(kind="input", pattern=Tensor)
+    dst = ParamDef(kind="input", pattern=Tensor)
+    barrier = ParamDef(kind="input", pattern=Tensor)
+
+
+@register_typeinfer(TmaBulkCopy)
+def _(call: "Call", ctx: "TypeInferContext") -> UnitType:
+    return UnitType()
+
+
+@register_verify_stmt(TmaBulkCopy)
+def _(call: "Call", ctx: "VerifyContext") -> None:
+    src = ctx.type_of(call.args[0])
+    dst = ctx.type_of(call.args[1])
+    bar = ctx.type_of(call.args[2])
+    if src.storage != StorageKind.GMEM:
+        ctx.error(call, f"TmaBulkCopy source must be gmem, got {src.storage}")
+    if dst.storage != StorageKind.SMEM:
+        ctx.error(call, f"TmaBulkCopy destination must be smem, got {dst.storage}")
+    if bar.storage != StorageKind.SMEM:
+        ctx.error(call, f"TmaBulkCopy barrier must be smem, got {bar.storage}")
+    if src.dtype != dst.dtype:
+        ctx.error(call, f"TmaBulkCopy dtype mismatch: {src.dtype} vs {dst.dtype}")
+    _verify_grain(ctx, call, src, dst)
+
+
+def _verify_grain(ctx, call, src, dst) -> None:
+    """Report unless the transfer is a whole number of ``_GRAIN_BYTES`` grains.
+
+    That constant is the instruction's transfer grain: both addresses and the
+    byte count are constrained to it, and off the grain the instruction has no
+    defined behaviour, so this checks rather than rounds. Only static extents
+    can be checked here; a run whose length is a DimVar carries the same
+    constraint to whoever supplies the value.
+    """
+    if src.shape != dst.shape:
+        ctx.error(call, f"TmaBulkCopy shape mismatch: {src.shape} vs {dst.shape}")
+        return
+    if any(not isinstance(d, int) for d in dst.shape):
+        return
+    width = getattr(dst.dtype, "bit_width", None)
+    if not isinstance(width, int):
+        return
+    total_bits = width
+    for d in dst.shape:
+        total_bits *= d
+    if total_bits % (_GRAIN_BYTES * 8):
+        ctx.error(
+            call,
+            f"TmaBulkCopy transfer must be a multiple of {_GRAIN_BYTES} bytes, "
+            f"got {total_bits // 8}",
+        )

--- a/src/tilefoundry/ir/tir/cuda/sync/__init__.py
+++ b/src/tilefoundry/ir/tir/cuda/sync/__init__.py
@@ -1,0 +1,1 @@
+"""CUDA synchronisation objects (the Hopper mbarrier)."""

--- a/src/tilefoundry/ir/tir/cuda/sync/mbarrier.py
+++ b/src/tilefoundry/ir/tir/cuda/sync/mbarrier.py
@@ -1,0 +1,174 @@
+"""Effect-form TIR Ops for the CUDA shared-memory barrier object (mbarrier).
+
+An mbarrier is a 64-bit shared-memory word carrying an arrival count, a
+transaction-byte count and a phase parity. It is not ``Sync``, a whole-mesh
+rendezvous every participant reaches: these let a *producer* signal completion
+of work a *consumer* did not perform, which is what an asynchronous copy needs.
+**Defined but not lowered**: no CUDA emit. The implementations live at
+``include/tilefoundry/runtime/cuda/ops/mbarrier.cuh``.
+
+See [tir §2.3](docs/spec/tir.md#23-tir-ops).
+"""
+
+from __future__ import annotations
+
+from tilefoundry.ir.core import Op
+from tilefoundry.ir.core.param_def import ParamDef
+from tilefoundry.ir.core.pattern import Scalar, Tensor
+from tilefoundry.ir.core.register import register_op
+from tilefoundry.ir.types import UnitType
+from tilefoundry.ir.types.storage import StorageKind
+from tilefoundry.visitor_registry import register_typeinfer, register_verify_stmt
+
+__all__ = [
+    "MBarrierInit",
+    "MBarrierArrive",
+    "MBarrierArriveExpectTx",
+    "MBarrierExpectTx",
+    "MBarrierWaitParity",
+    "MBarrierInvalidate",
+]
+
+
+def _require_smem_barrier(ctx, call, who: str) -> None:
+    """Report unless argument 0 is a shared-memory barrier object.
+
+    The instructions take a shared-window address. A barrier in global memory
+    is not a slower barrier, it is not one at all.
+    """
+    ty = ctx.type_of(call.args[0])
+    if ty.storage != StorageKind.SMEM:
+        ctx.error(call, f"{who} barrier must be smem, got {ty.storage}")
+
+
+@register_op(dialect="T", category="sync", name="mbarrier_init")
+class MBarrierInit(Op):
+    """Arm ``barrier`` so ``arrive_count`` arrivals complete a phase.
+
+    One thread initialises; a ``Sync`` covering every thread that will use the
+    barrier must separate this from the first arrival or wait.
+    """
+
+    barrier = ParamDef(kind="input", pattern=Tensor)
+    arrive_count = ParamDef(kind="attribute", annotation=int)
+
+
+@register_typeinfer(MBarrierInit)
+def _(call: "Call", ctx: "TypeInferContext") -> UnitType:
+    return UnitType()
+
+
+@register_verify_stmt(MBarrierInit)
+def _(call: "Call", ctx: "VerifyContext") -> None:
+    count = call.target.arrive_count
+    if not isinstance(count, int) or count <= 0:
+        ctx.error(call, f"MBarrierInit.arrive_count must be a positive int, got {count!r}")
+    _require_smem_barrier(ctx, call, "MBarrierInit")
+
+
+@register_op(dialect="T", category="sync", name="mbarrier_arrive")
+class MBarrierArrive(Op):
+    """Contribute one arrival to ``barrier``'s current phase."""
+
+    barrier = ParamDef(kind="input", pattern=Tensor)
+
+
+@register_typeinfer(MBarrierArrive)
+def _(call: "Call", ctx: "TypeInferContext") -> UnitType:
+    return UnitType()
+
+
+@register_verify_stmt(MBarrierArrive)
+def _(call: "Call", ctx: "VerifyContext") -> None:
+    _require_smem_barrier(ctx, call, "MBarrierArrive")
+
+
+@register_op(dialect="T", category="sync", name="mbarrier_arrive_expect_tx")
+class MBarrierArriveExpectTx(Op):
+    """Arrive on ``barrier`` and declare ``tx_bytes`` of asynchronous data.
+
+    The phase completes when both the arrivals and the byte count are satisfied,
+    so one wait covers a copy the waiting thread did not issue. One instruction
+    rather than an ``MBarrierArrive`` beside an ``MBarrierExpectTx``.
+
+    ``tx_bytes`` MUST equal the bytes the paired copy delivers: a phase that
+    expects a different count never completes, and that failure presents as a
+    hang rather than as a wrong value.
+    """
+
+    barrier = ParamDef(kind="input", pattern=Tensor)
+    tx_bytes = ParamDef(kind="attribute", annotation=int)
+
+
+@register_typeinfer(MBarrierArriveExpectTx)
+def _(call: "Call", ctx: "TypeInferContext") -> UnitType:
+    return UnitType()
+
+
+@register_verify_stmt(MBarrierArriveExpectTx)
+def _(call: "Call", ctx: "VerifyContext") -> None:
+    tx = call.target.tx_bytes
+    if not isinstance(tx, int) or tx <= 0:
+        ctx.error(call, f"MBarrierArriveExpectTx.tx_bytes must be a positive int, got {tx!r}")
+    _require_smem_barrier(ctx, call, "MBarrierArriveExpectTx")
+
+
+@register_op(dialect="T", category="sync", name="mbarrier_expect_tx")
+class MBarrierExpectTx(Op):
+    """Declare ``tx_bytes`` against ``barrier``'s phase without arriving."""
+
+    barrier = ParamDef(kind="input", pattern=Tensor)
+    tx_bytes = ParamDef(kind="attribute", annotation=int)
+
+
+@register_typeinfer(MBarrierExpectTx)
+def _(call: "Call", ctx: "TypeInferContext") -> UnitType:
+    return UnitType()
+
+
+@register_verify_stmt(MBarrierExpectTx)
+def _(call: "Call", ctx: "VerifyContext") -> None:
+    tx = call.target.tx_bytes
+    if not isinstance(tx, int) or tx <= 0:
+        ctx.error(call, f"MBarrierExpectTx.tx_bytes must be a positive int, got {tx!r}")
+    _require_smem_barrier(ctx, call, "MBarrierExpectTx")
+
+
+@register_op(dialect="T", category="sync", name="mbarrier_wait_parity")
+class MBarrierWaitParity(Op):
+    """Block until ``barrier``'s phase parity reaches ``phase``.
+
+    The parity alternates 0, 1, 0, ... across successive completions, which is
+    what lets a fixed ring of barriers serve a pipeline of any length: stage
+    ``t`` of a ring of ``n`` waits on parity ``(t // n) & 1``.
+    """
+
+    barrier = ParamDef(kind="input", pattern=Tensor)
+    phase = ParamDef(kind="input", pattern=Scalar)
+
+
+@register_typeinfer(MBarrierWaitParity)
+def _(call: "Call", ctx: "TypeInferContext") -> UnitType:
+    return UnitType()
+
+
+@register_verify_stmt(MBarrierWaitParity)
+def _(call: "Call", ctx: "VerifyContext") -> None:
+    _require_smem_barrier(ctx, call, "MBarrierWaitParity")
+
+
+@register_op(dialect="T", category="sync", name="mbarrier_invalidate")
+class MBarrierInvalidate(Op):
+    """Release ``barrier``'s shared-memory word for other use."""
+
+    barrier = ParamDef(kind="input", pattern=Tensor)
+
+
+@register_typeinfer(MBarrierInvalidate)
+def _(call: "Call", ctx: "TypeInferContext") -> UnitType:
+    return UnitType()
+
+
+@register_verify_stmt(MBarrierInvalidate)
+def _(call: "Call", ctx: "VerifyContext") -> None:
+    _require_smem_barrier(ctx, call, "MBarrierInvalidate")

--- a/src/tilefoundry/ir/tir/cuda/warp.py
+++ b/src/tilefoundry/ir/tir/cuda/warp.py
@@ -1,0 +1,145 @@
+"""Effect-form TIR Ops for the CUDA warp-scoped exchange primitives.
+
+These ops are **defined but not lowered**: there is no CUDA codegen emit for any
+of them. The runtime implementations they name live at
+``include/tilefoundry/runtime/cuda/ops/warp.cuh`` and are exercised directly by
+``tests/integration/test_runtime_device_ops.py``; wiring the emit belongs with
+the TIR backend rebuild, and an emit written now would be rewritten by it while
+these definitions would not.
+
+See [tir §2.3](docs/spec/tir.md#23-tir-ops).
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from tilefoundry.ir.core import Op
+from tilefoundry.ir.core.param_def import ParamDef
+from tilefoundry.ir.core.pattern import Scalar
+from tilefoundry.ir.core.register import register_op
+from tilefoundry.ir.types import UnitType
+from tilefoundry.ir.types.storage import StorageKind
+from tilefoundry.visitor_registry import register_typeinfer, register_verify_stmt
+
+__all__ = ["ShuffleXor", "ShuffleElect", "WarpReduceKind", "WarpReduce"]
+
+_WARP = 32
+
+
+def _require_rmem(ctx, call, at: int, who: str, role: str) -> None:
+    """Report unless operand *at* is register-resident.
+
+    ``_WARP`` above is the lane count a shuffle's partner is chosen inside, so
+    every constraint here is stated against it rather than against a mesh.
+
+    A warp shuffle moves a value between lanes' registers. An operand in shared
+    or global memory is not wrong by a tolerance -- it names a different
+    instruction -- so this is an error rather than a note.
+    """
+    ty = ctx.type_of(call.args[at])
+    if ty.storage != StorageKind.RMEM:
+        ctx.error(call, f"{who} {role} must be rmem, got {ty.storage}")
+
+
+@register_op(dialect="T", category="warp", name="shuffle_xor")
+class ShuffleXor(Op):
+    """Exchange a value with the lane whose id differs by ``lane_mask``.
+
+    ``dst`` receives the ``src`` of lane ``laneid ^ lane_mask``. One
+    ``__shfl_xor_sync``; with masks 1, 2, 4, 8, 16 in turn it is the butterfly
+    ``WarpReduce`` is built from.
+    """
+
+    src = ParamDef(kind="input", pattern=Scalar)
+    dst = ParamDef(kind="input", pattern=Scalar)
+    lane_mask = ParamDef(kind="attribute", annotation=int)
+
+
+@register_typeinfer(ShuffleXor)
+def _(call: "Call", ctx: "TypeInferContext") -> UnitType:
+    return UnitType()
+
+
+@register_verify_stmt(ShuffleXor)
+def _(call: "Call", ctx: "VerifyContext") -> None:
+    op = call.target
+    mask = op.lane_mask
+    if not isinstance(mask, int) or not 0 < mask < _WARP:
+        ctx.error(call, f"ShuffleXor.lane_mask must be in 1..{_WARP - 1}, got {mask!r}")
+    _require_rmem(ctx, call, 0, "ShuffleXor", "src")
+    _require_rmem(ctx, call, 1, "ShuffleXor", "dst")
+    src = ctx.type_of(call.args[0])
+    dst = ctx.type_of(call.args[1])
+    if src.dtype != dst.dtype:
+        ctx.error(call, f"ShuffleXor dtype mismatch: {src.dtype} vs {dst.dtype}")
+
+
+@register_op(dialect="T", category="warp", name="shuffle_elect")
+class ShuffleElect(Op):
+    """Select exactly one thread of the leading ``width`` threads of the CTA.
+
+    ``dst`` is true on that one thread and false on every other. It is one
+    thread of the *block*, not one lane of each warp: an mbarrier armed for a
+    single arrival is only correct under the first reading.
+    """
+
+    dst = ParamDef(kind="input", pattern=Scalar)
+    width = ParamDef(kind="attribute", annotation=int)
+
+
+@register_typeinfer(ShuffleElect)
+def _(call: "Call", ctx: "TypeInferContext") -> UnitType:
+    return UnitType()
+
+
+@register_verify_stmt(ShuffleElect)
+def _(call: "Call", ctx: "VerifyContext") -> None:
+    width = call.target.width
+    if not isinstance(width, int) or width <= 0:
+        ctx.error(call, f"ShuffleElect.width must be a positive int, got {width!r}")
+    _require_rmem(ctx, call, 0, "ShuffleElect", "dst")
+
+
+class WarpReduceKind(Enum):
+    """Which combine a ``WarpReduce`` folds with."""
+
+    SUM = "sum"
+    MAX = "max"
+    MIN = "min"
+
+
+@register_op(dialect="T", category="warp", name="warp_reduce")
+class WarpReduce(Op):
+    """Fold ``src`` across the warp's 32 lanes, leaving the result in every lane.
+
+    Defined as five ``ShuffleXor`` steps with masks 16, 8, 4, 2, 1 and a combine
+    between them -- five shuffles and five combines, not a loop over 32 lanes.
+    The count is stated here rather than left to a lowering to reveal, because
+    it is the reason a caller reaches for this instead of a shared-memory fold.
+
+    ``kind`` carries the combine, the way ``Binary`` and ``Unary`` carry theirs;
+    a class per combine would differ from its siblings in nothing else.
+    """
+
+    src = ParamDef(kind="input", pattern=Scalar)
+    dst = ParamDef(kind="input", pattern=Scalar)
+    kind = ParamDef(kind="attribute", annotation=WarpReduceKind)
+
+
+@register_typeinfer(WarpReduce)
+def _(call: "Call", ctx: "TypeInferContext") -> UnitType:
+    return UnitType()
+
+
+@register_verify_stmt(WarpReduce)
+def _(call: "Call", ctx: "VerifyContext") -> None:
+    op = call.target
+    if not isinstance(op.kind, WarpReduceKind):
+        ctx.error(call, f"WarpReduce: kind must be WarpReduceKind, got {type(op.kind)}")
+    _require_rmem(ctx, call, 0, "WarpReduce", "src")
+    _require_rmem(ctx, call, 1, "WarpReduce", "dst")
+    src = ctx.type_of(call.args[0])
+    dst = ctx.type_of(call.args[1])
+    if src.dtype != dst.dtype:
+        ctx.error(call, f"WarpReduce dtype mismatch: {src.dtype} vs {dst.dtype}")

--- a/tests/integration/runtime_ops/__init__.py
+++ b/tests/integration/runtime_ops/__init__.py
@@ -1,0 +1,53 @@
+"""Compile ``device_ops.cu`` against the CUDA runtime headers, once per session.
+
+The runtime's op headers are not standalone translation units -- ``runtime.cuh``
+includes each ``ops/<op>.cuh`` in-context inside ``namespace tilefoundry::ops``
+-- so a caller includes ``runtime.cuh`` and adds two include roots: the
+repository's ``include/`` and the vendored CuTe. Those are the same two roots
+``tilefoundry.codegen.linker`` puts on its own nvcc line, recomputed here rather
+than imported because the linker's are private to codegen and this compile
+deliberately does not go through codegen.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[3]
+_HERE = Path(__file__).resolve().parent
+_ARCH = os.environ.get("TILEFOUNDRY_TEST_CUDA_ARCH", "90a")
+
+_ext = None
+
+
+def device_ops():
+    """The compiled extension, built on the first call.
+
+    ``sm_90a`` by default: the ``elect.sync``, ``mbarrier.*`` and
+    ``cp.async.bulk`` instructions these ops are made of are Hopper's, and the
+    ``a`` variants are what the architecture's own instructions need.
+    """
+    global _ext
+    if _ext is None:
+        from torch.utils.cpp_extension import load  # noqa: PLC0415
+
+        _ext = load(
+            name="tilefoundry_device_ops_test",
+            sources=[str(_HERE / "device_ops.cu")],
+            extra_include_paths=[
+                str(_ROOT / "include"),
+                str(_ROOT / "third_party" / "cutlass" / "include"),
+            ],
+            extra_cuda_cflags=[
+                "-O2",
+                "-std=c++20",
+                f"-gencode=arch=compute_{_ARCH},code=sm_{_ARCH}",
+                "--expt-relaxed-constexpr",
+            ],
+            extra_cflags=["-O2", "-std=c++20"],
+            verbose=os.environ.get("TILEFOUNDRY_TEST_BUILD_VERBOSE", "") == "1",
+        )
+    return _ext
+
+
+__all__ = ["device_ops"]

--- a/tests/integration/runtime_ops/device_ops.cu
+++ b/tests/integration/runtime_ops/device_ops.cu
@@ -1,0 +1,210 @@
+/// Device-side harness for the warp / mbarrier / TMA runtime ops.
+///
+/// These ops have no codegen emit — their TIR definitions are declared but not
+/// wired to the CUDA backend while that chain is rebuilt — so the path
+/// test_mma_tir_handwritten.py uses (author TIR, compile, let codegen emit
+/// ``tilefoundry::ops::mma``) is not open to them.
+
+/// This file is the substitute: it calls the public entries the way a
+/// hand-written kernel does, and the test around it compares to torch. It
+/// includes ``runtime.cuh`` rather than the individual ``ops/<op>.cuh``
+/// headers, which are included in-context inside ``namespace
+/// tilefoundry::ops`` and are not standalone translation units.
+
+#include <tilefoundry/runtime/cuda/runtime.cuh>
+
+#include <ATen/cuda/CUDAContext.h>
+#include <torch/extension.h>
+
+namespace ops = tilefoundry::ops;
+
+namespace {
+
+constexpr int kThreads = 256;
+
+/// warp.
+
+template <class Combine>
+__global__ void warp_reduce_kernel(const float *in, float *out) {
+    const int t = blockIdx.x * blockDim.x + threadIdx.x;
+    out[t] = ops::warp_reduce<Combine>(in[t]);
+}
+
+__global__ void shuffle_xor_kernel(const float *in, float *out, int lane_mask) {
+    const int t = blockIdx.x * blockDim.x + threadIdx.x;
+    out[t] = ops::shuffle_xor(in[t], lane_mask);
+}
+
+/// One counter per block: how many threads the elect admitted. Every entry must
+/// read 1, which is the property an arrive-count-1 mbarrier depends on.
+template <int Width> __global__ void elect_count_kernel(int *out) {
+    if (ops::shuffle_elect<Width>())
+        atomicAdd(&out[blockIdx.x], 1);
+}
+
+/// mbarrier.
+
+/// One producer thread fills a shared tile and arrives; every consumer waits on
+/// the phase. `rounds` forces the parity to flip, which is what lets a fixed
+/// ring of barriers serve an unbounded pipeline.
+__global__ void mbarrier_pipeline_kernel(const float *in, float *out, int tile,
+                                         int rounds) {
+    extern __shared__ float sm[];
+    __shared__ alignas(8) uint64_t bar;
+
+    if (ops::shuffle_elect<kThreads>())
+        ops::mbarrier_init(&bar, 1);
+    ops::sync<ops::SyncKind::syncthreads>();
+
+    for (int r = 0; r < rounds; ++r) {
+        if (ops::shuffle_elect<kThreads>()) {
+            for (int i = 0; i < tile; ++i)
+                sm[i] = in[r * tile + i] + float(r);
+            ops::mbarrier_arrive(&bar);
+        }
+        ops::mbarrier_wait_parity(&bar, unsigned(r) & 1u);
+        for (int i = threadIdx.x; i < tile; i += kThreads)
+            out[r * tile + i] = sm[i];
+        ops::sync<ops::SyncKind::syncthreads>();
+    }
+}
+
+/// tma.
+
+/// A `stages`-deep ring staged by bulk copy, each tile doubled on the way out.
+/// The producer declares the byte count on the same instruction it arrives
+/// with, so a consumer's parity wait covers the copy without a second barrier.
+template <int Stages>
+__global__ void tma_stage_kernel(const float *in, float *out, int tile,
+                                 int ntile) {
+    extern __shared__ __align__(16) float sm[];
+    __shared__ alignas(8) uint64_t bar[Stages];
+
+    if (ops::shuffle_elect<kThreads>())
+        for (int s = 0; s < Stages; ++s)
+            ops::mbarrier_init(&bar[s], 1);
+    ops::sync<ops::SyncKind::syncthreads>();
+
+    for (int t = 0; t < ntile; ++t) {
+        const int slot = t % Stages;
+        const unsigned phase = unsigned(t / Stages) & 1u;
+        if (ops::shuffle_elect<kThreads>()) {
+            ops::mbarrier_arrive_expect_tx(&bar[slot],
+                                           ops::tma_bulk_bytes<float>(tile));
+            ops::tma_bulk_copy(in + t * tile, sm + slot * tile, tile,
+                               &bar[slot]);
+        }
+        ops::mbarrier_wait_parity(&bar[slot], phase);
+        for (int i = threadIdx.x; i < tile; i += kThreads)
+            out[t * tile + i] = sm[slot * tile + i] * 2.f;
+        ops::sync<ops::SyncKind::syncthreads>();
+    }
+}
+
+/// host wrappers.
+
+void check_f32_cuda(const torch::Tensor &t, const char *what) {
+    TORCH_CHECK(t.is_cuda() && t.is_contiguous() &&
+                    t.scalar_type() == at::kFloat,
+                what, " must be a contiguous f32 CUDA tensor");
+}
+
+torch::Tensor warp_reduce_sum(torch::Tensor x) {
+    check_f32_cuda(x, "x");
+    auto out = torch::empty_like(x);
+    const int n = int(x.numel());
+    TORCH_CHECK(n % kThreads == 0, "x must be a multiple of ", kThreads);
+    warp_reduce_kernel<ops::warp_sum>
+        <<<n / kThreads, kThreads, 0, at::cuda::getCurrentCUDAStream()>>>(
+            x.data_ptr<float>(), out.data_ptr<float>());
+    return out;
+}
+
+torch::Tensor warp_reduce_max(torch::Tensor x) {
+    check_f32_cuda(x, "x");
+    auto out = torch::empty_like(x);
+    const int n = int(x.numel());
+    TORCH_CHECK(n % kThreads == 0, "x must be a multiple of ", kThreads);
+    warp_reduce_kernel<ops::warp_max>
+        <<<n / kThreads, kThreads, 0, at::cuda::getCurrentCUDAStream()>>>(
+            x.data_ptr<float>(), out.data_ptr<float>());
+    return out;
+}
+
+torch::Tensor shuffle_xor(torch::Tensor x, int64_t lane_mask) {
+    check_f32_cuda(x, "x");
+    auto out = torch::empty_like(x);
+    const int n = int(x.numel());
+    TORCH_CHECK(n % kThreads == 0, "x must be a multiple of ", kThreads);
+    shuffle_xor_kernel<<<n / kThreads, kThreads, 0,
+                         at::cuda::getCurrentCUDAStream()>>>(
+        x.data_ptr<float>(), out.data_ptr<float>(), int(lane_mask));
+    return out;
+}
+
+torch::Tensor elect_count(int64_t width, int64_t blocks) {
+    auto out = torch::zeros({blocks},
+                            torch::dtype(torch::kInt32).device(torch::kCUDA));
+    auto stream = at::cuda::getCurrentCUDAStream();
+    auto *p = out.data_ptr<int>();
+    switch (width) {
+    case 8:
+        elect_count_kernel<8><<<blocks, kThreads, 0, stream>>>(p);
+        break;
+    case 32:
+        elect_count_kernel<32><<<blocks, kThreads, 0, stream>>>(p);
+        break;
+    case 256:
+        elect_count_kernel<256><<<blocks, kThreads, 0, stream>>>(p);
+        break;
+    default:
+        TORCH_CHECK(false, "elect_count: unsupported width ", width);
+    }
+    return out;
+}
+
+torch::Tensor mbarrier_pipeline(torch::Tensor x, int64_t tile) {
+    check_f32_cuda(x, "x");
+    const int rounds = int(x.numel() / tile);
+    TORCH_CHECK(int64_t(rounds) * tile == x.numel(), "tile must divide x");
+    auto out = torch::empty_like(x);
+    mbarrier_pipeline_kernel<<<1, kThreads, size_t(tile) * sizeof(float),
+                               at::cuda::getCurrentCUDAStream()>>>(
+        x.data_ptr<float>(), out.data_ptr<float>(), int(tile), rounds);
+    return out;
+}
+
+torch::Tensor tma_stage(torch::Tensor x, int64_t tile, int64_t stages) {
+    check_f32_cuda(x, "x");
+    TORCH_CHECK(tile * sizeof(float) % 16 == 0,
+                "tma_bulk_copy needs a 16-byte multiple; tile=", tile);
+    const int ntile = int(x.numel() / tile);
+    TORCH_CHECK(int64_t(ntile) * tile == x.numel(), "tile must divide x");
+    auto out = torch::empty_like(x);
+    const size_t smem = size_t(tile) * size_t(stages) * sizeof(float);
+    auto stream = at::cuda::getCurrentCUDAStream();
+    switch (stages) {
+    case 1:
+        tma_stage_kernel<1><<<1, kThreads, smem, stream>>>(
+            x.data_ptr<float>(), out.data_ptr<float>(), int(tile), ntile);
+        break;
+    case 3:
+        tma_stage_kernel<3><<<1, kThreads, smem, stream>>>(
+            x.data_ptr<float>(), out.data_ptr<float>(), int(tile), ntile);
+        break;
+    default:
+        TORCH_CHECK(false, "tma_stage: unsupported stage count ", stages);
+    }
+    return out;
+}
+
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+    m.def("warp_reduce_sum", &warp_reduce_sum);
+    m.def("warp_reduce_max", &warp_reduce_max);
+    m.def("shuffle_xor", &shuffle_xor);
+    m.def("elect_count", &elect_count);
+    m.def("mbarrier_pipeline", &mbarrier_pipeline);
+    m.def("tma_stage", &tma_stage);
+}

--- a/tests/integration/test_runtime_device_ops.py
+++ b/tests/integration/test_runtime_device_ops.py
@@ -1,0 +1,105 @@
+"""GPU e2e for the warp, mbarrier and TMA runtime ops, against torch.
+
+Each op runs through its single public ``tilefoundry::ops`` entry from a
+hand-written kernel -- the way a model's runtime twin calls it -- and the result
+is compared to the torch expression that states the same thing. These groups
+have TIR definitions but no codegen emit, so they cannot be reached the way
+``test_mma_tir_handwritten.py`` reaches ``ops::mma``. What ties the TIR
+definition to the implementation exercised here is therefore review, not this
+test: this pins the implementation, and the emit would pin the pair.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from tests.integration.runtime_ops import device_ops
+
+_THREADS = 256
+_WARP = 32
+
+
+@pytest.fixture(scope="module")
+def ops():
+    return device_ops()
+
+
+def _lanes(n_threads: int) -> torch.Tensor:
+    """Deterministic input with both signs and no ties across a warp."""
+    g = torch.Generator(device="cpu").manual_seed(20260905)
+    return torch.randn(n_threads, generator=g).cuda()
+
+
+def test_warp_reduce_sum_matches_torch_sum(ops) -> None:
+    """Every lane holds its warp's total, so the reference broadcasts back."""
+    x = _lanes(4 * _THREADS)
+    got = ops.warp_reduce_sum(x)
+    want = x.reshape(-1, _WARP).sum(-1, keepdim=True).expand(-1, _WARP).reshape(-1)
+    torch.testing.assert_close(got, want, rtol=0, atol=1e-5)
+
+
+def test_warp_reduce_max_matches_torch_amax(ops) -> None:
+    x = _lanes(4 * _THREADS)
+    got = ops.warp_reduce_max(x)
+    want = x.reshape(-1, _WARP).amax(-1, keepdim=True).expand(-1, _WARP).reshape(-1)
+    torch.testing.assert_close(got, want, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("lane_mask", [1, 2, 4, 8, 16])
+def test_shuffle_xor_exchanges_with_the_masked_lane(ops, lane_mask: int) -> None:
+    """Lane ``l`` must receive lane ``l ^ lane_mask``'s value."""
+    x = _lanes(2 * _THREADS)
+    got = ops.shuffle_xor(x, lane_mask)
+    lane = torch.arange(_WARP, device=x.device)
+    partner = lane ^ lane_mask
+    want = x.reshape(-1, _WARP).index_select(1, partner).reshape(-1)
+    torch.testing.assert_close(got, want, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("width", [8, 32, 256])
+def test_shuffle_elect_admits_exactly_one_thread_per_block(ops, width: int) -> None:
+    """An mbarrier armed for one arrival is correct only if this is exactly 1.
+
+    a per-warp elect would make it 8 in a 256-thread block.
+    """
+    counts = ops.elect_count(width, 5)
+    assert counts.tolist() == [1] * 5
+
+
+def test_mbarrier_pipeline_flips_parity_across_rounds(ops) -> None:
+    """A consumer that reads the wrong phase is caught by the addend.
+
+    The producer adds the round index, so a tile read from the wrong phase shows
+    up as the wrong addend rather than as stale data.
+    """
+    tile, rounds = 512, 6
+    x = _lanes(tile * rounds)
+    got = ops.mbarrier_pipeline(x, tile)
+    offsets = torch.arange(rounds, device=x.device, dtype=x.dtype)
+    want = x.reshape(rounds, tile) + offsets[:, None]
+    torch.testing.assert_close(got, want.reshape(-1), rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("stages", [1, 3])
+def test_tma_bulk_copy_stages_every_tile(ops, stages: int) -> None:
+    """Every tile arrives, over a ring that does not divide the tile count.
+
+    7 tiles over a 3-deep ring is two full turns plus one, so the parity is
+    exercised in both states and the tail is not a whole number of turns.
+    """
+    tile, ntile = 1024, 7
+    x = _lanes(tile * ntile)
+    got = ops.tma_stage(x, tile, stages)
+    torch.testing.assert_close(got, x * 2.0, rtol=0, atol=0)
+
+
+def test_tma_bulk_copy_rejects_an_unaligned_tile(ops) -> None:
+    """An off-grain tile is refused, not transferred.
+
+    The instruction has no defined behaviour off the 16-byte grain, so the entry
+    refuses rather than moving something else.
+    """
+    x = _lanes(_THREADS)
+    with pytest.raises(RuntimeError, match="16-byte multiple"):
+        ops.tma_stage(x, 3, 1)

--- a/tests/ir/tir/test_cuda_mbarrier.py
+++ b/tests/ir/tir/test_cuda_mbarrier.py
@@ -1,0 +1,106 @@
+"""Cover the CUDA mbarrier definitions: shared-memory residence and counts.
+
+These ops have no CUDA emit; the definition layer is what is verifiable here.
+The implementations they name are exercised as a producer/consumer pipeline in
+``tests/integration/test_runtime_device_ops.py``.
+
+See [tir §2.3](docs/spec/tir.md#23-tir-ops).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tilefoundry.ir.core import Var, VerifyError
+from tilefoundry.ir.tir.cuda.sync.mbarrier import (
+    MBarrierArrive,
+    MBarrierArriveExpectTx,
+    MBarrierExpectTx,
+    MBarrierInit,
+    MBarrierInvalidate,
+    MBarrierWaitParity,
+)
+from tilefoundry.ir.tir.prim_function import PrimFunction
+from tilefoundry.ir.tir.stmts import Evaluate, Return, Sequential
+from tilefoundry.ir.tir.verify import verify_prim_function
+from tilefoundry.ir.types import DType, make_tensor_type
+
+_SMEM_BAR = make_tensor_type((1,), DType.i64, storage="smem")
+_GMEM_BAR = make_tensor_type((1,), DType.i64, storage="gmem")
+_PHASE = make_tensor_type((), DType.i32, storage="rmem")
+
+
+def _pf(op, *types) -> PrimFunction:
+    args = tuple(Var(type=t, name=f"a{i}") for i, t in enumerate(types))
+    return PrimFunction(
+        name="fn",
+        params=args,
+        body=Sequential(body=(Evaluate(callable=op, args=args), Return())),
+    )
+
+
+_BARRIER_ONLY = [
+    pytest.param(MBarrierArrive(), id="arrive"),
+    pytest.param(MBarrierInvalidate(), id="invalidate"),
+]
+
+
+def test_init_accepts_a_shared_barrier_and_a_positive_count() -> None:
+    verify_prim_function(_pf(MBarrierInit(arrive_count=1), _SMEM_BAR))
+
+
+@pytest.mark.parametrize("count", [0, -1])
+def test_init_refuses_a_non_positive_arrive_count(count: int) -> None:
+    """A non-positive arrive count is refused.
+
+    A phase needing zero arrivals is complete before anything is produced, which
+    turns every consumer's wait into a no-op.
+    """
+    with pytest.raises(VerifyError, match="arrive_count must be a positive int"):
+        verify_prim_function(_pf(MBarrierInit(arrive_count=count), _SMEM_BAR))
+
+
+@pytest.mark.parametrize("op", _BARRIER_ONLY)
+def test_barrier_only_entries_accept_a_shared_barrier(op) -> None:
+    verify_prim_function(_pf(op, _SMEM_BAR))
+
+
+@pytest.mark.parametrize("op", _BARRIER_ONLY)
+def test_barrier_only_entries_refuse_a_global_barrier(op) -> None:
+    with pytest.raises(VerifyError, match="barrier must be smem"):
+        verify_prim_function(_pf(op, _GMEM_BAR))
+
+
+def test_init_refuses_a_global_barrier() -> None:
+    """A barrier outside shared memory is refused.
+
+    The instructions take a shared-window address, so a barrier in global memory
+    is not a slower barrier -- it is not one at all.
+    """
+    with pytest.raises(VerifyError, match="barrier must be smem"):
+        verify_prim_function(_pf(MBarrierInit(arrive_count=1), _GMEM_BAR))
+
+
+@pytest.mark.parametrize(
+    "make", [MBarrierArriveExpectTx, MBarrierExpectTx], ids=["arrive_expect_tx", "expect_tx"]
+)
+def test_expect_tx_entries_accept_a_positive_byte_count(make) -> None:
+    verify_prim_function(_pf(make(tx_bytes=4096), _SMEM_BAR))
+
+
+@pytest.mark.parametrize(
+    "make", [MBarrierArriveExpectTx, MBarrierExpectTx], ids=["arrive_expect_tx", "expect_tx"]
+)
+@pytest.mark.parametrize("tx", [0, -16])
+def test_expect_tx_entries_refuse_a_non_positive_byte_count(make, tx: int) -> None:
+    with pytest.raises(VerifyError, match="tx_bytes must be a positive int"):
+        verify_prim_function(_pf(make(tx_bytes=tx), _SMEM_BAR))
+
+
+def test_wait_parity_accepts_a_shared_barrier_and_a_phase() -> None:
+    verify_prim_function(_pf(MBarrierWaitParity(), _SMEM_BAR, _PHASE))
+
+
+def test_wait_parity_refuses_a_global_barrier() -> None:
+    with pytest.raises(VerifyError, match="barrier must be smem"):
+        verify_prim_function(_pf(MBarrierWaitParity(), _GMEM_BAR, _PHASE))

--- a/tests/ir/tir/test_cuda_tma.py
+++ b/tests/ir/tir/test_cuda_tma.py
@@ -1,0 +1,94 @@
+"""Cover the CUDA bulk-copy definition: direction, dtype, shape and grain.
+
+The op has no CUDA emit; the definition layer is what is verifiable here. The
+implementation it names is exercised as a staged ring in
+``tests/integration/test_runtime_device_ops.py``.
+
+See [tir §2.3](docs/spec/tir.md#23-tir-ops).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tilefoundry.ir.core import Var, VerifyError
+from tilefoundry.ir.tir.cuda.memory.tma import TmaBulkCopy
+from tilefoundry.ir.tir.prim_function import PrimFunction
+from tilefoundry.ir.tir.stmts import Evaluate, Return, Sequential
+from tilefoundry.ir.tir.verify import verify_prim_function
+from tilefoundry.ir.types import DType, make_tensor_type
+
+_BAR = make_tensor_type((1,), DType.i64, storage="smem")
+
+
+def _pf(src, dst, bar=_BAR) -> PrimFunction:
+    args = tuple(
+        Var(type=t, name=n) for t, n in ((src, "src"), (dst, "dst"), (bar, "bar"))
+    )
+    return PrimFunction(
+        name="fn",
+        params=args,
+        body=Sequential(body=(Evaluate(callable=TmaBulkCopy(), args=args), Return())),
+    )
+
+
+def _ty(n, dtype=DType.f32, storage="gmem"):
+    return make_tensor_type((n,), dtype, storage=storage)
+
+
+def test_accepts_a_whole_grain_gmem_to_smem_run() -> None:
+    """8 f32 is 32 bytes: two whole 16-byte grains."""
+    verify_prim_function(_pf(_ty(8), _ty(8, storage="smem")))
+
+
+def test_refuses_the_wrong_direction() -> None:
+    """Only gmem into smem is this instruction.
+
+    This stages global into shared; the reverse is a different instruction, not this one with
+    its operands swapped.
+    """
+    with pytest.raises(VerifyError, match="source must be gmem"):
+        verify_prim_function(_pf(_ty(8, storage="smem"), _ty(8, storage="smem")))
+    with pytest.raises(VerifyError, match="destination must be smem"):
+        verify_prim_function(_pf(_ty(8), _ty(8, storage="gmem")))
+
+
+def test_refuses_a_barrier_outside_shared_memory() -> None:
+    with pytest.raises(VerifyError, match="barrier must be smem"):
+        verify_prim_function(
+            _pf(_ty(8), _ty(8, storage="smem"), make_tensor_type((1,), DType.i64, storage="gmem"))
+        )
+
+
+def test_refuses_a_dtype_change() -> None:
+    """A bulk copy moves bytes; it does not convert them."""
+    with pytest.raises(VerifyError, match="dtype mismatch"):
+        verify_prim_function(_pf(_ty(8), _ty(8, DType.bf16, storage="smem")))
+
+
+def test_refuses_a_shape_change() -> None:
+    with pytest.raises(VerifyError, match="shape mismatch"):
+        verify_prim_function(_pf(_ty(8), _ty(4, storage="smem")))
+
+
+@pytest.mark.parametrize(
+    ("n", "dtype", "byte_count"),
+    [(5, DType.f32, 20), (1, DType.f32, 4), (7, DType.bf16, 14)],
+)
+def test_refuses_a_transfer_off_the_sixteen_byte_grain(n, dtype, byte_count) -> None:
+    """A transfer off the 16-byte grain is refused.
+
+    The instruction has no defined behaviour off the grain, so this is rejected rather than
+    rounded up to the next whole one.
+    """
+    with pytest.raises(VerifyError, match=f"multiple of 16 bytes, got {byte_count}"):
+        verify_prim_function(_pf(_ty(n, dtype), _ty(n, dtype, storage="smem")))
+
+
+def test_a_bf16_run_is_measured_in_bytes_not_elements() -> None:
+    """The grain is counted in bytes, not elements.
+
+    8 bf16 is 16 bytes -- one grain -- while 8 f32 is two, so the check reads the dtype's width
+    rather than the element count.
+    """
+    verify_prim_function(_pf(_ty(8, DType.bf16), _ty(8, DType.bf16, storage="smem")))

--- a/tests/ir/tir/test_cuda_warp.py
+++ b/tests/ir/tir/test_cuda_warp.py
@@ -1,0 +1,93 @@
+"""Cover the CUDA warp-op definitions: what they accept and what they refuse.
+
+These ops have no CUDA emit, so what is verifiable here is the definition layer
+-- the operand storage and dtype agreements, and the attribute ranges the
+hardware imposes. The implementations they name are exercised against torch in
+``tests/integration/test_runtime_device_ops.py``.
+
+See [tir §2.3](docs/spec/tir.md#23-tir-ops).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tilefoundry.ir.core import Var, VerifyError
+from tilefoundry.ir.tir.cuda.warp import (
+    ShuffleElect,
+    ShuffleXor,
+    WarpReduce,
+    WarpReduceKind,
+)
+from tilefoundry.ir.tir.prim_function import PrimFunction
+from tilefoundry.ir.tir.stmts import Evaluate, Return, Sequential
+from tilefoundry.ir.tir.verify import verify_prim_function
+from tilefoundry.ir.types import DType, make_tensor_type
+
+
+def _pf(op, *types) -> PrimFunction:
+    args = tuple(Var(type=t, name=f"a{i}") for i, t in enumerate(types))
+    return PrimFunction(
+        name="fn",
+        params=args,
+        body=Sequential(body=(Evaluate(callable=op, args=args), Return())),
+    )
+
+
+def _reg(dtype: DType = DType.f32):
+    return make_tensor_type((), dtype, storage="rmem")
+
+
+def test_shuffle_xor_accepts_a_register_pair_and_an_in_warp_mask() -> None:
+    verify_prim_function(_pf(ShuffleXor(lane_mask=16), _reg(), _reg()))
+
+
+@pytest.mark.parametrize("lane_mask", [0, 32, 64, -1])
+def test_shuffle_xor_refuses_a_mask_outside_the_warp(lane_mask: int) -> None:
+    """A mask outside 1..31 is refused.
+
+    A mask of 0 exchanges a lane with itself and 32 or more names a lane that is not in this
+    warp; neither is a butterfly step.
+    """
+    with pytest.raises(VerifyError, match="lane_mask must be in 1..31"):
+        verify_prim_function(_pf(ShuffleXor(lane_mask=lane_mask), _reg(), _reg()))
+
+
+def test_shuffle_xor_refuses_an_operand_outside_registers() -> None:
+    smem = make_tensor_type((), DType.f32, storage="smem")
+    with pytest.raises(VerifyError, match="src must be rmem"):
+        verify_prim_function(_pf(ShuffleXor(lane_mask=1), smem, _reg()))
+    with pytest.raises(VerifyError, match="dst must be rmem"):
+        verify_prim_function(_pf(ShuffleXor(lane_mask=1), _reg(), smem))
+
+
+def test_shuffle_xor_refuses_a_dtype_change() -> None:
+    with pytest.raises(VerifyError, match="dtype mismatch"):
+        verify_prim_function(_pf(ShuffleXor(lane_mask=1), _reg(DType.f32), _reg(DType.bf16)))
+
+
+def test_shuffle_elect_accepts_a_positive_width() -> None:
+    verify_prim_function(_pf(ShuffleElect(width=256), _reg()))
+
+
+@pytest.mark.parametrize("width", [0, -8])
+def test_shuffle_elect_refuses_a_non_positive_width(width: int) -> None:
+    with pytest.raises(VerifyError, match="width must be a positive int"):
+        verify_prim_function(_pf(ShuffleElect(width=width), _reg()))
+
+
+@pytest.mark.parametrize("kind", list(WarpReduceKind))
+def test_warp_reduce_accepts_every_combine(kind: WarpReduceKind) -> None:
+    verify_prim_function(_pf(WarpReduce(kind=kind), _reg(), _reg()))
+
+
+def test_warp_reduce_refuses_a_kind_that_is_not_the_enum() -> None:
+    with pytest.raises(VerifyError, match="kind must be WarpReduceKind"):
+        verify_prim_function(_pf(WarpReduce(kind="sum"), _reg(), _reg()))
+
+
+def test_warp_reduce_refuses_a_dtype_change() -> None:
+    with pytest.raises(VerifyError, match="dtype mismatch"):
+        verify_prim_function(
+            _pf(WarpReduce(kind=WarpReduceKind.SUM), _reg(DType.f32), _reg(DType.bf16))
+        )


### PR DESCRIPTION
## Why
- A persistent cooperative decode kernel needs three primitive groups this
  runtime does not have: warp-scoped exchange, the Hopper shared-memory barrier
  object, and the bulk asynchronous copy. `async_copy.py` is `cp.async`, not
  TMA; `sync.py` has only `Sync` and `SyncBarrier`; and the only warp shuffle in
  the tree was one `__shfl_xor_sync` private to `ops::reduce`.
- This is the first milestone of replacing an example's generated tilelang mega
  kernel with handwritten CUDA. The ops land in the public runtime rather than
  in the example so the next model does not have to copy them back out.

## What
- `ops::shuffle_xor`, `ops::shuffle_elect`, `ops::warp_reduce`;
  `ops::mbarrier_{init,arrive,arrive_expect_tx,expect_tx,try_wait_parity,
  wait_parity,invalidate}`; `ops::tma_bulk_copy` and `ops::tma_bulk_bytes`.
  One public entry each, implementations under `ops/<op>/`.
- `ops::reduce`'s intra-warp tier folds through `ops::warp_reduce`, so
  `__shfl_xor_sync` is spelled once in the repository instead of twice.
- Matching TIR ops under `ir/tir/cuda/` with types and verifier rules.
- `tests/integration/test_runtime_device_ops.py` drives every entry from a
  hand-written kernel and compares to torch, including a three-deep staged ring
  that exercises the phase parity in both states.

## Contract
- `docs/spec/runtime.md` gains §3.7–3.9 and `docs/spec/tir.md` gains the three
  op groups.
- **None of the three admits a tier.** A warp shuffle's operand is a register
  scalar; an mbarrier is a shared-memory word, not a sharded tensor; and the
  hardware's two bulk forms differ in their *operands* — a size against a
  host-encoded `TensorMap` — rather than in a tier a trait could select. Each is
  a single implementation behind a single entry, and the caller passes no
  selection. §3's one-entry rule is satisfied; it does not require an op to have
  more than one implementation.
- **The TIR ops carry no CUDA emit.** The compile side is being rebuilt; an emit
  written now would be rewritten by that work while these definitions would not.
  Each spec entry says so and names the `ops::` entry it corresponds to.

## Risk
- Because there is no emit, the established way to check a runtime op against
  torch (`test_mma_tir_handwritten.py`: author TIR, compile, let codegen emit
  the call) is not open to these. The new test pins the *implementation*; what
  ties it to the TIR definition is review, not the machine. Wiring the emit is
  what would pin the pair, and that waits on the TIR backend rebuild.
- `ops::tma_bulk_copy` implements only the rank-1 form. The tensor forms
  (`cp.async.bulk.tensor.Nd`) are absent because nothing calls them.
- The wheel ships neither `include/` nor the vendored CuTe, so a handwritten
  kernel outside this repository cannot yet reach these headers. `examples/` is
  not distributed either, so nothing in tree depends on that today.
