### PR TITLE
feat(examples): replace the nemotron tilelang mega kernel with handwritten CUDA

### DIFF
--- a/CLAUDE.local.md
+++ b/CLAUDE.local.md
@@ -1,0 +1,1 @@
+/home/qihang.zheng/TileFoundry/CLAUDE.local.md

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -1036,3 +1036,142 @@ __device__ void copy_async(TSrc const& src, TDst& dst);
     `cp_async_commit` and `cp_async_wait`.
   - Runtime implementation details such as vector width, tail handling, and
     architecture fallback live in code comments, not this spec entry.
+
+### 3.7 `tilefoundry::ops::warp_*` (warp-scoped exchange)
+
+Three ops, one public entry each, and **no tiers**: their operand is a
+register-resident scalar, which carries no `ShardLayout`, so there is nothing
+for a compile-time tier selection to read. The one-entry rule of
+[§3](#3-runtime-ops) requires one entry per op; it does not require every op to
+have more than one implementation.
+
+`warp.cuh` is included before `reduce.cuh` so that `ops::reduce`'s intra-warp
+tier folds through `warp_reduce` rather than spelling the butterfly a second
+time.
+
+```cpp
+/**
+ * @brief Exchange a value with the lane whose id differs by lane_mask.
+ * @param value this lane's contribution
+ * @param lane_mask the lane-id bits exchanged across
+ * @param member_mask the participating lanes
+ */
+template <class T>
+__device__ T shuffle_xor(T value, int lane_mask, unsigned member_mask = 0xFFFFFFFFu);
+
+/**
+ * @brief Select exactly one thread of the leading Width threads of the CTA.
+ * @tparam Width compile-time participating thread count
+ */
+template <int Width>
+__device__ bool shuffle_elect();
+
+/**
+ * @brief Fold value across the warp, leaving the result in every lane.
+ * @tparam Combine functor type supplying a static apply(T, T) -> T
+ * @param value this lane's contribution
+ */
+template <class Combine, class T>
+__device__ T warp_reduce(T value);
+```
+
+- constraints:
+  - `shuffle_elect` elects one thread of the **CTA**, not one lane of each warp.
+    An mbarrier armed for a single arrival is correct only under that reading.
+  - `warp_reduce` is the five-step butterfly and leaves its result in every lane.
+  - Types wider than the shuffle intrinsic's are exchanged word-wise; that
+    choice lives in code comments, not this entry.
+
+### 3.8 `tilefoundry::ops::mbarrier_*` (shared-memory barrier object)
+
+A Hopper mbarrier is a 64-bit shared-memory word carrying an arrival count, a
+transaction-byte count and a phase parity. It is not `ops::sync`
+([§3.4](#34-tilefoundryopssync-mesh-scoped-barrier)): that is a whole-mesh
+rendezvous every participant reaches, while these let a producer signal
+completion of work the consumer did not perform.
+
+`ops::sync` collapses five `SyncKind`s behind one entry because they are five
+ways to spell one op — "barrier for this mesh scope" — with the scope choosing
+the spelling. `mbarrier.init` / `arrive` / `try_wait` are not one op: they are
+three instructions with three meanings and three signatures. The one-entry rule
+forbids exposing the *tiers* of one op separately; it does not ask distinct
+operations to hide behind an enum. **No tiers:** a barrier is a shared-memory
+object, not a sharded tensor, so no operand carries a `ShardLayout`.
+
+```cpp
+/** @brief Arm a barrier so arrive_count arrivals complete a phase. */
+__device__ void mbarrier_init(uint64_t* bar, unsigned arrive_count);
+
+/** @brief Contribute one arrival to the barrier's current phase. */
+__device__ void mbarrier_arrive(uint64_t* bar);
+
+/** @brief Arrive and declare tx_bytes of asynchronous data in one instruction. */
+__device__ void mbarrier_arrive_expect_tx(uint64_t* bar, unsigned tx_bytes);
+
+/** @brief Declare tx_bytes against the current phase without arriving. */
+__device__ void mbarrier_expect_tx(uint64_t* bar, unsigned tx_bytes);
+
+/** @brief Test the phase once without blocking. */
+__device__ bool mbarrier_try_wait_parity(uint64_t* bar, unsigned phase);
+
+/** @brief Block until the barrier's phase parity reaches phase. */
+__device__ void mbarrier_wait_parity(uint64_t* bar, unsigned phase);
+
+/** @brief Release the barrier's shared-memory word. */
+__device__ void mbarrier_invalidate(uint64_t* bar);
+```
+
+- constraints:
+  - `bar` addresses shared memory. One thread calls `mbarrier_init`, and a
+    `sync` covering every thread that will use the barrier separates it from the
+    first arrival or wait.
+  - The parity alternates `0, 1, 0, ...` across successive completions, which is
+    what lets a fixed ring of barriers serve a pipeline of any length: stage `t`
+    of a ring of `n` waits on parity `(t / n) & 1`.
+  - A `tx_bytes` that disagrees with the bytes the paired copy delivers leaves
+    the phase permanently incomplete; the failure presents as a hang, not as a
+    wrong value.
+
+### 3.9 `tilefoundry::ops::tma_bulk_copy` (bulk async gmem→smem staging)
+
+`cp.async.bulk`, and not a tier of `ops::copy_async`
+([§3.6](#36-tilefoundryopscopy_async-async-gmemsmem-staging)): there every
+thread issues its own 4-, 8- or 16-byte load and a commit closes the group; here
+one thread issues a whole contiguous run and an mbarrier signals completion.
+
+**One implementation.** The hardware's two bulk forms are the rank-1
+`cp.async.bulk` implemented here and the tensor forms
+`cp.async.bulk.tensor.Nd`, which take a host-encoded `TensorMap` in place of a
+size. Those differ in their *operands*, not in a tier a trait could pick
+between, and a caller holding one cannot supply the other. A weaker-alignment
+fallback is likewise absent: that is `ops::copy_async`, and this entry refuses
+rather than silently becoming a slower copy.
+
+```cpp
+/**
+ * @brief Stage a contiguous run gmem→smem as one bulk async copy.
+ * @param src_gmem the source run
+ * @param dst_smem the shared destination
+ * @param count elements transferred
+ * @param bar the mbarrier the completion lands on
+ */
+template <class T>
+__device__ void tma_bulk_copy(T const* src_gmem, T* dst_smem, unsigned count, uint64_t* bar);
+
+/**
+ * @brief The byte count tma_bulk_copy transfers, for the arrival that declares it.
+ * @param count elements transferred
+ */
+template <class T>
+__device__ __host__ constexpr unsigned tma_bulk_bytes(unsigned count);
+```
+
+- constraints:
+  - Exactly one thread issues the copy, and nothing blocks: it is in flight when
+    the issuing thread reaches the next statement.
+  - Both addresses are 16-byte aligned and the byte count is a multiple of 16.
+    The instruction has no defined behaviour otherwise.
+  - The issuing thread pairs the copy with
+    `mbarrier_arrive_expect_tx(bar, tma_bulk_bytes<T>(count))`; consumers wait
+    with `mbarrier_wait_parity`. `tma_bulk_bytes` exists so the declared and
+    delivered counts cannot drift.

--- a/docs/spec/tir.md
+++ b/docs/spec/tir.md
@@ -1056,3 +1056,257 @@ class CpAsyncWait(Op):
 - constraints:
   - `n` is a non-negative compile-time count.
   - `n = 0` drains every outstanding committed group.
+
+##### TmaBulkCopy
+
+`cp.async.bulk` is the other asynchronous staging instruction, and it is not a
+tier of `CopyAsync`: there, every thread issues its own 4-, 8- or 16-byte load
+and a commit closes the group; here **one** thread issues a whole contiguous run
+and an mbarrier signals completion. They differ in who issues, in what closes
+them, and in the alignment they demand.
+
+Only the rank-1 form is defined. The tensor forms (`cp.async.bulk.tensor.Nd`)
+take a host-encoded `TensorMap` in place of a size, which is a different operand
+list rather than a different tier.
+
+```python
+class TmaBulkCopy(Op):
+    """Effect form; bulk async gmem→smem copy completing on an mbarrier.
+
+    Attributes:
+        src: input; gmem source, a contiguous run.
+        dst: input; smem destination.
+        barrier: input; smem mbarrier the completion lands on.
+    """
+
+    src: Tensor
+    dst: Tensor
+    barrier: Tensor
+```
+- constraints:
+  - `src` is gmem, `dst` is smem, `barrier` is smem.
+  - `src` and `dst` agree in dtype and shape; the copy moves bytes and does not
+    convert them.
+  - The transfer is a whole number of 16-byte grains. Off the grain the
+    instruction has no defined behaviour, so a static extent that violates this
+    is rejected rather than rounded.
+  - Exactly one thread issues it, and nothing blocks: the copy is in flight when
+    the issuing thread reaches the next statement.
+  - The issuing thread pairs it with `MBarrierArriveExpectTx` naming the same
+    byte count; consumers wait with `MBarrierWaitParity`.
+  - **No CUDA lowering is registered.** The op states the contract; the
+    implementation it corresponds to is
+    `tilefoundry::ops::tma_bulk_copy(src, dst, count, bar)`
+    ([runtime §3](./runtime.md#3-runtime-ops)), reached today only by a
+    hand-written kernel.
+
+#### Barrier object Ops (`tir.sync.mbarrier_*`)
+
+A Hopper mbarrier is a 64-bit shared-memory word carrying an arrival count, a
+transaction-byte count and a phase parity. It is not `Sync`
+([§1.5](#15-sync)): `Sync` is a whole-mesh rendezvous every participant reaches,
+while these let a producer signal completion of work the consumer did not
+perform — which is what an asynchronous copy needs, since the thread that issues
+one is not the thread that waits for it.
+
+**No CUDA lowering is registered for any op in this group.** Each states its
+contract and names the `tilefoundry::ops` entry it corresponds to
+([runtime §3](./runtime.md#3-runtime-ops)).
+
+##### MBarrierInit
+
+```python
+class MBarrierInit(Op):
+    """Effect form; arm a barrier for a fixed number of arrivals.
+
+    Attributes:
+        barrier: input; smem barrier object.
+        arrive_count: attribute; arrivals that complete one phase.
+    """
+
+    barrier: Tensor
+    arrive_count: int
+```
+- constraints:
+  - `barrier` is smem; the instructions take a shared-window address.
+  - `arrive_count` is a positive compile-time count. A phase needing zero
+    arrivals is complete before anything is produced, which makes every
+    consumer's wait a no-op.
+  - One thread initialises, and a `Sync` covering every thread that will use the
+    barrier separates this from the first arrival or wait.
+  - Corresponds to `tilefoundry::ops::mbarrier_init(bar, arrive_count)`.
+
+##### MBarrierArrive
+
+```python
+class MBarrierArrive(Op):
+    """Effect form; contribute one arrival to the barrier's current phase.
+
+    Attributes:
+        barrier: input; smem barrier object.
+    """
+
+    barrier: Tensor
+```
+- constraints:
+  - `barrier` is smem.
+  - The arrival token is not a value here: consumers wait on the phase parity,
+    not on a token handed between threads.
+  - Corresponds to `tilefoundry::ops::mbarrier_arrive(bar)`.
+
+##### MBarrierArriveExpectTx
+
+```python
+class MBarrierArriveExpectTx(Op):
+    """Effect form; arrive and declare asynchronous bytes in one instruction.
+
+    Attributes:
+        barrier: input; smem barrier object.
+        tx_bytes: attribute; bytes the paired copy delivers to this phase.
+    """
+
+    barrier: Tensor
+    tx_bytes: int
+```
+- constraints:
+  - `barrier` is smem and `tx_bytes` is a positive compile-time count.
+  - The phase completes when both the arrivals and the byte count are satisfied,
+    so one wait covers a copy the waiting thread did not issue.
+  - `tx_bytes` MUST equal the bytes the paired copy delivers. A phase expecting a
+    different count never completes, and that failure presents as a hang rather
+    than as a wrong value.
+  - Corresponds to `tilefoundry::ops::mbarrier_arrive_expect_tx(bar, tx_bytes)`.
+
+##### MBarrierExpectTx
+
+```python
+class MBarrierExpectTx(Op):
+    """Effect form; declare asynchronous bytes without arriving.
+
+    Attributes:
+        barrier: input; smem barrier object.
+        tx_bytes: attribute; bytes the paired copy delivers to this phase.
+    """
+
+    barrier: Tensor
+    tx_bytes: int
+```
+- constraints:
+  - `barrier` is smem and `tx_bytes` is a positive compile-time count.
+  - Corresponds to `tilefoundry::ops::mbarrier_expect_tx(bar, tx_bytes)`.
+
+##### MBarrierWaitParity
+
+```python
+class MBarrierWaitParity(Op):
+    """Effect form; block until the barrier's phase parity reaches a value.
+
+    Attributes:
+        barrier: input; smem barrier object.
+        phase: input; the parity waited for.
+    """
+
+    barrier: Tensor
+    phase: Tensor
+```
+- constraints:
+  - `barrier` is smem.
+  - The parity alternates `0, 1, 0, ...` across successive completions, which is
+    what lets a fixed ring of barriers serve a pipeline of any length: stage `t`
+    of a ring of `n` waits on parity `(t // n) & 1`.
+  - Corresponds to `tilefoundry::ops::mbarrier_wait_parity(bar, phase)`.
+
+##### MBarrierInvalidate
+
+```python
+class MBarrierInvalidate(Op):
+    """Effect form; release the barrier's shared-memory word.
+
+    Attributes:
+        barrier: input; smem barrier object.
+    """
+
+    barrier: Tensor
+```
+- constraints:
+  - `barrier` is smem.
+  - Corresponds to `tilefoundry::ops::mbarrier_invalidate(bar)`.
+
+#### Warp Ops (`tir.warp.*`)
+
+Lane-to-lane exchange inside one warp. Every operand is register-resident: a
+shuffle moves a value between lanes' registers, and an operand in shared or
+global memory names a different instruction rather than a slower spelling of
+this one.
+
+**No CUDA lowering is registered for any op in this group.** Each states its
+contract and names the `tilefoundry::ops` entry it corresponds to
+([runtime §3](./runtime.md#3-runtime-ops)).
+
+##### ShuffleXor
+
+```python
+class ShuffleXor(Op):
+    """Effect form; exchange a value with the lane whose id differs by a mask.
+
+    Attributes:
+        src: input; rmem scalar contributed by this lane.
+        dst: input; rmem scalar receiving the partner lane's value.
+        lane_mask: attribute; the lane-id bits exchanged across.
+    """
+
+    src: Tensor
+    dst: Tensor
+    lane_mask: int
+```
+- constraints:
+  - `src` and `dst` are rmem scalars agreeing in dtype.
+  - `lane_mask` is in `1..31`. Zero exchanges a lane with itself and 32 or more
+    names a lane outside this warp; neither is a butterfly step.
+  - `dst` receives the `src` of lane `laneid ^ lane_mask`.
+  - Corresponds to `tilefoundry::ops::shuffle_xor(value, lane_mask)`.
+
+##### ShuffleElect
+
+```python
+class ShuffleElect(Op):
+    """Effect form; select exactly one thread of a leading thread range.
+
+    Attributes:
+        dst: input; rmem scalar, true on the elected thread.
+        width: attribute; participating threads, counted from the CTA's first.
+    """
+
+    dst: Tensor
+    width: int
+```
+- constraints:
+  - `dst` is an rmem scalar and `width` is a positive compile-time count.
+  - The elected thread is one thread of the **CTA**, not one lane of each warp.
+    An mbarrier armed for a single arrival is correct only under that reading.
+  - Corresponds to `tilefoundry::ops::shuffle_elect<Width>()`.
+
+##### WarpReduce
+
+```python
+class WarpReduce(Op):
+    """Effect form; fold a value across the warp, leaving it in every lane.
+
+    Attributes:
+        src: input; rmem scalar contributed by this lane.
+        dst: input; rmem scalar receiving the warp's fold.
+        kind: attribute; the combine — sum, max or min.
+    """
+
+    src: Tensor
+    dst: Tensor
+    kind: WarpReduceKind
+```
+- constraints:
+  - `src` and `dst` are rmem scalars agreeing in dtype.
+  - Defined as five `ShuffleXor` steps with masks `16, 8, 4, 2, 1` and a combine
+    between them — five shuffles and five combines, not a fold over 32 lanes.
+    The count is stated because it is the reason a caller reaches for this rather
+    than a shared-memory fold.
+  - The result is in every lane, not only in lane 0.
+  - Corresponds to `tilefoundry::ops::warp_reduce<Combine>(value)`.

--- a/examples/nemotron_3_5_lightning_30b_a3b-tilelang/ISSUES.md
+++ b/examples/nemotron_3_5_lightning_30b_a3b-tilelang/ISSUES.md
@@ -177,6 +177,48 @@ unexpected keyword argument 'num_sms'`. What is actually wanted is
 
 ---
 
+### TF-8 a twin that imports lazily cannot be checked
+
+`tilefoundry check` puts a source file's directory on `sys.path` while it imports
+the module and takes it off again (`src/tilefoundry/cli/source.py:284,314`). Both
+kernels here are compiled on first *use*, from inside a method, which is the
+pattern `granite_4_0_h_small-cuda` uses too -- and by then the directory is gone:
+
+    tilefoundry check: error: No module named 'mega_kernel'
+    tilefoundry check: error: No module named 'kernels'
+
+Worked around here by re-inserting the module's own directory before each lazy
+import (`runtime_model._sibling_import`). The general fix belongs in the CLI:
+a source file's directory is where its siblings live for as long as it runs, not
+only while it is imported.
+
+### TF-9 `check`'s bounds admit only an implementation that rounds like the reference
+
+`check_all.py` derives each bound as `2^-9*sqrt(k)` over the bf16 landings on the
+path to an output, which treats the roundings as an independent random walk. A
+52-layer residual network amplifies a perturbation instead, so the bound is met
+only by an implementation whose arithmetic *is* the reference's. Measured on one
+batch of dumped activations, one card:
+
+| impl | passed | failing | logits rel_l2 | logits cosine |
+|---|---|---|---|---|
+| `ops` (torch) | yes | 0/119 | — | — |
+| `mega` (this directory's shipped kernel) | **no** | 34/119 | 9.65e-2 | 0.99551 |
+| `cuda` (handwritten) | no | 31/119 | 8.59e-2 | 0.99723 |
+
+The shipped kernel fails its own directory's check, and by more than the
+handwritten one does. Reading that as "the handwritten kernel is broken" is the
+mistake the table exists to prevent. What decides a kernel here is agreement with
+the incumbent plus greedy-token identity, which is what `README.md:11` reports.
+
+### TF-10 `check_all.py` had drifted off the CLI
+
+`--ckpt DIR`, `--inputs real` and repeated `--input FILE` are three arguments
+`tilefoundry check` no longer takes; the help text also pointed at a
+`dump_acts.py` that did not exist. The script could not run at all. Fixed here,
+and `dump_acts.py` written, because `--inputs random` draws states that no step
+could have produced and `check` says so itself.
+
 ## II. TileLang (the backend)
 
 In the order they were hit. All timings on an H200 with the SM clock at 1500 MHz.

--- a/examples/nemotron_3_5_lightning_30b_a3b-tilelang/ISSUES.md
+++ b/examples/nemotron_3_5_lightning_30b_a3b-tilelang/ISSUES.md
@@ -365,6 +365,30 @@ relaxed.
 
 ---
 
+## II-b. Do the TileLang problems survive a handwritten kernel?
+
+`NEMO_IMPL=cuda` reimplements the same step in CUDA, so each entry above can be
+answered rather than guessed at.
+
+| | what it was | under handwritten CUDA |
+|---|---|---|
+| TL-1 | descriptor TMA cannot take a device-only pointer | **gone.** `ops::tma_bulk_copy` is the rank-1 form, which takes an address, not a descriptor. |
+| TL-2 | `T.gemm` layout inference reaches through `T.view` | **gone.** No layout inference: a gemv is a loop over rows this code writes. |
+| TL-3 | a linear layout makes gemm 6x slower | **not applicable.** These are matrix-vector products; there is no tensor-core operand layout to get wrong. |
+| TL-4 | the shared allocator does not reuse disjoint lifetimes | **still there, differently.** One kernel calls every stage, so the compiler holds every stage's static shared array at once and the arena is sized to the widest. Writing past it was a real fault here, caught by compute-sanitizer. |
+| TL-5 | several things at M=16 | **gone.** No MMA instruction is issued. |
+| TL-6 | `ThreadSync` hoists `__syncthreads()` out of an `if` | **gone**, and its opposite arrived: a barrier this code does *not* write is not inserted for it. A missing one in `s_moe_down` corrupted the expert accumulator, which six separate launches had hidden. |
+| TL-7 | the instruction `T.copy` picks by default is worse than `cp_async` | **gone.** The instruction is written out. What replaces the problem is that the right choice is not uniform: staging wins for the Mamba projections and loses for the MoE experts, measured both ways in `kernels/nemotron.cu`. |
+| TL-8 | the eager builder rejects a Python-level loop over a tuple | **gone.** The 52 layers are a `for` in CUDA C, so `gen_kernel.py`'s reason for existing does not apply to the CUDA path. |
+
+The trade is not free: TL-4 and TL-6 come back as the author's problem instead of
+the backend's, and three of the four faults found while bringing the persistent
+grid up were of exactly that kind. A fourth is still open -- the fused path
+drifts from the stage-per-launch path across steps (1.3e-4 at three steps,
+3.6e-2 at thirty-six) and loses token identity at step 35, while the staged path
+holds 64 of 64. Same device code, so the difference is in what one resident
+launch does between layers that separate launches do not.
+
 ## III. One piece of good news
 
 `T.copy` (descriptorless, through cp.async) is **as fast as bulk TMA** on this

--- a/examples/nemotron_3_5_lightning_30b_a3b-tilelang/ISSUES.md
+++ b/examples/nemotron_3_5_lightning_30b_a3b-tilelang/ISSUES.md
@@ -383,11 +383,13 @@ answered rather than guessed at.
 
 The trade is not free: TL-4 and TL-6 come back as the author's problem instead of
 the backend's, and three of the four faults found while bringing the persistent
-grid up were of exactly that kind. A fourth is still open -- the fused path
-drifts from the stage-per-launch path across steps (1.3e-4 at three steps,
-3.6e-2 at thirty-six) and loses token identity at step 35, while the staged path
-holds 64 of 64. Same device code, so the difference is in what one resident
-launch does between layers that separate launches do not.
+grid up were of exactly that kind.
+
+One thing the handwritten kernels do **not** do worse: greedy token identity.
+Measured 48 steps, teacher-forced, three prompts, all three implementations lose
+it on one prompt each and hold it on another, and on `In 1969 the first humans`
+all three diverge at the same step and pick the same token as each other. The
+table is in `reports/WHY_SLOWER.md`.
 
 ## III. One piece of good news
 

--- a/examples/nemotron_3_5_lightning_30b_a3b-tilelang/README.md
+++ b/examples/nemotron_3_5_lightning_30b_a3b-tilelang/README.md
@@ -21,18 +21,21 @@ CUDA calling the public `tilefoundry::ops` entries, one cooperative launch over
 all 52 layers. A third, `NEMO_IMPL=cuda-stages`, runs the same device code a
 stage per launch, which is what bisects a disagreement to a layer.
 
-Where they stand against `transformers`, greedy and teacher-forced:
+**Token identity is prompt-specific, for every implementation.** Greedy and
+teacher-forced, 48 steps, three prompts, all three implementations:
 
-```
-NEMO_IMPL=cuda-stages    64 of 64 identical
-NEMO_IMPL=cuda           34 of 64 identical, first divergence at step 35
-```
+| prompt | `mega` | `cuda` | `cuda-stages` |
+|---|---|---|---|
+| `The capital of France is` | 48/48 | step 35 | step 35 |
+| `In 1969 the first humans` | step 3 | step 3 | step 3 |
+| `A prime number is` | step 42 | 48/48 | step 42 |
 
-The two CUDA paths run the same arithmetic, so the fused one carries a small
-systematic difference the staged one does not: measured against `cuda-stages` it
-is 1.3e-4 after three steps and 3.6e-2 after thirty-six, which is inside the
-envelope `check_all.py` derives and outside what token identity tolerates. It is
-not diagnosed yet.
+On the middle prompt all three diverge at the same step and pick the same token
+as each other (24556 against the reference's 33290), which is a tie the
+reference resolves one way and every implementation here resolves the other. The
+"64 of 64" in the block above is the first prompt with the TileLang kernel; it is
+not a property any of these three has in general. Nothing distinguishes the
+handwritten paths from the shipped one on this criterion.
 
 ```
                         ctx 32, one H200, one session

--- a/examples/nemotron_3_5_lightning_30b_a3b-tilelang/README.md
+++ b/examples/nemotron_3_5_lightning_30b_a3b-tilelang/README.md
@@ -40,10 +40,10 @@ handwritten paths from the shipped one on this criterion.
 ```
                         ctx 32, one H200, one session
 TileLang  NEMO_IMPL=mega     335.9 tok/s     2.977 ms/token
-CUDA      NEMO_IMPL=cuda     182.0 tok/s     5.495 ms/token
+CUDA      NEMO_IMPL=cuda     153.6 tok/s     6.510 ms/token
 ```
 
-**The CUDA one is 1.85x off and is not the default for that reason.** The gap is
+**The CUDA one is 2.19x off and is not the default for that reason.** The gap is
 taken apart layer by layer in `reports/WHY_SLOWER.md`, which also explains why
 the numbers there are not the ones in the block above: re-measured today, the
 TileLang kernel is 16-17% faster than this file records, so the recorded figures

--- a/examples/nemotron_3_5_lightning_30b_a3b-tilelang/README.md
+++ b/examples/nemotron_3_5_lightning_30b_a3b-tilelang/README.md
@@ -15,6 +15,37 @@ out, and the whole step is a single device launch.
 2.37x - 2.44x off the measured bandwidth floor, flat across nine context lengths
 ```
 
+There are now two implementations of that one launch. `NEMO_IMPL=mega` is the
+TileLang kernel above and stays the default; `NEMO_IMPL=cuda` is handwritten
+CUDA calling the public `tilefoundry::ops` entries, one cooperative launch over
+all 52 layers. A third, `NEMO_IMPL=cuda-stages`, runs the same device code a
+stage per launch, which is what bisects a disagreement to a layer.
+
+Where they stand against `transformers`, greedy and teacher-forced:
+
+```
+NEMO_IMPL=cuda-stages    64 of 64 identical
+NEMO_IMPL=cuda           34 of 64 identical, first divergence at step 35
+```
+
+The two CUDA paths run the same arithmetic, so the fused one carries a small
+systematic difference the staged one does not: measured against `cuda-stages` it
+is 1.3e-4 after three steps and 3.6e-2 after thirty-six, which is inside the
+envelope `check_all.py` derives and outside what token identity tolerates. It is
+not diagnosed yet.
+
+```
+                        ctx 32, one H200, one session
+TileLang  NEMO_IMPL=mega     335.9 tok/s     2.977 ms/token
+CUDA      NEMO_IMPL=cuda     182.0 tok/s     5.495 ms/token
+```
+
+**The CUDA one is 1.85x off and is not the default for that reason.** The gap is
+taken apart layer by layer in `reports/WHY_SLOWER.md`, which also explains why
+the numbers there are not the ones in the block above: re-measured today, the
+TileLang kernel is 16-17% faster than this file records, so the recorded figures
+are not a bar anything can be held to.
+
 **It does not beat SGLang.** It is 97.5% of it at short context and 83.2% at
 262080, and the gap is accounted for in §6. What is new here is the shape, not
 the speed: the authored HIR *is* the mega program, so `check` compares the thing

--- a/examples/nemotron_3_5_lightning_30b_a3b-tilelang/bench_mine.py
+++ b/examples/nemotron_3_5_lightning_30b_a3b-tilelang/bench_mine.py
@@ -35,7 +35,8 @@ def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--prepared", default=None, help="or $NEMOTRON35_PREPARED")
     ap.add_argument("--device", default="cuda:0")
-    ap.add_argument("--impl", default="mega", choices=["mega", "ops"])
+    ap.add_argument("--impl", default="mega",
+                    choices=["mega", "ops", "cuda", "cuda-stages"])
     ap.add_argument("--steps", type=int, default=256, help="timed steps per point")
     ap.add_argument("--warmup", type=int, default=32)
     ap.add_argument("--points", default=",".join(str(p) for p in POINTS))

--- a/examples/nemotron_3_5_lightning_30b_a3b-tilelang/check_all.py
+++ b/examples/nemotron_3_5_lightning_30b_a3b-tilelang/check_all.py
@@ -96,8 +96,12 @@ def main() -> int:
     if a.dry:
         print(" ".join(cmd))
         return 0
-    return subprocess.call([sys.executable.replace("python", "tilefoundry")] + cmd[1:]
-                           if False else cmd)
+    # The `tilefoundry` beside this interpreter, not whichever one PATH finds:
+    # a run made with one environment's python must not check with another's.
+    script = pathlib.Path(sys.executable).with_name("tilefoundry")
+    if script.exists():
+        cmd[0] = str(script)
+    return subprocess.call(cmd)
 
 
 if __name__ == "__main__":

--- a/examples/nemotron_3_5_lightning_30b_a3b-tilelang/check_all.py
+++ b/examples/nemotron_3_5_lightning_30b_a3b-tilelang/check_all.py
@@ -60,24 +60,31 @@ def outputs():
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--ckpt", default=None,
-                    help="what `tilefoundry check --ckpt` wants is the "
-                         "**prepared** directory (or $NEMOTRON35_PREPARED)")
+                    help="what `tilefoundry check --weights ckpt:DIR` wants is "
+                         "the **prepared** directory (or $NEMOTRON35_PREPARED)")
     ap.add_argument("--source", default="runtime_model.py:Nemotron35Lightning30BA3BRuntime.decode_step")
     ap.add_argument("--ctx-full", default="0")
     ap.add_argument("--ctx-tail", default="1")
     ap.add_argument("--json", default="reports/check.json")
     ap.add_argument("--acts", default=None,
-                    help="a directory of real activation files from dump_acts.py")
+                    help="a directory of activation files from dump_acts.py. "
+                         "Without it the run draws activations independently, "
+                         "which `tilefoundry check` warns is not decisive for a "
+                         "model whose states are what earlier steps left behind")
     ap.add_argument("--dry", action="store_true")
     a = ap.parse_args()
 
-    cmd = ["tilefoundry", "check", a.source, "--ckpt", str(paths.need("prepared", a.ckpt)),
+    cmd = ["tilefoundry", "check", a.source,
+           "--weights", f"ckpt:{paths.need('prepared', a.ckpt)}",
            "--dim", f"ctx_full={a.ctx_full}", "--dim", f"ctx_tail={a.ctx_tail}",
            "--json", a.json]
-    cmd += [] if a.acts else ["--inputs", "real"]
     if a.acts:
-        for f in sorted(pathlib.Path(a.acts).glob("*.pt")):
-            cmd += ["--input", str(f)]
+        files = sorted(pathlib.Path(a.acts).glob("*.pt"))
+        if not files:
+            raise SystemExit(f"no *.pt under {a.acts}; run dump_acts.py first")
+        cmd += ["--inputs", "files:" + ",".join(str(f) for f in files)]
+    else:
+        cmd += ["--inputs", "random"]
     for at, (name, kind, k) in enumerate(outputs()):
         bound = _ULP * math.sqrt(max(k, 1))
         cmd += ["--out", f"output[{at}]", "--fn", "nan_inf"]

--- a/examples/nemotron_3_5_lightning_30b_a3b-tilelang/check_layer.py
+++ b/examples/nemotron_3_5_lightning_30b_a3b-tilelang/check_layer.py
@@ -78,11 +78,72 @@ def rel_l2(a, b):
     return (a - b).norm().item() / (denom if denom else 1.0)
 
 
+def _real(a) -> int:
+    """One layer of the checkpoint, on a hidden row a real step produced.
+
+    A synthetic draw does not reproduce the checkpoint's weight distribution or
+    the magnitude the residual stream reaches by the middle of the model, and a
+    stage whose error only shows up there is invisible without this.
+    """
+    import pathlib as _pl  # noqa: PLC0415
+
+    import paths  # noqa: PLC0415
+    import runtime_model as R  # noqa: PLC0415
+    from tilefoundry.runtime import SafetensorsResource  # noqa: PLC0415
+
+    dev = "cuda:0"
+    twin = R.Nemotron35Lightning30BA3BRuntime()
+    R.set_impl("ops")
+    twin.load(SafetensorsResource(str(paths.need("prepared", a.prepared)), device=dev))
+
+    params = model.Nemotron35Lightning30BA3B.entry_function().params
+    files = sorted(_pl.Path(a.acts).glob("*.pt"))
+    if not files:
+        raise SystemExit(f"no *.pt under {a.acts}; run dump_acts.py first")
+    acts, j = {}, 0
+    for p in params:
+        if p.is_const:
+            continue
+        acts[p.name] = torch.load(files[j], map_location=dev)
+        j += 1
+    acts["cur_pos"] = int(acts["cur_pos"][0])
+
+    layer = a.layer
+    if layer is None:
+        layer = model.LAYER_KINDS.index("linear_attention")
+    if model.LAYER_KINDS[layer] != "linear_attention":
+        raise SystemExit(f"layer {layer} is {model.LAYER_KINDS[layer]}, not Mamba-2")
+
+    h = R._ops_step(twin._bound, acts, stop=layer).reshape(1, 1, H).to(BF16)
+    w = twin._bound
+    args = (h.reshape(H), w[f"l{layer}_gamma"].reshape(H),
+            w[f"l{layer}_w_in"].reshape(PROJ, H), w[f"l{layer}_w_out"].reshape(H, MI),
+            w[f"l{layer}_conv_w"].reshape(CONV, KER), w[f"l{layer}_conv_b"].reshape(CONV),
+            w[f"l{layer}_gamma_gdn"].reshape(MI),
+            torch.stack([w[f"l{layer}_a_log"].reshape(MH),
+                         w[f"l{layer}_dt_bias"].reshape(MH),
+                         w[f"l{layer}_d_skip"].reshape(MH)]),
+            acts[f"l{layer}_conv_state"].reshape(CONV, WIN),
+            acts[f"l{layer}_ssm_state"].reshape(MH, MD, SS).float())
+    print(f"layer {layer}  |h| = {h.float().norm().item():.4e}")
+    return _compare(a, *args)
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--seed", type=int, default=0)
     ap.add_argument("--tol-scale", type=float, default=1.0)
+    ap.add_argument("--real", action="store_true",
+                    help="use the checkpoint's weights and a real hidden row, "
+                         "not a synthetic draw")
+    ap.add_argument("--layer", type=int, default=None,
+                    help="with --real: which Mamba layer (default: the first)")
+    ap.add_argument("--acts", default="acts")
+    ap.add_argument("--prepared", default=None)
     a = ap.parse_args()
+
+    if a.real:
+        return _real(a)
 
     torch.manual_seed(a.seed)
     dev = "cuda"
@@ -115,6 +176,13 @@ def main() -> int:
     d_skip = torch.randn(MH, device=dev) * 0.5 + 1.0
     mscal = torch.stack([a_log.to(BF16), dt_bias.to(BF16), d_skip.to(BF16)])
 
+    return _compare(a, h, gamma, w_in, w_out, conv_w, conv_b, ggdn, mscal,
+                    conv_state, ssm_state)
+
+
+def _compare(a, h, gamma, w_in, w_out, conv_w, conv_b, ggdn, mscal,
+             conv_state, ssm_state) -> int:
+    """Run both sides over one layer's inputs and report every stage."""
     ref = reference(h, gamma, w_in, w_out, conv_w, conv_b, ggdn, mscal,
                     conv_state, ssm_state)
 

--- a/examples/nemotron_3_5_lightning_30b_a3b-tilelang/check_layer.py
+++ b/examples/nemotron_3_5_lightning_30b_a3b-tilelang/check_layer.py
@@ -139,6 +139,8 @@ def main() -> int:
     ap.add_argument("--layer", type=int, default=None,
                     help="with --real: which Mamba layer (default: the first)")
     ap.add_argument("--acts", default="acts")
+    ap.add_argument("--bench", type=int, default=0,
+                    help="also time the layer over this many iterations")
     ap.add_argument("--prepared", default=None)
     a = ap.parse_args()
 
@@ -214,8 +216,33 @@ def _compare(a, h, gamma, w_in, w_out, conv_w, conv_b, ggdn, mscal,
         bad += not ok
         note = "ok" if ok else ("FAIL (reference is degenerate)" if not alive else "FAIL")
         print(f"{name:10} {r:12.3e}  {bound:10.3e}  {live:10.3e}   {note}")
+    if a.bench:
+        _bench(a.bench, ops(), mine, got, h, gamma, w_in, w_out, conv_w, conv_b,
+               ggdn, mscal, conv_state, ssm_state)
     print("PASS" if not bad else f"{bad} stage(s) FAILED")
     return 1 if bad else 0
+
+
+def _bench(iters, ext, mine, got, h, gamma, w_in, w_out, conv_w, conv_b, ggdn,
+           mscal, conv_state, ssm_state) -> None:
+    """Time one layer, warmed, on the stream the launches actually use."""
+    import time  # noqa: PLC0415
+
+    call = lambda: ext.mamba_layer(  # noqa: E731
+        h.reshape(H), gamma.reshape(H), w_in.reshape(-1), w_out.reshape(-1),
+        conv_w.reshape(-1), conv_b.reshape(CONV), ggdn.reshape(MI),
+        mscal.reshape(-1), conv_state.reshape(-1), ssm_state.reshape(-1))
+    for _ in range(max(8, iters // 8)):
+        call()
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    for _ in range(iters):
+        call()
+    torch.cuda.synchronize()
+    us = (time.perf_counter() - t0) / iters * 1e6
+    # 23 of the 52 layers are this one, so the step-level cost it implies is
+    # what a whole-step number has to be read against.
+    print(f"\nmamba layer: {us:8.1f} us/layer   x23 = {us * 23 / 1e3:6.3f} ms/step")
 
 
 if __name__ == "__main__":

--- a/examples/nemotron_3_5_lightning_30b_a3b-tilelang/check_layer.py
+++ b/examples/nemotron_3_5_lightning_30b_a3b-tilelang/check_layer.py
@@ -1,0 +1,154 @@
+"""Compare the handwritten Mamba-2 layer against the op-by-op reference, stage by stage.
+
+`check_all.py` has one setting -- the whole step, 59 outputs -- and the mega
+kernel has no per-layer entry, so neither can say which stage of a layer went
+wrong. This runs the layer's five stages against the same torch expressions
+`runtime_model._ops_step` uses and reports each one, so a disagreement names its
+own stage instead of arriving as a wrong hidden row.
+
+    python check_layer.py [--seed N] [--tol-scale F]
+"""
+from __future__ import annotations
+
+import argparse
+
+import torch
+import torch.nn.functional as F
+
+import model
+
+H, MH, MD, SS, NG, MI, CONV, KER, WIN, PROJ, GRP, HPG = (
+    model.H, model.MH, model.MD, model.SS, model.NG, model.MI, model.CONV,
+    model.KER, model.WIN, model.PROJ, model.GRP, model.HPG)
+EPS, DTMIN = model.EPS, model.DTMIN
+BF16 = torch.bfloat16
+
+#: One bf16 round-to-nearest is at most 2^-9 relative; a stage k roundings deep
+#: is bounded by the random-walk sum, which is what `check_all.py` argues too.
+ULP = 2.0 ** -9
+
+
+def reference(h, gamma, w_in, w_out, conv_w, conv_b, ggdn, mscal, conv_state, ssm_state):
+    """The Mamba-2 branch of `runtime_model._ops_step`, operation for operation."""
+    a_log, dt_bias, d_skip = mscal[0], mscal[1], mscal[2]
+    hh = h.reshape(1, 1, H)
+    xf = hh.float()
+    nz = (xf * torch.rsqrt(xf.pow(2).mean(-1, keepdim=True) + EPS)).to(BF16)
+    h2 = (nz * gamma.reshape(1, 1, -1)).reshape(1, H)
+
+    gate = h2 @ w_in[0:MI].t()
+    col0 = h2 @ w_in[MI:MI + CONV].t()
+    dt = h2 @ w_in[MI + CONV:PROJ].t()
+    proj = torch.cat([gate.reshape(-1), col0.reshape(-1), dt.reshape(-1)])
+
+    win = torch.cat([conv_state.reshape(1, CONV, WIN), col0.reshape(1, CONV, 1)], dim=2)
+    conv_out = win[:, :, 1:KER].contiguous()
+    cs = (win * conv_w.reshape(1, CONV, KER)).sum(-1)
+    xbc = F.silu(cs + conv_b.reshape(1, CONV))
+
+    x = xbc[:, 0:MI].reshape(1, MH, MD)
+    bg = xbc[:, MI:MI + NG * SS].reshape(1, NG, SS)
+    cg = xbc[:, MI + NG * SS:CONV].reshape(1, NG, SS)
+    b = bg.repeat_interleave(HPG, dim=1).reshape(1, MH, 1, SS)
+    c = cg.repeat_interleave(HPG, dim=1).reshape(1, MH, SS, 1)
+    dta = F.softplus(dt.reshape(1, MH, 1) + dt_bias.reshape(1, MH, 1)).clamp(min=DTMIN)
+    dte = dta.reshape(1, MH, 1, 1)
+    an = (-torch.exp(a_log.float())).reshape(1, MH, 1, 1)
+    da = torch.exp(dte.float() * an)
+    dbx = ((dte * b) * x.reshape(1, MH, MD, 1)).float()
+    ssm_out = ssm_state.reshape(1, MH, MD, SS) * da + dbx
+    y = torch.matmul(ssm_out.to(BF16), c.to(BF16)).reshape(1, MH, MD)
+
+    yd = y + x * d_skip.reshape(1, MH, 1)
+    yf = yd.reshape(1, MI).float() * F.silu(gate.float())
+    yg = yf.reshape(1, NG, GRP)
+    yn = (yg * torch.rsqrt(yg.pow(2).mean(-1, keepdim=True) + EPS)).reshape(1, MI)
+    scan = ggdn.reshape(1, MI) * yn.to(BF16)
+    mix = (scan @ w_out.t()).reshape(1, 1, H)
+    return {
+        "proj": proj, "xbc": xbc.reshape(-1), "y": y.reshape(-1),
+        "scan": scan.reshape(-1), "h_out": (hh + mix).reshape(-1),
+        "conv_out": conv_out.reshape(-1), "ssm_out": ssm_out.reshape(-1),
+    }
+
+
+def rel_l2(a, b):
+    a, b = a.float(), b.float()
+    denom = b.norm().item()
+    return (a - b).norm().item() / (denom if denom else 1.0)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--seed", type=int, default=0)
+    ap.add_argument("--tol-scale", type=float, default=1.0)
+    a = ap.parse_args()
+
+    torch.manual_seed(a.seed)
+    dev = "cuda"
+
+    def rb(*shape, scale=1.0):
+        return (torch.randn(*shape, device=dev) * scale).to(BF16)
+
+    #: Weight magnitudes near the checkpoint's, so the bf16 error the bounds
+    #: below argue about is the error the real thing makes.
+    h = rb(H, scale=0.5)
+    gamma = rb(H, scale=1.0)
+    w_in = rb(PROJ, H, scale=0.02)
+    w_out = rb(H, MI, scale=0.02)
+    conv_w = rb(CONV, KER, scale=0.3)
+    conv_b = rb(CONV, scale=0.1)
+    ggdn = rb(MI, scale=1.0)
+    conv_state = rb(CONV, WIN, scale=0.5)
+    ssm_state = torch.randn(MH, MD, SS, device=dev) * 0.3
+
+    #: The three scales are drawn the way Mamba-2 initialises them, not from a
+    #: unit normal. `a_log` is the log of a state decay in [1, 16] and `dt_bias`
+    #: is the inverse-softplus of a step in [0.001, 0.1], so both land where the
+    #: exponentials are worked hardest. A unit-normal draw keeps every argument
+    #: near zero, where an approximate `expf` agrees with an accurate one and a
+    #: precision fault this test exists to catch does not show up at all.
+    decay = torch.rand(MH, device=dev) * (16.0 - 1.0) + 1.0
+    a_log = torch.log(decay)
+    step = torch.rand(MH, device=dev) * (0.1 - 0.001) + 0.001
+    dt_bias = step + torch.log(-torch.expm1(-step))
+    d_skip = torch.randn(MH, device=dev) * 0.5 + 1.0
+    mscal = torch.stack([a_log.to(BF16), dt_bias.to(BF16), d_skip.to(BF16)])
+
+    ref = reference(h, gamma, w_in, w_out, conv_w, conv_b, ggdn, mscal,
+                    conv_state, ssm_state)
+
+    from kernels import ops  # noqa: PLC0415
+    got = ops().mamba_layer(h, gamma, w_in.reshape(-1), w_out.reshape(-1),
+                            conv_w.reshape(-1), conv_b, ggdn, mscal.reshape(-1),
+                            conv_state.reshape(-1), ssm_state.reshape(-1))
+    names = ["h_out", "conv_out", "ssm_out", "proj", "xbc", "y", "scan"]
+    mine = dict(zip(names, got))
+
+    #: bf16 landings on the way to each stage, counted off the reference above.
+    landings = {"proj": 3, "xbc": 5, "conv_out": 3, "y": 9, "ssm_out": 8,
+                "scan": 12, "h_out": 14}
+    order = ["proj", "conv_out", "xbc", "ssm_out", "y", "scan", "h_out"]
+
+    print(f"{'stage':10} {'rel_l2':>12}  {'bound':>10}  {'|ref|':>10}   verdict")
+    bad = 0
+    for name in order:
+        k = landings[name]
+        bound = ULP * (k ** 0.5) * a.tol_scale
+        r = rel_l2(mine[name].reshape(-1), ref[name].reshape(-1))
+        got_t = mine[name].reshape(-1).float()
+        ref_t = ref[name].reshape(-1).float()
+        # A stage whose reference is all zeros would pass any bound, so the
+        # magnitude is a criterion too: this reports what it compared.
+        live = ref_t.abs().mean().item()
+        alive = live > 1e-6 and (ref_t != 0).float().mean().item() > 0.5
+        ok = r <= bound and torch.isfinite(got_t).all().item() and alive
+        bad += not ok
+        note = "ok" if ok else ("FAIL (reference is degenerate)" if not alive else "FAIL")
+        print(f"{name:10} {r:12.3e}  {bound:10.3e}  {live:10.3e}   {note}")
+    print("PASS" if not bad else f"{bad} stage(s) FAILED")
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/nemotron_3_5_lightning_30b_a3b-tilelang/check_moe.py
+++ b/examples/nemotron_3_5_lightning_30b_a3b-tilelang/check_moe.py
@@ -1,0 +1,140 @@
+"""Compare the handwritten MoE layer against the op-by-op reference, stage by stage.
+
+Same idea as `check_layer.py` for Mamba-2: the whole-step check cannot say which
+part of a layer disagrees, so this runs the router, the six routed experts and
+the shared one against the torch expressions `runtime_model._ops_step` uses.
+
+    python check_moe.py --layer 1 [--bench 200]
+"""
+from __future__ import annotations
+
+import argparse
+import pathlib
+
+import torch
+import torch.nn.functional as F
+
+import model
+import paths
+
+H, E, K, I, IS, EPS, RSCALE = (model.H, model.E, model.K, model.I, model.IS,
+                               model.EPS, model.RSCALE)
+BF16 = torch.bfloat16
+ULP = 2.0 ** -9
+
+
+def reference(h, gamma, w_router, e_bias, w_up, w_down, w_sh_up, w_sh_down):
+    """The MoE branch of `runtime_model._ops_step`, operation for operation."""
+    hh = h.reshape(1, 1, H)
+    xf = hh.float()
+    nz = (xf * torch.rsqrt(xf.pow(2).mean(-1, keepdim=True) + EPS)).to(BF16)
+    h2 = (nz * gamma.reshape(1, 1, -1)).reshape(1, H)
+
+    lg = h2.float() @ w_router.float().t()
+    sig = torch.sigmoid(lg)
+    ch = sig + e_bias.reshape(1, E)
+    _tv, ti = torch.topk(ch, K, dim=-1, sorted=False)
+    flat = ti.reshape(K)
+    pick = sig.reshape(E)[flat].reshape(1, K)
+    gw = (pick / (pick.sum(-1, keepdim=True) + 1e-20)) * RSCALE
+
+    total = None
+    for j, e in enumerate(flat.tolist()):
+        mid = torch.square(torch.relu(h2 @ w_up[e].t()))
+        r = (mid @ w_down[e].t()).reshape(H).float() * gw[0, j]
+        total = r if total is None else total + r
+    smid = torch.square(torch.relu(h2 @ w_sh_up.t()))
+    sh = (smid @ w_sh_down.t()).reshape(H)
+    mix = (total.to(BF16) + sh).reshape(1, 1, H)
+    return {"h2": h2.reshape(-1), "idx": flat, "gw": gw.reshape(-1),
+            "acc": total, "smid": smid.reshape(-1), "h_out": (hh + mix).reshape(-1)}
+
+
+def rel_l2(a, b):
+    a, b = a.reshape(-1).float(), b.reshape(-1).float()
+    d = b.norm().item()
+    return (a - b).norm().item() / (d if d else 1.0)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--prepared", default=None)
+    ap.add_argument("--acts", default="acts")
+    ap.add_argument("--layer", type=int, default=None)
+    ap.add_argument("--bench", type=int, default=0)
+    a = ap.parse_args()
+
+    import runtime_model as R  # noqa: PLC0415
+    from tilefoundry.runtime import SafetensorsResource  # noqa: PLC0415
+
+    dev = "cuda:0"
+    twin = R.Nemotron35Lightning30BA3BRuntime()
+    R.set_impl("ops")
+    twin.load(SafetensorsResource(str(paths.need("prepared", a.prepared)), device=dev))
+
+    params = model.Nemotron35Lightning30BA3B.entry_function().params
+    files = sorted(pathlib.Path(a.acts).glob("*.pt"))
+    acts, j = {}, 0
+    for p in params:
+        if p.is_const:
+            continue
+        acts[p.name] = torch.load(files[j], map_location=dev)
+        j += 1
+    acts["cur_pos"] = int(acts["cur_pos"][0])
+
+    layer = a.layer if a.layer is not None else model.LAYER_KINDS.index("moe")
+    if model.LAYER_KINDS[layer] != "moe":
+        raise SystemExit(f"layer {layer} is {model.LAYER_KINDS[layer]}, not MoE")
+
+    h = R._ops_step(twin._bound, acts, stop=layer).reshape(1, 1, H).to(BF16)
+    w = twin._bound
+    args = (h.reshape(H), w[f"l{layer}_gamma"].reshape(H),
+            w[f"l{layer}_w_router"].reshape(E, H),
+            w[f"l{layer}_e_bias"].reshape(E).float(),
+            w[f"l{layer}_w_up"].reshape(E, I, H),
+            w[f"l{layer}_w_down"].reshape(E, H, I),
+            w[f"l{layer}_w_sh_up"].reshape(IS, H),
+            w[f"l{layer}_w_sh_down"].reshape(H, IS))
+    ref = reference(*args)
+
+    from kernels import ops  # noqa: PLC0415
+    ext = ops()
+    call = lambda: ext.moe_layer(  # noqa: E731
+        args[0], args[1], args[2].reshape(-1), args[3], args[4].reshape(-1),
+        args[5].reshape(-1), args[6].reshape(-1), args[7].reshape(-1))
+    got = call()
+    mine = dict(zip(["h_out", "idx", "gw", "h2", "mid", "smid", "acc"], got))
+
+    print(f"layer {layer}  |h| = {h.float().norm().item():.4e}")
+    same_set = set(mine["idx"].tolist()) == set(ref["idx"].tolist())
+    print(f"expert set: mine {sorted(mine['idx'].tolist())}  "
+          f"ref {sorted(ref['idx'].tolist())}   {'same' if same_set else 'DIFFER'}")
+
+    landings = {"h2": 2, "smid": 4, "acc": 5, "h_out": 12}
+    bad = 0 if same_set else 1
+    print(f"{'stage':8} {'rel_l2':>12}  {'bound':>10}  {'|ref|':>10}   verdict")
+    for name in ("h2", "smid", "acc", "h_out"):
+        bound = ULP * (landings[name] ** 0.5)
+        r = rel_l2(mine[name], ref[name])
+        live = ref[name].reshape(-1).float().abs().mean().item()
+        ok = r <= bound and live > 1e-8
+        bad += not ok
+        print(f"{name:8} {r:12.3e}  {bound:10.3e}  {live:10.3e}   {'ok' if ok else 'FAIL'}")
+
+    if a.bench:
+        import time  # noqa: PLC0415
+        for _ in range(max(8, a.bench // 8)):
+            call()
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        for _ in range(a.bench):
+            call()
+        torch.cuda.synchronize()
+        us = (time.perf_counter() - t0) / a.bench * 1e6
+        print(f"\nmoe layer: {us:8.1f} us/layer   x23 = {us * 23 / 1e3:6.3f} ms/step")
+    print("PASS" if not bad else f"{bad} check(s) FAILED")
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/nemotron_3_5_lightning_30b_a3b-tilelang/compare_impls.py
+++ b/examples/nemotron_3_5_lightning_30b_a3b-tilelang/compare_impls.py
@@ -1,0 +1,119 @@
+"""Run one decode step twice, on real weights, and compare the two implementations.
+
+`check_all.py` compares a twin against the authored semantics and needs the whole
+model evaluated to do it. This is the cheaper gate that comes first: load once,
+run two `NEMO_IMPL` settings over the same inputs and states, and report the
+logits and every state tensor.
+
+    python compare_impls.py --a ops --b cuda [--steps 3]
+"""
+from __future__ import annotations
+
+import argparse
+
+import torch
+
+import paths
+
+
+def _owners():
+    """One label per `fresh` tensor, in the order a step returns them."""
+    import model  # noqa: PLC0415
+
+    out = []
+    for i, kind in enumerate(model.LAYER_KINDS):
+        if kind == "linear_attention":
+            out += [f"L{i} mamba conv_out", f"L{i} mamba ssm_out"]
+        elif kind == "full_attention":
+            out += [f"L{i} attn k_new", f"L{i} attn v_new"]
+    return out
+
+
+_OWNER = None
+
+
+def _owner(n):
+    global _OWNER
+    if _OWNER is None:
+        _OWNER = _owners()
+    return _OWNER[n] if n < len(_OWNER) else f"#{n}"
+
+
+def rel_l2(a, b):
+    a, b = a.reshape(-1).float(), b.reshape(-1).float()
+    d = b.norm().item()
+    return (a - b).norm().item() / (d if d else 1.0)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--prepared", default=None)
+    ap.add_argument("--device", default="cuda:0")
+    ap.add_argument("--a", default="ops")
+    ap.add_argument("--b", default="cuda")
+    ap.add_argument("--steps", type=int, default=3)
+    ap.add_argument("--max-rel", type=float, default=None,
+                    help="default: the bound check_all.py derives for the logits")
+    a = ap.parse_args()
+
+    # No invented tolerance. The bound is the one `check_all.py` argues from
+    # how many times a value lands in bf16 on the way to the logits: one
+    # round-to-nearest is at most 2^-9 relative, and k of them sum as a random
+    # walk. Two implementations that round differently at every layer are
+    # allowed to differ by that much and no more.
+    if a.max_rel is None:
+        import math  # noqa: PLC0415
+
+        import check_all  # noqa: PLC0415
+        import model as _m  # noqa: PLC0415
+        k = sum(check_all._LANDINGS[kind] for kind in _m.LAYER_KINDS) + 3
+        a.max_rel = 2.0 ** -9 * math.sqrt(k)
+        print(f"bound 2^-9*sqrt({k}) = {a.max_rel:.3e}  (check_all.py's derivation)")
+
+    from tilefoundry.runtime import SafetensorsResource  # noqa: PLC0415
+    import runtime_model  # noqa: PLC0415
+
+    twin = runtime_model.Nemotron35Lightning30BA3BRuntime()
+    twin.load(SafetensorsResource(str(paths.need("prepared", a.prepared)), device=a.device))
+
+    def run(impl):
+        runtime_model.set_impl(impl)
+        caches = twin.init_caches(device=a.device, capacity=a.steps + 4)
+        ids = torch.full((a.steps + 4,), 1784, dtype=torch.int64, device=a.device)
+        outs = []
+        for step in range(a.steps):
+            args = twin.prepare_inputs_for_generation(ids[: step + 1], step, caches,
+                                                      device=a.device)
+            logits, fresh = twin.forward(*args)
+            caches = twin.append_cache(caches, fresh)
+            outs.append((logits.detach().clone(),
+                         [f.detach().clone() for f in fresh]))
+        return outs
+
+    ra, rb = run(a.a), run(a.b)
+    worst, bad = 0.0, 0
+    for step, ((la, fa), (lb, fb)) in enumerate(zip(ra, rb)):
+        r = rel_l2(lb, la)
+        worst = max(worst, r)
+        top_a = int(torch.argmax(la.reshape(-1)).item())
+        top_b = int(torch.argmax(lb.reshape(-1)).item())
+        same = "same" if top_a == top_b else f"DIFFER {top_a} vs {top_b}"
+        bad += top_a != top_b
+        print(f"step {step}  logits rel_l2 {r:.3e}   argmax {same}")
+        # Name which tensor is worst, and which layer produced it: a number
+        # with no owner says a step is wrong without saying where.
+        rows = [(rel_l2(y, x), n) for n, (x, y) in enumerate(zip(fa, fb))]
+        rows.sort(reverse=True)
+        fr = rows[0][0] if rows else 0.0
+        worst = max(worst, fr)
+        print(f"          worst state rel_l2 {fr:.3e}  over {len(fa)} tensors")
+        for r, n in rows[:3]:
+            print(f"            [{n:2d}] {_owner(n):28} {r:.3e}")
+    over = worst > a.max_rel
+    print(f"\nworst rel_l2 {worst:.3e}  (limit {a.max_rel:.1e})   "
+          f"{'FAIL' if over or bad else 'PASS'}")
+    return 1 if (over or bad) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/nemotron_3_5_lightning_30b_a3b-tilelang/dump_acts.py
+++ b/examples/nemotron_3_5_lightning_30b_a3b-tilelang/dump_acts.py
@@ -1,0 +1,70 @@
+"""Dump one step's activations, so `tilefoundry check` compares coherent states.
+
+`--inputs random` draws every activation independently, and this model's
+activations are not independent: a convolution window, an SSM matrix and a K/V
+cache are what previous steps left behind, and three unrelated draws put the
+model in a state it can never reach. `tilefoundry check` says so itself and asks
+for `--inputs files:...` when the answer has to be decisive.
+
+This advances the op-by-op path for a few steps and writes the resulting
+activations, one file per declared non-const parameter, in declared order.
+
+    python dump_acts.py --steps 4 --out acts/
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import torch
+
+import paths
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--prepared", default=None)
+    ap.add_argument("--device", default="cuda:0")
+    ap.add_argument("--steps", type=int, default=4, help="steps to advance before dumping")
+    ap.add_argument("--out", default="acts")
+    a = ap.parse_args()
+
+    from tilefoundry.runtime import SafetensorsResource  # noqa: PLC0415
+    import runtime_model  # noqa: PLC0415
+    from model import Nemotron35Lightning30BA3B as SEM  # noqa: PLC0415
+
+    runtime_model.set_impl("ops")
+    twin = runtime_model.Nemotron35Lightning30BA3BRuntime()
+    twin.load(SafetensorsResource(str(paths.need("prepared", a.prepared)), device=a.device))
+
+    cap = a.steps + 4
+    caches = twin.init_caches(device=a.device, capacity=cap)
+    ids = torch.full((cap,), 1784, dtype=torch.int64, device=a.device)
+    args = None
+    for step in range(a.steps):
+        args = twin.prepare_inputs_for_generation(ids[: step + 1], step, caches,
+                                                  device=a.device)
+        _, fresh = twin.forward(*args)
+        caches = twin.append_cache(caches, fresh)
+    args = twin.prepare_inputs_for_generation(ids[: a.steps + 1], a.steps, caches,
+                                              device=a.device)
+
+    out = Path(a.out)
+    out.mkdir(parents=True, exist_ok=True)
+    params = SEM.entry_function().params
+    written = []
+    for at, p in enumerate(params):
+        if p.is_const:
+            continue
+        # Zero-padded so a lexical sort is the declared order, and named so a
+        # file that lands in the wrong slot is visible rather than silent.
+        path = out / f"{len(written):03d}_{p.name}.pt"
+        torch.save(args[at].detach().cpu(), path)
+        written.append(path)
+    print(f"wrote {len(written)} activation files to {out}/ after {a.steps} steps")
+    print(",".join(str(p) for p in written))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/nemotron_3_5_lightning_30b_a3b-tilelang/gen_kernel.py
+++ b/examples/nemotron_3_5_lightning_30b_a3b-tilelang/gen_kernel.py
@@ -1184,83 +1184,24 @@ F_SH = F_MIX + (H + CTAS - 1) // CTAS + 1
 SUMSLOT = 4 * HQ
 MAXSLOT = 4 * HQ + 1
 
-PACK = {{
-    "win": (N_MAMBA, PROJ, H), "wout": (N_MAMBA, H, MI),
-    "convw": (N_MAMBA, CONV, KER), "convb": (N_MAMBA, CONV), "ggdn": (N_MAMBA, MI),
-    "wqkv": (N_ATTN, QP + 2 * KVP, H), "wo": (N_ATTN, H, QP),
-    "wrt": (N_MOE, E, H), "wup": (N_MOE, E, I, H), "wdn": (N_MOE, E, H, I),
-    "wsu": (N_MOE, IS, H), "wsd": (N_MOE, H, IS),
-    "gam": (NL, H), "table": (V, H), "whead": (V, H),
-    "mscal": (N_MAMBA, 3, MH), "gf": (H,),
-}}
-PACK_F32 = {{"eb": (N_MOE, E)}}
-PACK_ORDER = list(PACK) + list(PACK_F32)
-RING = 4
-
-
-def _numel(shape):
-    n = 1
-    for s in shape:
-        n *= s
-    return n
+#: The weight layout lives in `packing.py`, not here. It is a property of the
+#: model rather than of this backend, and the handwritten CUDA path reads the
+#: same one -- two copies could drift and a drifted layout is a silently wrong
+#: weight rather than an error.
+from packing import (  # noqa: E402
+    PACK,
+    PACK_F32,
+    PACK_ORDER,
+    RING,
+    Packed,
+    _numel,
+    pack_into,
+)
 
 
 def bf(x):
     """Round to bf16 and go on in f32, the way a bf16 op does."""
     return T.Cast("float32", T.Cast("bfloat16", x))
-
-
-class Packed:
-    """Every weight of one class in one flat tensor."""
-
-    def __init__(self, device):
-        self.shape = dict(PACK) | dict(PACK_F32)
-        self.t = {{n: torch.zeros(_numel(s), dtype=torch.bfloat16, device=device)
-                  for n, s in PACK.items()}}
-        self.t.update({{n: torch.zeros(_numel(s), dtype=torch.float32, device=device)
-                       for n, s in PACK_F32.items()}})
-
-    def view(self, name):
-        return self.t[name].view(self.shape[name])
-
-    def flat_order(self):
-        return [self.t[n] for n in PACK_ORDER]
-
-
-def pack_into(packed: Packed, name: str, value: torch.Tensor):
-    """Copy one declared weight into its slot; return the view standing for it."""
-    def put(key, *idx):
-        dst = packed.view(key)
-        for j in idx:
-            dst = dst[j]
-        dst.copy_(value.reshape(dst.shape).to(dst.dtype))
-        return dst
-
-    if name in ("table", "w_head"):
-        return put({{"table": "table", "w_head": "whead"}}[name])
-    if name == "gamma_final":
-        return put("gf")
-    layer = int(name.split("_")[0][1:])
-    kid, at = _LAYER_META[layer]
-    tail = name[name.index("_") + 1:]
-    if tail == "gamma":
-        return put("gam", layer)
-    if kid == 0:
-        simple = {{"w_in": "win", "w_out": "wout", "conv_w": "convw",
-                  "conv_b": "convb", "gamma_gdn": "ggdn"}}
-        if tail in simple:
-            return put(simple[tail], at)
-        return put("mscal", at, {{"a_log": 0, "dt_bias": 1, "d_skip": 2}}[tail])
-    if kid == 1:
-        if tail == "w_o":
-            return put("wo", at)
-        off = {{"w_q": 0, "w_k": QP, "w_v": QP + KVP}}[tail]
-        dst = packed.view("wqkv")[at, off:off + value.shape[0]]
-        dst.copy_(value)
-        return dst
-    simple = {{"w_router": "wrt", "w_up": "wup", "w_down": "wdn",
-              "w_sh_up": "wsu", "w_sh_down": "wsd", "e_bias": "eb"}}
-    return put(simple[tail], at)
 
 
 @tilelang.jit

--- a/examples/nemotron_3_5_lightning_30b_a3b-tilelang/kernels/__init__.py
+++ b/examples/nemotron_3_5_lightning_30b_a3b-tilelang/kernels/__init__.py
@@ -1,0 +1,61 @@
+"""Build ``nemotron.cu`` on first import and hand back the loaded extension.
+
+The build is cached under ``kernels/.build`` keyed by nvcc's own timestamp
+check, so a run after an edit recompiles and a run after nothing does not.
+
+Unlike ``granite_4_0_h_small-cuda``, this kernel does not carry its own
+primitives: it includes ``tilefoundry/runtime/cuda/runtime.cuh`` and calls the
+public ``tilefoundry::ops`` entries. That header is not a standalone translation
+unit -- it includes each ``ops/<op>.cuh`` in-context inside its own namespace --
+so the two include roots below are the repository's ``include/`` and the
+vendored CuTe, the same pair ``tilefoundry.codegen.linker`` puts on its nvcc
+line.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_BUILD = _HERE / ".build"
+_ROOT = _HERE.parents[2]
+
+#: sm_90a: the H200 is Hopper, and the `elect.sync`, `mbarrier.*` and
+#: `cp.async.bulk` instructions this kernel is made of are the `a` variants'.
+_ARCH = os.environ.get("NEMOTRON_CUDA_ARCH", "90a")
+
+_ext = None
+
+
+def ops():
+    """The compiled extension module, built on the first call."""
+    global _ext
+    if _ext is None:
+        from torch.utils.cpp_extension import load  # noqa: PLC0415
+
+        _BUILD.mkdir(exist_ok=True)
+        _ext = load(
+            name="nemotron_kernels",
+            sources=[str(_HERE / "nemotron.cu")],
+            build_directory=str(_BUILD),
+            extra_include_paths=[
+                str(_ROOT / "include"),
+                str(_ROOT / "third_party" / "cutlass" / "include"),
+            ],
+            extra_cuda_cflags=[
+                "-O3",
+                # No `--use_fast_math`: it swaps in the approximate
+                # transcendentals, and this kernel's exponentials are compared
+                # elementwise against torch's accurate ones.
+                "-lineinfo",
+                "-std=c++20",
+                f"-gencode=arch=compute_{_ARCH},code=sm_{_ARCH}",
+                "--expt-relaxed-constexpr",
+            ],
+            extra_cflags=["-O3", "-std=c++20"],
+            verbose=os.environ.get("NEMOTRON_BUILD_VERBOSE", "") == "1",
+        )
+    return _ext
+
+
+__all__ = ["ops"]

--- a/examples/nemotron_3_5_lightning_30b_a3b-tilelang/kernels/nemotron.cu
+++ b/examples/nemotron_3_5_lightning_30b_a3b-tilelang/kernels/nemotron.cu
@@ -1,0 +1,445 @@
+/// Nemotron-3.5-Lightning-30B-A3B decode, handwritten.
+///
+/// Every stage is a `__device__` function over gmem pointers plus a shared
+/// scratch. The `__global__` wrappers below launch one stage at a time, which
+/// is what makes a stage checkable on its own against the op-by-op path; a
+/// persistent cooperative grid calls the same functions with a grid barrier
+/// where a wrapper boundary is today.
+
+/// Primitives come from the runtime, not from this file:
+/// `tilefoundry::ops::{warp_reduce, shuffle_elect, mbarrier_*, tma_bulk_copy}`.
+/// The weight staging below is the shape the tilelang implementation uses --
+/// one elected lane issues a bulk copy of eight weight rows and arrives on that
+/// tile's mbarrier, consumers wait on the phase parity -- expressed through
+/// those entries instead of through inline PTX.
+#include <tilefoundry/runtime/cuda/runtime.cuh>
+
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAException.h>
+#include <cuda_bf16.h>
+#include <torch/extension.h>
+
+#include <set>
+#include <vector>
+
+namespace ops = tilefoundry::ops;
+
+namespace {
+
+constexpr int H = 2688;
+constexpr int MH = 64;
+constexpr int MD = 64;
+constexpr int SS = 128;
+constexpr int NG = 8;
+constexpr int MI = 4096;
+constexpr int CONV = 6144;
+constexpr int KER = 4;
+constexpr int WIN = 3;
+constexpr int PROJ = 10304;
+constexpr int GRP = 512;
+constexpr int HPG = 8;
+constexpr float EPS = 1e-5f;
+constexpr float DTMIN = 0.001f;
+
+constexpr int THREADS = 256;
+constexpr int WARPS = THREADS / 32;
+
+using bf16 = __nv_bfloat16;
+
+/// Round to bf16 and carry on in f32, which is what a bf16 op does.
+__device__ inline float bf(float x) {
+    return __bfloat162float(__float2bfloat16(x));
+}
+
+__device__ inline float ld(const bf16 *p) { return __bfloat162float(*p); }
+
+__device__ inline float silu_f(float x) { return x / (1.0f + expf(-x)); }
+
+/// ``F.softplus``: log1p(exp(x)), with the large-x branch the library takes so
+/// a big activation does not overflow the exponential.
+__device__ inline float softplus_f(float x) {
+    return x > 20.0f ? x : log1pf(expf(x));
+}
+
+/// Sum ``v`` across the whole CTA, leaving the total in every thread.
+///
+/// A warp fold through ``ops::warp_reduce`` and then one slot per warp in
+/// shared memory; the second fold is over eight values, so it costs less as a
+/// serial loop than as a second butterfly.
+__device__ inline float cta_sum(float v, float *slots) {
+    v = ops::warp_reduce<ops::warp_sum>(v);
+    const int lane = threadIdx.x & 31;
+    const int warp = threadIdx.x >> 5;
+    if (lane == 0) slots[warp] = v;
+    ops::sync<ops::SyncKind::syncthreads>();
+    float total = 0.0f;
+    for (int i = 0; i < WARPS; ++i) total += slots[i];
+    return total;
+}
+
+
+/// One weight tile: ``TILE_ROWS`` whole rows of an ``(out, in)`` matrix.
+///
+/// A CTA owns a run of output rows, so its slice is a contiguous byte run and
+/// the rank-1 bulk copy is the instruction that moves it. Eight rows is what
+/// makes the run a whole number of 16-byte grains for both widths this model
+/// uses, and it is one row per warp.
+constexpr int TILE_ROWS = WARPS;
+
+/// ``out[row] = dot(w[row], x)`` for a run of rows, streaming ``w`` through a
+/// shared ring.
+///
+/// The loads run ``STAGES`` tiles ahead, so the tile issued last is still in
+/// flight while this one is being folded. Every fold is a warp butterfly, and
+/// the accumulator is f32 with a bf16 landing on the way out -- what a bf16
+/// matmul does.
+template <int IN, int STAGES>
+__device__ void gemv_rows(const bf16 *__restrict__ w, const bf16 *__restrict__ x,
+                          bf16 *__restrict__ out, int tile0, int ntiles,
+                          bf16 *stage, uint64_t *bars,
+                          const bf16 *__restrict__ resid = nullptr) {
+    constexpr unsigned kBytes = unsigned(TILE_ROWS) * IN * sizeof(bf16);
+    constexpr int kTileElems = TILE_ROWS * IN;
+    const int warp = threadIdx.x >> 5;
+    const int lane = threadIdx.x & 31;
+
+    const bool elected = ops::shuffle_elect<THREADS>();
+    if (elected)
+        for (int s = 0; s < STAGES; ++s) ops::mbarrier_init(&bars[s], 1);
+    ops::sync<ops::SyncKind::syncthreads>();
+
+    for (int s = 0; s < STAGES && s < ntiles; ++s) {
+        if (elected) {
+            ops::mbarrier_arrive_expect_tx(&bars[s], kBytes);
+            ops::tma_bulk_copy(w + size_t(tile0 + s) * kTileElems,
+                               stage + s * kTileElems, kTileElems, &bars[s]);
+        }
+    }
+
+    for (int t = 0; t < ntiles; ++t) {
+        const int slot = t % STAGES;
+        ops::mbarrier_wait_parity(&bars[slot], unsigned(t / STAGES) & 1u);
+
+        const bf16 *row = stage + slot * kTileElems + warp * IN;
+        float acc = 0.0f;
+        for (int j = lane; j < IN; j += 32) acc += ld(row + j) * ld(x + j);
+        acc = ops::warp_reduce<ops::warp_sum>(acc);
+        if (lane == 0) {
+            const int row = (tile0 + t) * TILE_ROWS + warp;
+            // The product lands in bf16 before the residual adds to it, which
+            // is what `h + (scan @ w_out.t())` does one operation at a time.
+            out[row] = __float2bfloat16(resid ? ld(resid + row) + bf(acc) : acc);
+        }
+
+        ops::sync<ops::SyncKind::syncthreads>();
+        const int next = t + STAGES;
+        if (next < ntiles && elected) {
+            ops::mbarrier_arrive_expect_tx(&bars[slot], kBytes);
+            ops::tma_bulk_copy(w + size_t(tile0 + next) * kTileElems,
+                               stage + slot * kTileElems, kTileElems, &bars[slot]);
+        }
+    }
+    if (elected)
+        for (int s = 0; s < STAGES; ++s) ops::mbarrier_invalidate(&bars[s]);
+}
+
+/// The published ``NemotronHRMSNorm``, into shared memory.
+///
+/// The normalised value lands in bf16 **before** the weight multiplies it,
+/// which is one rounding more than doing the whole thing in f32 would be. It is
+/// what the checkpoint's own implementation does, so it is what this does.
+__device__ void rms_norm_to_smem(const bf16 *__restrict__ h,
+                                 const bf16 *__restrict__ gamma,
+                                 bf16 *__restrict__ dst, float *slots) {
+    float sq = 0.0f;
+    for (int i = threadIdx.x; i < H; i += THREADS) {
+        const float v = ld(h + i);
+        sq += v * v;
+    }
+    const float scale = rsqrtf(cta_sum(sq, slots) / float(H) + EPS);
+    for (int i = threadIdx.x; i < H; i += THREADS)
+        dst[i] = __float2bfloat16(bf(ld(h + i) * scale) * ld(gamma + i));
+}
+
+/// The depthwise convolution over one channel run, and the state it hands on.
+///
+/// The window a step hands on is two columns of the window it was handed,
+/// shifted, plus one fresh column from the input projection. Every rounding
+/// below is one the op-by-op reference makes: the products land in bf16, the
+/// fold over the four taps is f32, and the bias and the silu each land again.
+__device__ void mamba_conv_stage(const bf16 *__restrict__ col0,
+                                 const bf16 *__restrict__ conv_state,
+                                 const bf16 *__restrict__ conv_w,
+                                 const bf16 *__restrict__ conv_b,
+                                 bf16 *__restrict__ conv_out,
+                                 bf16 *__restrict__ xbc, int c0, int c1) {
+    for (int c = c0 + int(threadIdx.x); c < c1; c += THREADS) {
+        float win[KER];
+        for (int k = 0; k < WIN; ++k) win[k] = ld(conv_state + c * WIN + k);
+        win[WIN] = ld(col0 + c);
+        for (int k = 0; k < WIN; ++k)
+            conv_out[c * WIN + k] = __float2bfloat16(win[k + 1]);
+        float acc = 0.0f;
+        for (int k = 0; k < KER; ++k) acc += bf(win[k] * ld(conv_w + c * KER + k));
+        xbc[c] = __float2bfloat16(silu_f(bf(bf(acc) + ld(conv_b + c))));
+    }
+}
+
+/// One head's recurrence: advance the state and contract it against C.
+///
+/// ``head`` is passed rather than read from ``blockIdx`` so a persistent grid
+/// can call this for whichever head the CTA owns. Warp ``w`` takes the ``d``
+/// rows ``w, w + 8, ...`` and its lanes take ``s`` in strides of 32, so the
+/// contraction over ``s`` is a warp fold and nothing crosses a warp.
+__device__ void mamba_ssm_stage(const bf16 *__restrict__ xbc,
+                                const bf16 *__restrict__ dt,
+                                const bf16 *__restrict__ mscal,
+                                const float *__restrict__ ssm_in,
+                                float *__restrict__ ssm_out,
+                                bf16 *__restrict__ y, int head) {
+    const int warp = threadIdx.x >> 5;
+    const int lane = threadIdx.x & 31;
+    const int group = head / HPG;
+
+    const float a_log = ld(mscal + 0 * MH + head);
+    const float dt_bias = ld(mscal + 1 * MH + head);
+    const float dta = bf(fmaxf(bf(softplus_f(bf(ld(dt + head) + dt_bias))), DTMIN));
+    const float da = expf(dta * (-expf(a_log)));
+
+    const bf16 *bg = xbc + MI + group * SS;
+    const bf16 *cg = xbc + MI + NG * SS + group * SS;
+
+    for (int d = warp; d < MD; d += WARPS) {
+        const float xv = ld(xbc + head * MD + d);
+        float acc = 0.0f;
+        for (int s = lane; s < SS; s += 32) {
+            const size_t at = (size_t(head) * MD + d) * SS + s;
+            const float dbx = bf(bf(dta * ld(bg + s)) * xv);
+            const float so = ssm_in[at] * da + dbx;
+            ssm_out[at] = so;
+            acc += bf(so) * ld(cg + s);
+        }
+        acc = ops::warp_reduce<ops::warp_sum>(acc);
+        if (lane == 0) y[head * MD + d] = __float2bfloat16(acc);
+    }
+}
+
+/// The D skip, the gate, and the gated group norm over one group.
+///
+/// ``group`` names which of the ``NG`` runs of ``GRP`` this call owns. The norm
+/// is over that run alone, so the CTA-wide fold below is the whole reduction.
+__device__ void mamba_gate_norm_stage(const bf16 *__restrict__ y,
+                                      const bf16 *__restrict__ xbc,
+                                      const bf16 *__restrict__ gate,
+                                      const bf16 *__restrict__ mscal,
+                                      const bf16 *__restrict__ ggdn,
+                                      bf16 *__restrict__ scan, int group,
+                                      float *slots, float *yf) {
+    const int base = group * GRP;
+    float sq = 0.0f;
+    for (int j = int(threadIdx.x); j < GRP; j += THREADS) {
+        const int i = base + j;
+        const int head = i / MD;
+        const float xv = ld(xbc + i);
+        const float d_skip = ld(mscal + 2 * MH + head);
+        const float yd = bf(ld(y + i) + bf(xv * d_skip));
+        const float v = yd * silu_f(ld(gate + i));
+        yf[j] = v;
+        sq += v * v;
+    }
+    const float scale = rsqrtf(cta_sum(sq, slots) / float(GRP) + EPS);
+    for (int j = int(threadIdx.x); j < GRP; j += THREADS)
+        scan[base + j] = __float2bfloat16(bf(yf[j] * scale) * ld(ggdn + base + j));
+}
+
+/// The tile range CTA ``c`` of ``nc`` owns, splitting ``ntiles`` as evenly as
+/// an integer division allows.
+__device__ __host__ inline void tile_span(int ntiles, int c, int nc, int *first,
+                                          int *count) {
+    const int lo = int(int64_t(ntiles) * c / nc);
+    const int hi = int(int64_t(ntiles) * (c + 1) / nc);
+    *first = lo;
+    *count = hi - lo;
+}
+
+/// Shared layout shared by both projections: the staged weight ring first (the
+/// bulk copy's destination has the strictest alignment), then the input vector,
+/// then the barriers and the per-warp fold slots.
+template <int IN, int STAGES> struct ProjSmem {
+    bf16 *stage;
+    bf16 *x;
+    uint64_t *bars;
+    float *slots;
+
+    __device__ explicit ProjSmem(char *raw) {
+        stage = reinterpret_cast<bf16 *>(raw);
+        x = stage + size_t(STAGES) * TILE_ROWS * IN;
+        bars = reinterpret_cast<uint64_t *>(x + IN);
+        slots = reinterpret_cast<float *>(bars + STAGES);
+    }
+    static constexpr size_t bytes() {
+        return sizeof(bf16) * (size_t(STAGES) * TILE_ROWS * IN + IN) +
+               sizeof(uint64_t) * STAGES + sizeof(float) * WARPS;
+    }
+};
+
+constexpr int IN_STAGES = 3;
+constexpr int OUT_STAGES = 2;
+constexpr int PROJ_TILES = PROJ / TILE_ROWS;
+constexpr int OUT_TILES = H / TILE_ROWS;
+
+/// Pre-norm and the input projection, in one launch.
+///
+/// Every CTA normalises the hidden row itself rather than one CTA doing it
+/// behind a barrier: 2688 elements is not work worth dividing, and dividing it
+/// would cost a barrier to put back together.
+__global__ __launch_bounds__(THREADS) void k_in_proj(
+    const bf16 *__restrict__ h, const bf16 *__restrict__ gamma,
+    const bf16 *__restrict__ w_in, bf16 *__restrict__ proj) {
+    extern __shared__ __align__(16) char raw[];
+    ProjSmem<H, IN_STAGES> sm(raw);
+    rms_norm_to_smem(h, gamma, sm.x, sm.slots);
+    ops::sync<ops::SyncKind::syncthreads>();
+    int first, count;
+    tile_span(PROJ_TILES, int(blockIdx.x), int(gridDim.x), &first, &count);
+    gemv_rows<H, IN_STAGES>(w_in, sm.x, proj, first, count, sm.stage, sm.bars);
+}
+
+/// The output projection and the residual add.
+__global__ __launch_bounds__(THREADS) void k_out_proj(
+    const bf16 *__restrict__ scan, const bf16 *__restrict__ w_out,
+    const bf16 *__restrict__ h_in, bf16 *__restrict__ h_out) {
+    extern __shared__ __align__(16) char raw[];
+    ProjSmem<MI, OUT_STAGES> sm(raw);
+    for (int i = int(threadIdx.x); i < MI; i += THREADS) sm.x[i] = scan[i];
+    ops::sync<ops::SyncKind::syncthreads>();
+    int first, count;
+    tile_span(OUT_TILES, int(blockIdx.x), int(gridDim.x), &first, &count);
+    gemv_rows<MI, OUT_STAGES>(w_out, sm.x, h_out, first, count, sm.stage, sm.bars,
+                              h_in);
+}
+
+__global__ __launch_bounds__(THREADS) void k_conv(
+    const bf16 *__restrict__ proj, const bf16 *__restrict__ conv_state,
+    const bf16 *__restrict__ conv_w, const bf16 *__restrict__ conv_b,
+    bf16 *__restrict__ conv_out, bf16 *__restrict__ xbc) {
+    const int per = (CONV + int(gridDim.x) - 1) / int(gridDim.x);
+    const int c0 = int(blockIdx.x) * per;
+    mamba_conv_stage(proj + MI, conv_state, conv_w, conv_b, conv_out, xbc, c0,
+                     min(c0 + per, CONV));
+}
+
+__global__ __launch_bounds__(THREADS) void k_ssm(
+    const bf16 *__restrict__ xbc, const bf16 *__restrict__ proj,
+    const bf16 *__restrict__ mscal, const float *__restrict__ ssm_in,
+    float *__restrict__ ssm_out, bf16 *__restrict__ y) {
+    mamba_ssm_stage(xbc, proj + MI + CONV, mscal, ssm_in, ssm_out, y,
+                    int(blockIdx.x));
+}
+
+__global__ __launch_bounds__(THREADS) void k_gate_norm(
+    const bf16 *__restrict__ y, const bf16 *__restrict__ xbc,
+    const bf16 *__restrict__ proj, const bf16 *__restrict__ mscal,
+    const bf16 *__restrict__ ggdn, bf16 *__restrict__ scan) {
+    __shared__ float slots[WARPS];
+    __shared__ float yf[GRP];
+    mamba_gate_norm_stage(y, xbc, proj, mscal, ggdn, scan, int(blockIdx.x), slots,
+                          yf);
+}
+
+/// Number of resident CTAs the projections launch with: one per SM, queried
+/// rather than assumed so the split does not depend on which card this is.
+int sm_count() {
+    static int n = 0;
+    if (n == 0) n = at::cuda::getCurrentDeviceProperties()->multiProcessorCount;
+    return n;
+}
+
+/// Raise a kernel's dynamic shared-memory ceiling past the 48 KB default.
+template <class Fn> void allow_smem(Fn *fn, size_t bytes) {
+    static thread_local std::set<void *> done;
+    if (done.insert(reinterpret_cast<void *>(fn)).second)
+        C10_CUDA_CHECK(cudaFuncSetAttribute(
+            reinterpret_cast<const void *>(fn),
+            cudaFuncAttributeMaxDynamicSharedMemorySize, int(bytes)));
+}
+
+void check_bf16(const torch::Tensor &t, int64_t n, const char *what) {
+    TORCH_CHECK(t.is_cuda() && t.is_contiguous() && t.scalar_type() == at::kBFloat16,
+                what, " must be a contiguous bf16 CUDA tensor");
+    TORCH_CHECK(t.numel() == n, what, " must hold ", n, " elements, got ", t.numel());
+}
+
+/// One Mamba-2 layer, stage by stage.
+///
+/// Returns every intermediate, not only the three the model carries forward: a
+/// stage that disagrees with the op-by-op reference is then located directly
+/// rather than bisected out of a single wrong hidden row.
+std::vector<torch::Tensor> mamba_layer(
+    torch::Tensor h, torch::Tensor gamma, torch::Tensor w_in, torch::Tensor w_out,
+    torch::Tensor conv_w, torch::Tensor conv_b, torch::Tensor ggdn,
+    torch::Tensor mscal, torch::Tensor conv_state, torch::Tensor ssm_state) {
+    check_bf16(h, H, "h");
+    check_bf16(gamma, H, "gamma");
+    check_bf16(w_in, int64_t(PROJ) * H, "w_in");
+    check_bf16(w_out, int64_t(H) * MI, "w_out");
+    check_bf16(conv_w, int64_t(CONV) * KER, "conv_w");
+    check_bf16(conv_b, CONV, "conv_b");
+    check_bf16(ggdn, MI, "ggdn");
+    check_bf16(mscal, 3 * MH, "mscal");
+    check_bf16(conv_state, int64_t(CONV) * WIN, "conv_state");
+    TORCH_CHECK(ssm_state.is_cuda() && ssm_state.is_contiguous() &&
+                    ssm_state.scalar_type() == at::kFloat &&
+                    ssm_state.numel() == int64_t(MH) * MD * SS,
+                "ssm_state must be a contiguous f32 CUDA tensor of MH*MD*SS");
+
+    const auto bf_opt = h.options();
+    auto proj = torch::empty({PROJ}, bf_opt);
+    auto xbc = torch::empty({CONV}, bf_opt);
+    auto y = torch::empty({MI}, bf_opt);
+    auto scan = torch::empty({MI}, bf_opt);
+    auto h_out = torch::empty({H}, bf_opt);
+    auto conv_out = torch::empty({int64_t(CONV) * WIN}, bf_opt);
+    auto ssm_out = torch::empty_like(ssm_state);
+
+    auto *P = static_cast<bf16 *>(proj.data_ptr());
+    auto *X = static_cast<bf16 *>(xbc.data_ptr());
+    auto stream = at::cuda::getCurrentCUDAStream();
+    const int ctas = sm_count();
+
+    constexpr size_t kIn = ProjSmem<H, IN_STAGES>::bytes();
+    constexpr size_t kOut = ProjSmem<MI, OUT_STAGES>::bytes();
+    allow_smem(k_in_proj, kIn);
+    allow_smem(k_out_proj, kOut);
+
+    k_in_proj<<<ctas, THREADS, kIn, stream>>>(
+        static_cast<const bf16 *>(h.data_ptr()),
+        static_cast<const bf16 *>(gamma.data_ptr()),
+        static_cast<const bf16 *>(w_in.data_ptr()), P);
+    k_conv<<<CONV / THREADS, THREADS, 0, stream>>>(
+        P, static_cast<const bf16 *>(conv_state.data_ptr()),
+        static_cast<const bf16 *>(conv_w.data_ptr()),
+        static_cast<const bf16 *>(conv_b.data_ptr()),
+        static_cast<bf16 *>(conv_out.data_ptr()), X);
+    k_ssm<<<MH, THREADS, 0, stream>>>(
+        X, P, static_cast<const bf16 *>(mscal.data_ptr()),
+        static_cast<const float *>(ssm_state.data_ptr()),
+        static_cast<float *>(ssm_out.data_ptr()),
+        static_cast<bf16 *>(y.data_ptr()));
+    k_gate_norm<<<NG, THREADS, 0, stream>>>(
+        static_cast<const bf16 *>(y.data_ptr()), X, P,
+        static_cast<const bf16 *>(mscal.data_ptr()),
+        static_cast<const bf16 *>(ggdn.data_ptr()),
+        static_cast<bf16 *>(scan.data_ptr()));
+    k_out_proj<<<ctas, THREADS, kOut, stream>>>(
+        static_cast<const bf16 *>(scan.data_ptr()),
+        static_cast<const bf16 *>(w_out.data_ptr()),
+        static_cast<const bf16 *>(h.data_ptr()),
+        static_cast<bf16 *>(h_out.data_ptr()));
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return {h_out, conv_out, ssm_out, proj, xbc, y, scan};
+}
+
+}  // namespace
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) { m.def("mamba_layer", &mamba_layer); }

--- a/examples/nemotron_3_5_lightning_30b_a3b-tilelang/kernels/nemotron.cu
+++ b/examples/nemotron_3_5_lightning_30b_a3b-tilelang/kernels/nemotron.cu
@@ -14,6 +14,8 @@
 /// those entries instead of through inline PTX.
 #include <tilefoundry/runtime/cuda/runtime.cuh>
 
+#include <cooperative_groups.h>
+
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/cuda/CUDAException.h>
 #include <cuda_bf16.h>
@@ -23,6 +25,7 @@
 #include <vector>
 
 namespace ops = tilefoundry::ops;
+namespace cg = cooperative_groups;
 
 namespace {
 
@@ -364,59 +367,86 @@ constexpr int OUT_TILES = H / TILE_ROWS;
 /// Every CTA normalises the hidden row itself rather than one CTA doing it
 /// behind a barrier: 2688 elements is not work worth dividing, and dividing it
 /// would cost a barrier to put back together.
+__device__ void s_in_proj(int cta, int nctas, const bf16 *__restrict__ h, const bf16 *__restrict__ gamma, const bf16 *__restrict__ w_in, bf16 *__restrict__ proj) {
+    __shared__ float slots[WARPS];
+    __shared__ __align__(16) bf16 xs[H];
+    rms_norm_to_smem(h, gamma, xs, slots);
+    ops::sync<ops::SyncKind::syncthreads>();
+    int first, count;
+    tile_span(PROJ_TILES, cta, nctas, &first, &count);
+    gemv_rows_direct<H>(w_in, xs, proj, first * TILE_ROWS, count * TILE_ROWS);
+}
+
 __global__ __launch_bounds__(THREADS) void k_in_proj(
     const bf16 *__restrict__ h, const bf16 *__restrict__ gamma,
     const bf16 *__restrict__ w_in, bf16 *__restrict__ proj) {
-    extern __shared__ __align__(16) char raw[];
-    ProjSmem<H, IN_STAGES> sm(raw);
-    rms_norm_to_smem(h, gamma, sm.x, sm.slots);
-    ops::sync<ops::SyncKind::syncthreads>();
-    int first, count;
-    tile_span(PROJ_TILES, int(blockIdx.x), int(gridDim.x), &first, &count);
-    gemv_rows<H, IN_STAGES>(w_in, sm.x, proj, first, count, sm.stage, sm.bars);
+    s_in_proj(int(blockIdx.x), int(gridDim.x), h, gamma, w_in, proj);
 }
 
+
 /// The output projection and the residual add.
+__device__ void s_out_proj(int cta, int nctas, const bf16 *__restrict__ scan, const bf16 *__restrict__ w_out, const bf16 *__restrict__ h_in, bf16 *__restrict__ h_out) {
+    __shared__ __align__(16) bf16 xs[MI];
+    for (int i = int(threadIdx.x); i < MI; i += THREADS) xs[i] = scan[i];
+    ops::sync<ops::SyncKind::syncthreads>();
+    int first, count;
+    tile_span(OUT_TILES, cta, nctas, &first, &count);
+    gemv_rows_direct<MI>(w_out, xs, h_out, first * TILE_ROWS, count * TILE_ROWS,
+                         h_in);
+}
+
 __global__ __launch_bounds__(THREADS) void k_out_proj(
     const bf16 *__restrict__ scan, const bf16 *__restrict__ w_out,
     const bf16 *__restrict__ h_in, bf16 *__restrict__ h_out) {
-    extern __shared__ __align__(16) char raw[];
-    ProjSmem<MI, OUT_STAGES> sm(raw);
-    for (int i = int(threadIdx.x); i < MI; i += THREADS) sm.x[i] = scan[i];
-    ops::sync<ops::SyncKind::syncthreads>();
-    int first, count;
-    tile_span(OUT_TILES, int(blockIdx.x), int(gridDim.x), &first, &count);
-    gemv_rows<MI, OUT_STAGES>(w_out, sm.x, h_out, first, count, sm.stage, sm.bars,
-                              h_in);
+    s_out_proj(int(blockIdx.x), int(gridDim.x), scan, w_out, h_in, h_out);
+}
+
+
+__device__ void s_conv(int cta, int nctas, const bf16 *__restrict__ proj, const bf16 *__restrict__ conv_state, const bf16 *__restrict__ conv_w, const bf16 *__restrict__ conv_b, bf16 *__restrict__ conv_out, bf16 *__restrict__ xbc) {
+    const int per = (CONV + nctas - 1) / nctas;
+    const int c0 = cta * per;
+    mamba_conv_stage(proj + MI, conv_state, conv_w, conv_b, conv_out, xbc, c0,
+                     min(c0 + per, CONV));
 }
 
 __global__ __launch_bounds__(THREADS) void k_conv(
     const bf16 *__restrict__ proj, const bf16 *__restrict__ conv_state,
     const bf16 *__restrict__ conv_w, const bf16 *__restrict__ conv_b,
     bf16 *__restrict__ conv_out, bf16 *__restrict__ xbc) {
-    const int per = (CONV + int(gridDim.x) - 1) / int(gridDim.x);
-    const int c0 = int(blockIdx.x) * per;
-    mamba_conv_stage(proj + MI, conv_state, conv_w, conv_b, conv_out, xbc, c0,
-                     min(c0 + per, CONV));
+    s_conv(int(blockIdx.x), int(gridDim.x), proj, conv_state, conv_w, conv_b, conv_out, xbc);
+}
+
+
+__device__ void s_ssm(int cta, int nctas, const bf16 *__restrict__ xbc, const bf16 *__restrict__ proj, const bf16 *__restrict__ mscal, const float *__restrict__ ssm_in, float *__restrict__ ssm_out, bf16 *__restrict__ y) {
+    // 64 heads over however many CTAs the grid has. A persistent grid has more
+    // of them than there are heads, and a CTA that owns none must not index one.
+    for (int head = cta; head < MH; head += nctas)
+        mamba_ssm_stage(xbc, proj + MI + CONV, mscal, ssm_in, ssm_out, y, head);
 }
 
 __global__ __launch_bounds__(THREADS) void k_ssm(
     const bf16 *__restrict__ xbc, const bf16 *__restrict__ proj,
     const bf16 *__restrict__ mscal, const float *__restrict__ ssm_in,
     float *__restrict__ ssm_out, bf16 *__restrict__ y) {
-    mamba_ssm_stage(xbc, proj + MI + CONV, mscal, ssm_in, ssm_out, y,
-                    int(blockIdx.x));
+    s_ssm(int(blockIdx.x), int(gridDim.x), xbc, proj, mscal, ssm_in, ssm_out, y);
+}
+
+
+__device__ void s_gate_norm(int cta, int nctas, const bf16 *__restrict__ y, const bf16 *__restrict__ xbc, const bf16 *__restrict__ proj, const bf16 *__restrict__ mscal, const bf16 *__restrict__ ggdn, bf16 *__restrict__ scan) {
+    __shared__ float slots[WARPS];
+    __shared__ float yf[GRP];
+    // Eight groups, same reasoning as the heads above.
+    for (int group = cta; group < NG; group += nctas)
+        mamba_gate_norm_stage(y, xbc, proj, mscal, ggdn, scan, group, slots, yf);
 }
 
 __global__ __launch_bounds__(THREADS) void k_gate_norm(
     const bf16 *__restrict__ y, const bf16 *__restrict__ xbc,
     const bf16 *__restrict__ proj, const bf16 *__restrict__ mscal,
     const bf16 *__restrict__ ggdn, bf16 *__restrict__ scan) {
-    __shared__ float slots[WARPS];
-    __shared__ float yf[GRP];
-    mamba_gate_norm_stage(y, xbc, proj, mscal, ggdn, scan, int(blockIdx.x), slots,
-                          yf);
+    s_gate_norm(int(blockIdx.x), int(gridDim.x), y, xbc, proj, mscal, ggdn, scan);
 }
+
 
 /// Number of resident CTAs the projections launch with: one per SM, queried
 /// rather than assumed so the split does not depend on which card this is.
@@ -525,24 +555,21 @@ constexpr int MOE_STAGES = 3;
 ///
 /// Every CTA normalises the hidden row itself, as elsewhere; CTA zero also
 /// publishes it, because the expert projections read it next.
-__global__ __launch_bounds__(THREADS) void k_moe_logits(
-    const bf16 *__restrict__ h, const bf16 *__restrict__ gamma,
-    const bf16 *__restrict__ w_router, bf16 *__restrict__ h2,
-    float *__restrict__ logits) {
+__device__ void s_moe_logits(int cta, int nctas, const bf16 *__restrict__ h, const bf16 *__restrict__ gamma, const bf16 *__restrict__ w_router, bf16 *__restrict__ h2, float *__restrict__ logits) {
     __shared__ float slots[WARPS];
     __shared__ __align__(16) bf16 xs[H];
 
     rms_norm_to_smem(h, gamma, xs, slots);
     ops::sync<ops::SyncKind::syncthreads>();
-    if (blockIdx.x == 0)
+    if (cta == 0)
         for (int i = int(threadIdx.x); i < H; i += THREADS) h2[i] = xs[i];
 
     const int warp = threadIdx.x >> 5;
     const int lane = threadIdx.x & 31;
     constexpr int kVec = H / 8;
     const int4 *xv = reinterpret_cast<const int4 *>(xs);
-    const int warps_total = int(gridDim.x) * WARPS;
-    const int my_warp = int(blockIdx.x) * WARPS + warp;
+    const int warps_total = nctas * WARPS;
+    const int my_warp = cta * WARPS + warp;
 
     for (int e = my_warp; e < E; e += warps_total) {
         const int4 *wv = reinterpret_cast<const int4 *>(w_router + size_t(e) * H);
@@ -563,14 +590,20 @@ __global__ __launch_bounds__(THREADS) void k_moe_logits(
     }
 }
 
+__global__ __launch_bounds__(THREADS) void k_moe_logits(
+    const bf16 *__restrict__ h, const bf16 *__restrict__ gamma,
+    const bf16 *__restrict__ w_router, bf16 *__restrict__ h2,
+    float *__restrict__ logits) {
+    s_moe_logits(int(blockIdx.x), int(gridDim.x), h, gamma, w_router, h2, logits);
+}
+
+
 /// Which six experts, and with what weights.
 ///
 /// 128 logits and six passes over them: one CTA, and the choice is not divided.
 /// Dividing it would cost a barrier to put back together for less work than the
 /// barrier.
-__global__ __launch_bounds__(32) void k_moe_topk(
-    const float *__restrict__ logits, const float *__restrict__ e_bias,
-    int *__restrict__ idx, float *__restrict__ gw) {
+__device__ void s_moe_topk(int cta, int nctas, const float *__restrict__ logits, const float *__restrict__ e_bias, int *__restrict__ idx, float *__restrict__ gw) {
     __shared__ float sig[E];
     __shared__ float ch[E];
     for (int e = int(threadIdx.x); e < E; e += 32) {
@@ -593,23 +626,27 @@ __global__ __launch_bounds__(32) void k_moe_topk(
     for (int j = 0; j < KTOP; ++j) gw[j] = sig[idx[j]] * inv * RSCALE;
 }
 
+__global__ __launch_bounds__(32) void k_moe_topk(
+    const float *__restrict__ logits, const float *__restrict__ e_bias,
+    int *__restrict__ idx, float *__restrict__ gw) {
+    s_moe_topk(int(blockIdx.x), int(gridDim.x), logits, e_bias, idx, gw);
+}
+
+
 /// One expert's up projection: ``square(relu(h2 @ w_up[e].t()))``.
 ///
 /// ``slot`` selects which of the chosen experts this launch runs, so the six
 /// are six launches here and six stages of one kernel once the grid is
 /// persistent.
-__global__ __launch_bounds__(THREADS) void k_moe_up(
-    const bf16 *__restrict__ h2, const bf16 *__restrict__ w_up,
-    const int *__restrict__ idx, bf16 *__restrict__ mid) {
+__device__ void s_moe_up(int cta, int nctas, int slot, const bf16 *__restrict__ h2, const bf16 *__restrict__ w_up, const int *__restrict__ idx, bf16 *__restrict__ mid) {
     /// `blockIdx.y` is which of the chosen experts this CTA runs. The six are
     /// independent, so they are one launch: at batch 1 each projection moves
     /// about 10 MB, which is microseconds of bandwidth against a launch apiece.
-    const int slot = int(blockIdx.y);
     __shared__ __align__(16) bf16 xs[H];
     for (int i = int(threadIdx.x); i < H; i += THREADS) xs[i] = h2[i];
     ops::sync<ops::SyncKind::syncthreads>();
     int first, count;
-    tile_span(UP_TILES, int(blockIdx.x), int(gridDim.x), &first, &count);
+    tile_span(UP_TILES, cta, nctas, &first, &count);
     const bf16 *w = w_up + size_t(idx[slot]) * I * H;
     bf16 *out = mid + size_t(slot) * I;
     const int lo = first * TILE_ROWS, hi = (first + count) * TILE_ROWS;
@@ -621,15 +658,18 @@ __global__ __launch_bounds__(THREADS) void k_moe_up(
     }
 }
 
+__global__ __launch_bounds__(THREADS) void k_moe_up(
+    const bf16 *__restrict__ h2, const bf16 *__restrict__ w_up,
+    const int *__restrict__ idx, bf16 *__restrict__ mid) {
+    s_moe_up(int(blockIdx.x), int(gridDim.x), int(blockIdx.y), h2, w_up, idx, mid);
+}
+
+
 /// One expert's down projection, scaled by its routing weight and accumulated.
 ///
 /// The accumulator is f32 because the reference sums the experts in f32 and
 /// only lands in bf16 once, after the six.
-__global__ __launch_bounds__(THREADS) void k_moe_down(
-    const bf16 *__restrict__ mid, const bf16 *__restrict__ w_down,
-    const int *__restrict__ idx, const float *__restrict__ gw,
-    float *__restrict__ acc) {
-    const int slot = int(blockIdx.y);
+__device__ void s_moe_down(int cta, int nctas, int slot, const bf16 *__restrict__ mid, const bf16 *__restrict__ w_down, const int *__restrict__ idx, const float *__restrict__ gw, float *__restrict__ acc) {
     __shared__ __align__(16) bf16 xs[I];
     const bf16 *my_mid = mid + size_t(slot) * I;
     for (int i = int(threadIdx.x); i < I; i += THREADS) xs[i] = my_mid[i];
@@ -638,7 +678,7 @@ __global__ __launch_bounds__(THREADS) void k_moe_down(
     const int warp = threadIdx.x >> 5;
     const int lane = threadIdx.x & 31;
     int first, count;
-    tile_span(DOWN_TILES, int(blockIdx.x), int(gridDim.x), &first, &count);
+    tile_span(DOWN_TILES, cta, nctas, &first, &count);
     const bf16 *w = w_down + size_t(idx[slot]) * H * I;
     const float scale = gw[slot];
     const int lo = first * TILE_ROWS, hi = (first + count) * TILE_ROWS;
@@ -663,18 +703,29 @@ __global__ __launch_bounds__(THREADS) void k_moe_down(
         // part in 1e7 against a budget of parts in 1e3.
         if (lane == 0) atomicAdd(&acc[row], bf(dot) * scale);
     }
+    // `xs` holds *this* expert's activations. A persistent grid runs the six
+    // experts one after another in the same CTA, so without this the next
+    // expert overwrites the tile while threads are still folding against it.
+    // Six separate launches never had to say so.
+    ops::sync<ops::SyncKind::syncthreads>();
 }
+
+__global__ __launch_bounds__(THREADS) void k_moe_down(
+    const bf16 *__restrict__ mid, const bf16 *__restrict__ w_down,
+    const int *__restrict__ idx, const float *__restrict__ gw,
+    float *__restrict__ acc) {
+    s_moe_down(int(blockIdx.x), int(gridDim.x), int(blockIdx.y), mid, w_down, idx, gw, acc);
+}
+
 
 /// The shared expert's up projection. Every token goes through it, so it is not
 /// selected and takes no routing weight.
-__global__ __launch_bounds__(THREADS) void k_moe_shared_up(
-    const bf16 *__restrict__ h2, const bf16 *__restrict__ w_sh_up,
-    bf16 *__restrict__ smid) {
+__device__ void s_moe_shared_up(int cta, int nctas, const bf16 *__restrict__ h2, const bf16 *__restrict__ w_sh_up, bf16 *__restrict__ smid) {
     __shared__ __align__(16) bf16 xs[H];
     for (int i = int(threadIdx.x); i < H; i += THREADS) xs[i] = h2[i];
     ops::sync<ops::SyncKind::syncthreads>();
     int first, count;
-    tile_span(SH_UP_TILES, int(blockIdx.x), int(gridDim.x), &first, &count);
+    tile_span(SH_UP_TILES, cta, nctas, &first, &count);
     const int lo = first * TILE_ROWS, hi = (first + count) * TILE_ROWS;
     gemv_rows_direct<H>(w_sh_up, xs, smid, lo, hi - lo);
     ops::sync<ops::SyncKind::syncthreads>();
@@ -684,14 +735,18 @@ __global__ __launch_bounds__(THREADS) void k_moe_shared_up(
     }
 }
 
+__global__ __launch_bounds__(THREADS) void k_moe_shared_up(
+    const bf16 *__restrict__ h2, const bf16 *__restrict__ w_sh_up,
+    bf16 *__restrict__ smid) {
+    s_moe_shared_up(int(blockIdx.x), int(gridDim.x), h2, w_sh_up, smid);
+}
+
+
 /// The shared expert's down projection, the routed sum, and the residual.
 ///
 /// The routed experts land in bf16 once, after all six have been summed in f32
 /// -- ``(total.to(bf16) + sh)`` -- so the accumulator arrives here still in f32.
-__global__ __launch_bounds__(THREADS) void k_moe_finish(
-    const bf16 *__restrict__ smid, const bf16 *__restrict__ w_sh_down,
-    const float *__restrict__ acc, const bf16 *__restrict__ h_in,
-    bf16 *__restrict__ h_out) {
+__device__ void s_moe_finish(int cta, int nctas, const bf16 *__restrict__ smid, const bf16 *__restrict__ w_sh_down, const float *__restrict__ acc, const bf16 *__restrict__ h_in, bf16 *__restrict__ h_out) {
     __shared__ __align__(16) bf16 xs[IS];
     for (int i = int(threadIdx.x); i < IS; i += THREADS) xs[i] = smid[i];
     ops::sync<ops::SyncKind::syncthreads>();
@@ -699,7 +754,7 @@ __global__ __launch_bounds__(THREADS) void k_moe_finish(
     const int warp = threadIdx.x >> 5;
     const int lane = threadIdx.x & 31;
     int first, count;
-    tile_span(DOWN_TILES, int(blockIdx.x), int(gridDim.x), &first, &count);
+    tile_span(DOWN_TILES, cta, nctas, &first, &count);
     const int lo = first * TILE_ROWS, hi = (first + count) * TILE_ROWS;
     constexpr int kVec = IS / 8;
     const int4 *xv = reinterpret_cast<const int4 *>(xs);
@@ -725,6 +780,14 @@ __global__ __launch_bounds__(THREADS) void k_moe_finish(
         }
     }
 }
+
+__global__ __launch_bounds__(THREADS) void k_moe_finish(
+    const bf16 *__restrict__ smid, const bf16 *__restrict__ w_sh_down,
+    const float *__restrict__ acc, const bf16 *__restrict__ h_in,
+    bf16 *__restrict__ h_out) {
+    s_moe_finish(int(blockIdx.x), int(gridDim.x), smid, w_sh_down, acc, h_in, h_out);
+}
+
 
 /// One MoE layer: router, six routed experts, the shared expert, the residual.
 std::vector<torch::Tensor> moe_layer(
@@ -808,12 +871,8 @@ constexpr int Q_PER_WARP = GQA / ATT_WARPS;
 /// reduction crosses the warp for a score. The softmax over the 32 keys a warp
 /// holds is two warp folds, and the value accumulation broadcasts each weight
 /// back with a shuffle.
-__global__ __launch_bounds__(ATT_THREADS) void k_attn_block(
-    const bf16 *__restrict__ q, const bf16 *__restrict__ kc,
-    const bf16 *__restrict__ vc, int nkey, int blk_offset,
-    float *__restrict__ pm, float *__restrict__ pl, float *__restrict__ pacc) {
-    const int blk = int(blockIdx.x);
-    const int head = int(blockIdx.y);
+__device__ void s_attn_block(int cta, int nctas, int head, const bf16 *__restrict__ q, const bf16 *__restrict__ kc, const bf16 *__restrict__ vc, int nkey, int blk_offset, float *__restrict__ pm, float *__restrict__ pl, float *__restrict__ pacc) {
+    const int blk = cta;
     const int warp = threadIdx.x >> 5;
     const int lane = threadIdx.x & 31;
 
@@ -880,16 +939,29 @@ __global__ __launch_bounds__(ATT_THREADS) void k_attn_block(
     }
 }
 
+__global__ __launch_bounds__(ATT_THREADS) void k_attn_block(
+    const bf16 *__restrict__ q, const bf16 *__restrict__ kc,
+    const bf16 *__restrict__ vc, int nkey, int blk_offset,
+    float *__restrict__ pm, float *__restrict__ pl, float *__restrict__ pacc) {
+    s_attn_block(int(blockIdx.x), int(gridDim.x), int(blockIdx.y), q, kc, vc, nkey, blk_offset, pm, pl, pacc);
+}
+
+
 /// Merge the per-block partials into the context vector.
 ///
 /// One CTA per (head, query). The merge is the same online step the blocks ran,
 /// applied across them, so splitting the scan changes nothing about the value.
-__global__ __launch_bounds__(DH) void k_attn_combine(
-    const float *__restrict__ pm, const float *__restrict__ pl,
-    const float *__restrict__ pacc, int nblock, bf16 *__restrict__ ctx) {
-    const int head = int(blockIdx.y);
-    const int g = int(blockIdx.x);
+__device__ void s_attn_combine(int cta, int nctas, int head,
+                               const float *__restrict__ pm,
+                               const float *__restrict__ pl,
+                               const float *__restrict__ pacc, int nblock,
+                               bf16 *__restrict__ ctx) {
+    const int g = cta;
     const int d = int(threadIdx.x);
+    // One thread per head dimension. A persistent grid runs this with the
+    // block size the rest of the step uses, which is wider than DH, and a
+    // thread past the end would write over whatever follows `ctx`.
+    if (d >= DH) return;
 
     float m = -INFINITY, l = 0.0f, acc = 0.0f;
     for (int b = 0; b < nblock; ++b) {
@@ -906,6 +978,14 @@ __global__ __launch_bounds__(DH) void k_attn_combine(
     ctx[(size_t(head) * GQA + g) * DH + d] = __float2bfloat16(acc / l);
 }
 
+__global__ __launch_bounds__(DH) void k_attn_combine(
+    const float *__restrict__ pm, const float *__restrict__ pl,
+    const float *__restrict__ pacc, int nblock, bf16 *__restrict__ ctx) {
+    s_attn_combine(int(blockIdx.x), int(gridDim.x), int(blockIdx.y), pm, pl,
+                   pacc, nblock, ctx);
+}
+
+
 constexpr int QKV = QP + 2 * KVP;
 constexpr int QKV_TILES = QKV / TILE_ROWS;
 constexpr int O_TILES = H / TILE_ROWS;
@@ -914,17 +994,14 @@ constexpr int O_TILES = H / TILE_ROWS;
 ///
 /// `cache_update`, realised on the cache's own buffer: the row this token adds
 /// is written where the scan will read it, so nothing is copied between steps.
-__global__ __launch_bounds__(THREADS) void k_qkv(
-    const bf16 *__restrict__ h, const bf16 *__restrict__ gamma,
-    const bf16 *__restrict__ w_qkv, bf16 *__restrict__ qkv,
-    bf16 *__restrict__ k_tail, bf16 *__restrict__ v_tail, int cur_pos) {
-    extern __shared__ __align__(16) char raw[];
-    ProjSmem<H, IN_STAGES> sm(raw);
-    rms_norm_to_smem(h, gamma, sm.x, sm.slots);
+__device__ void s_qkv(int cta, int nctas, const bf16 *__restrict__ h, const bf16 *__restrict__ gamma, const bf16 *__restrict__ w_qkv, bf16 *__restrict__ qkv, bf16 *__restrict__ k_tail, bf16 *__restrict__ v_tail, int cur_pos) {
+    __shared__ float slots[WARPS];
+    __shared__ __align__(16) bf16 xs[H];
+    rms_norm_to_smem(h, gamma, xs, slots);
     ops::sync<ops::SyncKind::syncthreads>();
     int first, count;
-    tile_span(QKV_TILES, int(blockIdx.x), int(gridDim.x), &first, &count);
-    gemv_rows<H, IN_STAGES>(w_qkv, sm.x, qkv, first, count, sm.stage, sm.bars);
+    tile_span(QKV_TILES, cta, nctas, &first, &count);
+    gemv_rows_direct<H>(w_qkv, xs, qkv, first * TILE_ROWS, count * TILE_ROWS);
     ops::sync<ops::SyncKind::syncthreads>();
 
     const int lo = first * TILE_ROWS, hi = (first + count) * TILE_ROWS;
@@ -937,18 +1014,31 @@ __global__ __launch_bounds__(THREADS) void k_qkv(
     }
 }
 
+__global__ __launch_bounds__(THREADS) void k_qkv(
+    const bf16 *__restrict__ h, const bf16 *__restrict__ gamma,
+    const bf16 *__restrict__ w_qkv, bf16 *__restrict__ qkv,
+    bf16 *__restrict__ k_tail, bf16 *__restrict__ v_tail, int cur_pos) {
+    s_qkv(int(blockIdx.x), int(gridDim.x), h, gamma, w_qkv, qkv, k_tail, v_tail, cur_pos);
+}
+
+
 /// The output projection and the residual add.
-__global__ __launch_bounds__(THREADS) void k_o_proj(
-    const bf16 *__restrict__ ctx, const bf16 *__restrict__ w_o,
-    const bf16 *__restrict__ h_in, bf16 *__restrict__ h_out) {
+__device__ void s_o_proj(int cta, int nctas, const bf16 *__restrict__ ctx, const bf16 *__restrict__ w_o, const bf16 *__restrict__ h_in, bf16 *__restrict__ h_out) {
     __shared__ __align__(16) bf16 xs[QP];
     for (int i = int(threadIdx.x); i < QP; i += THREADS) xs[i] = ctx[i];
     ops::sync<ops::SyncKind::syncthreads>();
     int first, count;
-    tile_span(O_TILES, int(blockIdx.x), int(gridDim.x), &first, &count);
+    tile_span(O_TILES, cta, nctas, &first, &count);
     gemv_rows_direct<QP>(w_o, xs, h_out, first * TILE_ROWS, count * TILE_ROWS,
                          h_in);
 }
+
+__global__ __launch_bounds__(THREADS) void k_o_proj(
+    const bf16 *__restrict__ ctx, const bf16 *__restrict__ w_o,
+    const bf16 *__restrict__ h_in, bf16 *__restrict__ h_out) {
+    s_o_proj(int(blockIdx.x), int(gridDim.x), ctx, w_o, h_in, h_out);
+}
+
 
 /// One full-attention layer.
 std::vector<torch::Tensor> attn_layer(
@@ -1017,10 +1107,304 @@ std::vector<torch::Tensor> attn_layer(
     return {h_out, qkv, ctx};
 }
 
+
+/// The closing norm and the head.
+///
+/// 131072 rows over 132 CTAs is 124 tiles each, which is where running tiles
+/// ahead pays; the head is the single largest read in the step at 705 MB.
+__device__ void s_head(char *arena, int cta, int nctas, const bf16 *__restrict__ h,
+                       const bf16 *__restrict__ gf, const bf16 *__restrict__ whead,
+                       int vocab, float *__restrict__ logits) {
+    char *raw = arena;
+    ProjSmem<H, IN_STAGES> sm(raw);
+    rms_norm_to_smem(h, gf, sm.x, sm.slots);
+    ops::sync<ops::SyncKind::syncthreads>();
+
+    const int ntiles = vocab / TILE_ROWS;
+    int first, count;
+    tile_span(ntiles, cta, nctas, &first, &count);
+
+    constexpr unsigned kBytes = unsigned(TILE_ROWS) * H * sizeof(bf16);
+    constexpr int kTileElems = TILE_ROWS * H;
+    const int warp = threadIdx.x >> 5;
+    const int lane = threadIdx.x & 31;
+    const bool elected = ops::shuffle_elect<THREADS>();
+    if (elected)
+        for (int s = 0; s < IN_STAGES; ++s) ops::mbarrier_init(&sm.bars[s], 1);
+    ops::sync<ops::SyncKind::syncthreads>();
+    for (int s = 0; s < IN_STAGES && s < count; ++s)
+        if (elected) {
+            ops::mbarrier_arrive_expect_tx(&sm.bars[s], kBytes);
+            ops::tma_bulk_copy(whead + size_t(first + s) * kTileElems,
+                               sm.stage + s * kTileElems, kTileElems, &sm.bars[s]);
+        }
+    for (int t = 0; t < count; ++t) {
+        const int s = t % IN_STAGES;
+        ops::mbarrier_wait_parity(&sm.bars[s], unsigned(t / IN_STAGES) & 1u);
+        const bf16 *row = sm.stage + s * kTileElems + warp * H;
+        float part[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+        // `j` steps by 32, so `j & 7` is constant for a lane and would leave
+        // seven accumulators at zero. The step index is what varies.
+        for (int j = lane, u = 0; j < H; j += 32, ++u)
+            part[u & 7] += ld(row + j) * ld(sm.x + j);
+        float acc = (part[0] + part[1]) + (part[2] + part[3]) +
+                    ((part[4] + part[5]) + (part[6] + part[7]));
+        acc = ops::warp_reduce<ops::warp_sum>(acc);
+        // `(fh @ w_head.t()).float()`: the product lands in bf16 and only then
+        // widens, so the rounding is the matmul's, not the store's.
+        if (lane == 0) logits[(first + t) * TILE_ROWS + warp] = bf(acc);
+        ops::sync<ops::SyncKind::syncthreads>();
+        const int next = t + IN_STAGES;
+        if (next < count && elected) {
+            ops::mbarrier_arrive_expect_tx(&sm.bars[s], kBytes);
+            ops::tma_bulk_copy(whead + size_t(first + next) * kTileElems,
+                               sm.stage + s * kTileElems, kTileElems, &sm.bars[s]);
+        }
+    }
+    if (elected)
+        for (int s = 0; s < IN_STAGES; ++s) ops::mbarrier_invalidate(&sm.bars[s]);
+}
+
+/// The arena every staged projection overlays, sized to the largest of them.
+///
+/// One kernel calls all of them, so one allocation has to cover the widest:
+/// `s_out_proj` stages 4096-wide rows and needs more than `s_in_proj`'s 2688.
+/// Getting this wrong is a shared-memory write past the end, which is what
+/// compute-sanitizer reported before it was a constant.
+constexpr size_t kMegaSmem = ProjSmem<H, IN_STAGES>::bytes();
+
+/// Everything one step reads that does not change between steps.
+struct Weights {
+    const bf16 *win, *wout, *convw, *convb, *ggdn, *mscal;
+    const bf16 *wqkv, *wo;
+    const bf16 *wrt, *wup, *wdn, *wsu, *wsd;
+    const float *eb;
+    const bf16 *gam, *table, *whead, *gf;
+};
+
+/// Everything one step writes that is not a state it hands on.
+struct Scratch {
+    bf16 *h, *h2, *proj, *xbc, *y, *scan, *qkv, *ctx, *mid, *smid;
+    float *acc, *rlog, *pm, *pl, *pacc;
+    int *idx;
+    float *gw;
+    float *logits;
+};
+
+/// One decode step, resident.
+///
+/// The grid stays on the card for the whole step and a barrier is what ends a
+/// stage, so nothing returns between the embedding and the head. Every
+/// `grid.sync()` below sits where `model.py` reshards a value back out of its
+/// mesh split -- an `tf.reshard(..., "gmem")` that closes a projection -- which
+/// is a property of the authored dataflow rather than a choice made here.
+///
+/// The residual add is in place: the CTA that writes a row of the hidden vector
+/// is the CTA that read it, so no barrier separates the two and no second pass
+/// over 2688 elements is needed.
+__global__ __launch_bounds__(THREADS) void mega_decode(
+    Weights w, Scratch s, void **st, const int *kind, const int *at,
+    const long *token_ids, int nlayer, int n_mamba, int n_attn, int cur_pos,
+    int ctx_full, int ctx_tail, int vocab) {
+    extern __shared__ __align__(16) char arena[];
+    cg::grid_group grid = cg::this_grid();
+    const int cta = int(blockIdx.x), nctas = int(gridDim.x);
+    const int tid = int(threadIdx.x);
+
+    const long tok = token_ids[0];
+    for (int i = cta * THREADS + tid; i < H; i += nctas * THREADS)
+        s.h[i] = w.table[size_t(tok) * H + i];
+    grid.sync();
+
+    const int live_tail = cur_pos + 1;
+    const int nb_full = (ctx_full + ABLK - 1) / ABLK;
+    const int nb_tail = (live_tail + ABLK - 1) / ABLK;
+
+    for (int L = 0; L < nlayer; ++L) {
+        const bf16 *gam = w.gam + size_t(L) * H;
+        const int a = at[L];
+        if (kind[L] == 0) {
+            bf16 *conv_in = static_cast<bf16 *>(st[0 * n_mamba + a]);
+            float *ssm_in = static_cast<float *>(st[1 * n_mamba + a]);
+            bf16 *conv_out = static_cast<bf16 *>(st[2 * n_mamba + a]);
+            float *ssm_out = static_cast<float *>(st[3 * n_mamba + a]);
+            const bf16 *ms = w.mscal + size_t(a) * 3 * MH;
+            s_in_proj(cta, nctas, s.h, gam, w.win + size_t(a) * PROJ * H,
+                      s.proj);
+            grid.sync();
+            s_conv(cta, nctas, s.proj, conv_in, w.convw + size_t(a) * CONV * KER,
+                   w.convb + size_t(a) * CONV, conv_out, s.xbc);
+            grid.sync();
+            s_ssm(cta, nctas, s.xbc, s.proj, ms, ssm_in, ssm_out, s.y);
+            grid.sync();
+            s_gate_norm(cta, nctas, s.y, s.xbc, s.proj, ms,
+                        w.ggdn + size_t(a) * MI, s.scan);
+            grid.sync();
+            s_out_proj(cta, nctas, s.scan, w.wout + size_t(a) * H * MI, s.h,
+                       s.h);
+            grid.sync();
+        } else if (kind[L] == 1) {
+            const bf16 *kc = static_cast<const bf16 *>(st[4 * n_mamba + 0 * n_attn + a]);
+            const bf16 *vc = static_cast<const bf16 *>(st[4 * n_mamba + 1 * n_attn + a]);
+            bf16 *kt = static_cast<bf16 *>(st[4 * n_mamba + 2 * n_attn + a]);
+            bf16 *vt = static_cast<bf16 *>(st[4 * n_mamba + 3 * n_attn + a]);
+            s_qkv(cta, nctas, s.h, gam, w.wqkv + size_t(a) * QKV * H, s.qkv,
+                  kt, vt, cur_pos);
+            grid.sync();
+            for (int b = cta; b < nb_full * HKV; b += nctas)
+                s_attn_block(b / HKV, nb_full, b % HKV, s.qkv, kc, vc, ctx_full, 0,
+                             s.pm, s.pl, s.pacc);
+            for (int b = cta; b < nb_tail * HKV; b += nctas)
+                s_attn_block(b / HKV, nb_tail, b % HKV, s.qkv, kt, vt, live_tail,
+                             nb_full, s.pm, s.pl, s.pacc);
+            grid.sync();
+            for (int u = cta; u < GQA * HKV; u += nctas)
+                s_attn_combine(u / HKV, 0, u % HKV, s.pm, s.pl, s.pacc,
+                               nb_full + nb_tail, s.ctx);
+            grid.sync();
+            s_o_proj(cta, nctas, s.ctx, w.wo + size_t(a) * H * QP, s.h, s.h);
+            grid.sync();
+        } else {
+            s_moe_logits(cta, nctas, s.h, gam, w.wrt + size_t(a) * E * H, s.h2,
+                         s.rlog);
+            grid.sync();
+            if (cta == 0)
+                s_moe_topk(0, 1, s.rlog, w.eb + size_t(a) * E, s.idx, s.gw);
+            for (int i = cta * THREADS + tid; i < H; i += nctas * THREADS)
+                s.acc[i] = 0.0f;
+            grid.sync();
+            for (int slot = 0; slot < KTOP; ++slot)
+                s_moe_up(cta, nctas, slot, s.h2, w.wup + size_t(a) * E * I * H,
+                         s.idx, s.mid);
+            s_moe_shared_up(cta, nctas, s.h2, w.wsu + size_t(a) * IS * H, s.smid);
+            grid.sync();
+            for (int slot = 0; slot < KTOP; ++slot)
+                s_moe_down(cta, nctas, slot, s.mid, w.wdn + size_t(a) * E * H * I,
+                           s.idx, s.gw, s.acc);
+            grid.sync();
+            s_moe_finish(cta, nctas, s.smid, w.wsd + size_t(a) * H * IS, s.acc,
+                         s.h, s.h);
+            grid.sync();
+        }
+    }
+    s_head(arena, cta, nctas, s.h, w.gf, w.whead, vocab, s.logits);
+}
+
+/// How many CTAs of `mega_decode` fit at once.
+///
+/// A cooperative launch may not ask for more than the card can hold resident:
+/// its grid barrier deadlocks if any CTA is still queued. The answer depends on
+/// the shared-memory request, so it is asked rather than assumed.
+int mega_grid(size_t smem) {
+    static int n = 0;
+    if (n == 0) {
+        // The ceiling has to be raised before residency is asked about it:
+        // the default is 48 KB and the answer would be zero.
+        C10_CUDA_CHECK(cudaFuncSetAttribute(
+            reinterpret_cast<const void *>(mega_decode),
+            cudaFuncAttributeMaxDynamicSharedMemorySize, int(smem)));
+        cudaFuncAttributes fa{};
+        C10_CUDA_CHECK(cudaFuncGetAttributes(
+            &fa, reinterpret_cast<const void *>(mega_decode)));
+        int per_sm = 0;
+        C10_CUDA_CHECK(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+            &per_sm, reinterpret_cast<const void *>(mega_decode), THREADS, smem));
+        TORCH_CHECK(per_sm > 0, "mega_decode is not resident: ", fa.sharedSizeBytes,
+                    " bytes static plus ", smem,
+                    " dynamic exceeds what an SM can hold, and a cooperative "
+                    "launch deadlocks if any CTA stays queued");
+        n = per_sm * sm_count();
+    }
+    return n;
+}
+
+/// One decode step as a single cooperative launch.
+///
+/// `weights` arrive in the pack's own order and `states` in the table order the
+/// kernel indexes; both are views into tensors the twin already holds, so this
+/// copies no weight.
+torch::Tensor mega_step(std::vector<torch::Tensor> weights,
+                        std::vector<torch::Tensor> states,
+                        std::vector<torch::Tensor> scratch, torch::Tensor kinds,
+                        torch::Tensor ats, torch::Tensor token_ids,
+                        int64_t cur_pos, int64_t ctx_full, int64_t ctx_tail,
+                        int64_t layers) {
+    TORCH_CHECK(weights.size() == 18, "expected 18 packed weight tensors");
+    TORCH_CHECK(scratch.size() == 18, "expected 18 scratch tensors");
+    auto B = [&](const torch::Tensor &t) { return static_cast<bf16 *>(t.data_ptr()); };
+    auto CB = [&](const torch::Tensor &t) {
+        return static_cast<const bf16 *>(t.data_ptr());
+    };
+    auto F = [&](const torch::Tensor &t) { return static_cast<float *>(t.data_ptr()); };
+
+    Weights w{CB(weights[0]),  CB(weights[1]),  CB(weights[2]),  CB(weights[3]),
+              CB(weights[4]),  CB(weights[15]), CB(weights[5]),  CB(weights[6]),
+              CB(weights[7]),  CB(weights[8]),  CB(weights[9]),  CB(weights[10]),
+              CB(weights[11]), static_cast<const float *>(weights[17].data_ptr()),
+              CB(weights[12]), CB(weights[13]), CB(weights[14]), CB(weights[16])};
+
+    Scratch s{B(scratch[0]),  B(scratch[1]),  B(scratch[2]),  B(scratch[3]),
+              B(scratch[4]),  B(scratch[5]),  B(scratch[6]),  B(scratch[7]),
+              B(scratch[8]),  B(scratch[9]),  F(scratch[10]), F(scratch[11]),
+              F(scratch[12]), F(scratch[13]), F(scratch[14]),
+              static_cast<int *>(scratch[15].data_ptr()), F(scratch[16]),
+              F(scratch[17])};
+
+    // The state pointers travel as a device array, so the kernel indexes them by
+    // (kind, layer) the way it indexes a weight.
+    std::vector<void *> host_ptrs;
+    host_ptrs.reserve(states.size());
+    for (auto &t : states) host_ptrs.push_back(t.data_ptr());
+    // The table has to outlive the launch. A local tensor is returned to the
+    // caching allocator when this function returns, and the next allocation
+    // hands the same bytes to somebody else while the kernel is still reading
+    // them -- which reads as an illegal access one step later, not here.
+    static torch::Tensor table;
+    if (!table.defined() || table.numel() < int64_t(host_ptrs.size()))
+        table = torch::empty({int64_t(host_ptrs.size())},
+                             torch::dtype(torch::kInt64).device(token_ids.device()));
+    C10_CUDA_CHECK(cudaMemcpyAsync(table.data_ptr(), host_ptrs.data(),
+                                   host_ptrs.size() * sizeof(void *),
+                                   cudaMemcpyHostToDevice,
+                                   at::cuda::getCurrentCUDAStream()));
+
+    // `layers` stops the walk early, which is how a divergence is bisected to
+    // the layer that introduces it; 0 means the whole step.
+    int nlayer = layers > 0 ? int(layers) : int(kinds.numel());
+    int vocab = int(scratch[17].numel());
+    int n_mamba = 0, n_attn = 0;
+    auto kinds_cpu = kinds.to(torch::kCPU);
+    const int *kp = kinds_cpu.data_ptr<int>();
+    for (int i = 0; i < int(kinds.numel()); ++i) {
+        if (kp[i] == 0) ++n_mamba;
+        else if (kp[i] == 1) ++n_attn;
+    }
+
+    constexpr size_t kSmem = kMegaSmem;
+    const int grid = mega_grid(kSmem);
+
+    void **st = static_cast<void **>(table.data_ptr());
+    int *kd = static_cast<int *>(kinds.data_ptr());
+    int *atp = static_cast<int *>(ats.data_ptr());
+    long *tok = static_cast<long *>(token_ids.data_ptr());
+    int cp = int(cur_pos), cf = int(ctx_full), ct = int(ctx_tail);
+    void *args[] = {&w,      &s,       &st,     &kd, &atp, &tok, &nlayer,
+                    &n_mamba, &n_attn, &cp,     &cf, &ct,  &vocab};
+    C10_CUDA_CHECK(cudaLaunchCooperativeKernel(
+        reinterpret_cast<const void *>(mega_decode), dim3(grid), dim3(THREADS),
+        args, kSmem, at::cuda::getCurrentCUDAStream()));
+    return scratch[17];
+}
+
+/// How many CTAs the cooperative launch will use, for the twin to report.
+int64_t mega_grid_size() { return mega_grid(kMegaSmem); }
+
 }  // namespace
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     m.def("mamba_layer", &mamba_layer);
     m.def("moe_layer", &moe_layer);
     m.def("attn_layer", &attn_layer);
+    m.def("mega_step", &mega_step);
+    m.def("mega_grid_size", &mega_grid_size);
 }

--- a/examples/nemotron_3_5_lightning_30b_a3b-tilelang/kernels/nemotron.cu
+++ b/examples/nemotron_3_5_lightning_30b_a3b-tilelang/kernels/nemotron.cu
@@ -41,6 +41,12 @@ constexpr int HPG = 8;
 constexpr float EPS = 1e-5f;
 constexpr float DTMIN = 0.001f;
 
+constexpr int E = 128;
+constexpr int KTOP = 6;
+constexpr int I = 1856;
+constexpr int IS = 3712;
+constexpr float RSCALE = 2.5f;
+
 constexpr int THREADS = 256;
 constexpr int WARPS = THREADS / 32;
 
@@ -141,6 +147,63 @@ __device__ void gemv_rows(const bf16 *__restrict__ w, const bf16 *__restrict__ x
     }
     if (elected)
         for (int s = 0; s < STAGES; ++s) ops::mbarrier_invalidate(&bars[s]);
+}
+
+/// Which of the two gemv shapes wins is a measurement, and both are here so it
+/// can be repeated. Measured on one H200, one layer of the checkpoint:
+///
+///   Mamba-2 layer   staged 49.6 us   direct 85.7 us
+///   MoE layer       staged  320 us   direct  114 us (with the router fixed)
+///
+/// The split is how many tiles a CTA gets. The Mamba projections give each CTA
+/// about 78 rows, and running three tiles ahead hides the next load behind this
+/// tile's fold. The MoE experts give each CTA under two tiles, so the prologue
+/// issues more than the loop consumes and the staging is pure overhead. Staged
+/// for the first, direct for the second.
+
+/// ``out[row] = dot(w[row], x)`` straight from global memory, no staging.
+///
+/// A gemv reads each weight byte exactly once, so there is nothing for a shared
+/// tile to be reused by. What staging costs instead is occupancy: three stages
+/// of eight 2688-wide rows is 129 KB, which fits one CTA per SM and leaves the
+/// memory system with one CTA's worth of requests in flight. This reads 16
+/// bytes per lane straight from gmem -- a warp covers 512 bytes a step, fully
+/// coalesced -- and keeps the shared budget at zero, so the SM holds as many
+/// CTAs as the launch offers.
+///
+/// Kept beside `gemv_rows` rather than replacing it: which one wins is a
+/// measurement, and the two are here so the measurement can be repeated.
+template <int IN>
+__device__ void gemv_rows_direct(const bf16 *__restrict__ w,
+                                 const bf16 *__restrict__ x,
+                                 bf16 *__restrict__ out, int row0, int nrows,
+                                 const bf16 *__restrict__ resid = nullptr) {
+    static_assert(IN % 8 == 0, "gemv_rows_direct: IN must be a multiple of 8");
+    constexpr int kVec = IN / 8;
+    const int warp = threadIdx.x >> 5;
+    const int lane = threadIdx.x & 31;
+    const int4 *xv = reinterpret_cast<const int4 *>(x);
+
+    for (int r = warp; r < nrows; r += WARPS) {
+        const int row = row0 + r;
+        const int4 *wv = reinterpret_cast<const int4 *>(w + size_t(row) * IN);
+        // Eight accumulators, not one. A single running sum makes the whole row
+        // a serial chain of dependent FMAs, and the loads cannot run ahead of a
+        // chain: the row's latency, not its bytes, is what the warp waits on.
+        float part[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+        for (int v = lane; v < kVec; v += 32) {
+            const int4 a = wv[v], b = xv[v];
+            const bf16 *pa = reinterpret_cast<const bf16 *>(&a);
+            const bf16 *pb = reinterpret_cast<const bf16 *>(&b);
+#pragma unroll
+            for (int k = 0; k < 8; ++k) part[k] += ld(pa + k) * ld(pb + k);
+        }
+        float acc = (part[0] + part[1]) + (part[2] + part[3]) +
+                    ((part[4] + part[5]) + (part[6] + part[7]));
+        acc = ops::warp_reduce<ops::warp_sum>(acc);
+        if (lane == 0)
+            out[row] = __float2bfloat16(resid ? ld(resid + row) + bf(acc) : acc);
+    }
 }
 
 /// The published ``NemotronHRMSNorm``, into shared memory.
@@ -440,6 +503,288 @@ std::vector<torch::Tensor> mamba_layer(
     return {h_out, conv_out, ssm_out, proj, xbc, y, scan};
 }
 
+constexpr int UP_TILES = I / TILE_ROWS;
+constexpr int DOWN_TILES = H / TILE_ROWS;
+constexpr int SH_UP_TILES = IS / TILE_ROWS;
+constexpr int MOE_STAGES = 3;
+
+/// The router's logits: 128 numbers, spread over the whole grid.
+///
+/// One warp per expert row, lanes striding it 16 bytes at a time. Written out
+/// because the obvious shape -- one *thread* per expert, walking its row -- puts
+/// consecutive threads 5376 bytes apart and coalesces nothing: measured at
+/// 236 us for 688 KB, against 74 us for the 160 MB of expert weights beside it.
+///
+/// Every CTA normalises the hidden row itself, as elsewhere; CTA zero also
+/// publishes it, because the expert projections read it next.
+__global__ __launch_bounds__(THREADS) void k_moe_logits(
+    const bf16 *__restrict__ h, const bf16 *__restrict__ gamma,
+    const bf16 *__restrict__ w_router, bf16 *__restrict__ h2,
+    float *__restrict__ logits) {
+    __shared__ float slots[WARPS];
+    __shared__ __align__(16) bf16 xs[H];
+
+    rms_norm_to_smem(h, gamma, xs, slots);
+    ops::sync<ops::SyncKind::syncthreads>();
+    if (blockIdx.x == 0)
+        for (int i = int(threadIdx.x); i < H; i += THREADS) h2[i] = xs[i];
+
+    const int warp = threadIdx.x >> 5;
+    const int lane = threadIdx.x & 31;
+    constexpr int kVec = H / 8;
+    const int4 *xv = reinterpret_cast<const int4 *>(xs);
+    const int warps_total = int(gridDim.x) * WARPS;
+    const int my_warp = int(blockIdx.x) * WARPS + warp;
+
+    for (int e = my_warp; e < E; e += warps_total) {
+        const int4 *wv = reinterpret_cast<const int4 *>(w_router + size_t(e) * H);
+        float part[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+        for (int v = lane; v < kVec; v += 32) {
+            const int4 a = wv[v], b = xv[v];
+            const bf16 *pa = reinterpret_cast<const bf16 *>(&a);
+            const bf16 *pb = reinterpret_cast<const bf16 *>(&b);
+#pragma unroll
+            for (int k = 0; k < 8; ++k) part[k] += ld(pa + k) * ld(pb + k);
+        }
+        float acc = (part[0] + part[1]) + (part[2] + part[3]) +
+                    ((part[4] + part[5]) + (part[6] + part[7]));
+        acc = ops::warp_reduce<ops::warp_sum>(acc);
+        // The router runs in f32 on both sides -- `h2.float() @ w.float().t()`
+        // -- so this is the one projection that does not land in bf16.
+        if (lane == 0) logits[e] = acc;
+    }
+}
+
+/// Which six experts, and with what weights.
+///
+/// 128 logits and six passes over them: one CTA, and the choice is not divided.
+/// Dividing it would cost a barrier to put back together for less work than the
+/// barrier.
+__global__ __launch_bounds__(32) void k_moe_topk(
+    const float *__restrict__ logits, const float *__restrict__ e_bias,
+    int *__restrict__ idx, float *__restrict__ gw) {
+    __shared__ float sig[E];
+    __shared__ float ch[E];
+    for (int e = int(threadIdx.x); e < E; e += 32) {
+        const float s = 1.0f / (1.0f + expf(-logits[e]));
+        sig[e] = s;
+        ch[e] = s + e_bias[e];
+    }
+    ops::sync<ops::SyncKind::syncthreads>();
+    if (threadIdx.x != 0) return;
+    float total = 0.0f;
+    for (int j = 0; j < KTOP; ++j) {
+        int best = 0;
+        for (int e = 1; e < E; ++e)
+            if (ch[e] > ch[best]) best = e;
+        idx[j] = best;
+        total += sig[best];
+        ch[best] = -INFINITY;
+    }
+    const float inv = 1.0f / (total + 1e-20f);
+    for (int j = 0; j < KTOP; ++j) gw[j] = sig[idx[j]] * inv * RSCALE;
+}
+
+/// One expert's up projection: ``square(relu(h2 @ w_up[e].t()))``.
+///
+/// ``slot`` selects which of the chosen experts this launch runs, so the six
+/// are six launches here and six stages of one kernel once the grid is
+/// persistent.
+__global__ __launch_bounds__(THREADS) void k_moe_up(
+    const bf16 *__restrict__ h2, const bf16 *__restrict__ w_up,
+    const int *__restrict__ idx, bf16 *__restrict__ mid) {
+    /// `blockIdx.y` is which of the chosen experts this CTA runs. The six are
+    /// independent, so they are one launch: at batch 1 each projection moves
+    /// about 10 MB, which is microseconds of bandwidth against a launch apiece.
+    const int slot = int(blockIdx.y);
+    __shared__ __align__(16) bf16 xs[H];
+    for (int i = int(threadIdx.x); i < H; i += THREADS) xs[i] = h2[i];
+    ops::sync<ops::SyncKind::syncthreads>();
+    int first, count;
+    tile_span(UP_TILES, int(blockIdx.x), int(gridDim.x), &first, &count);
+    const bf16 *w = w_up + size_t(idx[slot]) * I * H;
+    bf16 *out = mid + size_t(slot) * I;
+    const int lo = first * TILE_ROWS, hi = (first + count) * TILE_ROWS;
+    gemv_rows_direct<H>(w, xs, out, lo, hi - lo);
+    ops::sync<ops::SyncKind::syncthreads>();
+    for (int row = lo + int(threadIdx.x); row < hi; row += THREADS) {
+        const float v = fmaxf(ld(out + row), 0.0f);
+        out[row] = __float2bfloat16(bf(v) * bf(v));
+    }
+}
+
+/// One expert's down projection, scaled by its routing weight and accumulated.
+///
+/// The accumulator is f32 because the reference sums the experts in f32 and
+/// only lands in bf16 once, after the six.
+__global__ __launch_bounds__(THREADS) void k_moe_down(
+    const bf16 *__restrict__ mid, const bf16 *__restrict__ w_down,
+    const int *__restrict__ idx, const float *__restrict__ gw,
+    float *__restrict__ acc) {
+    const int slot = int(blockIdx.y);
+    __shared__ __align__(16) bf16 xs[I];
+    const bf16 *my_mid = mid + size_t(slot) * I;
+    for (int i = int(threadIdx.x); i < I; i += THREADS) xs[i] = my_mid[i];
+    ops::sync<ops::SyncKind::syncthreads>();
+
+    const int warp = threadIdx.x >> 5;
+    const int lane = threadIdx.x & 31;
+    int first, count;
+    tile_span(DOWN_TILES, int(blockIdx.x), int(gridDim.x), &first, &count);
+    const bf16 *w = w_down + size_t(idx[slot]) * H * I;
+    const float scale = gw[slot];
+    const int lo = first * TILE_ROWS, hi = (first + count) * TILE_ROWS;
+    constexpr int kVec = I / 8;
+    const int4 *xv = reinterpret_cast<const int4 *>(xs);
+
+    for (int row = lo + warp; row < hi; row += WARPS) {
+        const int4 *wv = reinterpret_cast<const int4 *>(w + size_t(row) * I);
+        float part[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+        for (int v = lane; v < kVec; v += 32) {
+            const int4 a = wv[v], b = xv[v];
+            const bf16 *pa = reinterpret_cast<const bf16 *>(&a);
+            const bf16 *pb = reinterpret_cast<const bf16 *>(&b);
+#pragma unroll
+            for (int k = 0; k < 8; ++k) part[k] += ld(pa + k) * ld(pb + k);
+        }
+        float dot = (part[0] + part[1]) + (part[2] + part[3]) +
+                    ((part[4] + part[5]) + (part[6] + part[7]));
+        dot = ops::warp_reduce<ops::warp_sum>(dot);
+        // Six experts land on the same row, so the accumulation is atomic. The
+        // reference sums them in f32 too; only the order differs, which is a
+        // part in 1e7 against a budget of parts in 1e3.
+        if (lane == 0) atomicAdd(&acc[row], bf(dot) * scale);
+    }
+}
+
+/// The shared expert's up projection. Every token goes through it, so it is not
+/// selected and takes no routing weight.
+__global__ __launch_bounds__(THREADS) void k_moe_shared_up(
+    const bf16 *__restrict__ h2, const bf16 *__restrict__ w_sh_up,
+    bf16 *__restrict__ smid) {
+    __shared__ __align__(16) bf16 xs[H];
+    for (int i = int(threadIdx.x); i < H; i += THREADS) xs[i] = h2[i];
+    ops::sync<ops::SyncKind::syncthreads>();
+    int first, count;
+    tile_span(SH_UP_TILES, int(blockIdx.x), int(gridDim.x), &first, &count);
+    const int lo = first * TILE_ROWS, hi = (first + count) * TILE_ROWS;
+    gemv_rows_direct<H>(w_sh_up, xs, smid, lo, hi - lo);
+    ops::sync<ops::SyncKind::syncthreads>();
+    for (int row = lo + int(threadIdx.x); row < hi; row += THREADS) {
+        const float v = fmaxf(ld(smid + row), 0.0f);
+        smid[row] = __float2bfloat16(bf(v) * bf(v));
+    }
+}
+
+/// The shared expert's down projection, the routed sum, and the residual.
+///
+/// The routed experts land in bf16 once, after all six have been summed in f32
+/// -- ``(total.to(bf16) + sh)`` -- so the accumulator arrives here still in f32.
+__global__ __launch_bounds__(THREADS) void k_moe_finish(
+    const bf16 *__restrict__ smid, const bf16 *__restrict__ w_sh_down,
+    const float *__restrict__ acc, const bf16 *__restrict__ h_in,
+    bf16 *__restrict__ h_out) {
+    __shared__ __align__(16) bf16 xs[IS];
+    for (int i = int(threadIdx.x); i < IS; i += THREADS) xs[i] = smid[i];
+    ops::sync<ops::SyncKind::syncthreads>();
+
+    const int warp = threadIdx.x >> 5;
+    const int lane = threadIdx.x & 31;
+    int first, count;
+    tile_span(DOWN_TILES, int(blockIdx.x), int(gridDim.x), &first, &count);
+    const int lo = first * TILE_ROWS, hi = (first + count) * TILE_ROWS;
+    constexpr int kVec = IS / 8;
+    const int4 *xv = reinterpret_cast<const int4 *>(xs);
+
+    for (int row = lo + warp; row < hi; row += WARPS) {
+        const int4 *wv = reinterpret_cast<const int4 *>(w_sh_down + size_t(row) * IS);
+        float part[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+        for (int v = lane; v < kVec; v += 32) {
+            const int4 a = wv[v], b = xv[v];
+            const bf16 *pa = reinterpret_cast<const bf16 *>(&a);
+            const bf16 *pb = reinterpret_cast<const bf16 *>(&b);
+#pragma unroll
+            for (int k = 0; k < 8; ++k) part[k] += ld(pa + k) * ld(pb + k);
+        }
+        float dot = (part[0] + part[1]) + (part[2] + part[3]) +
+                    ((part[4] + part[5]) + (part[6] + part[7]));
+        dot = ops::warp_reduce<ops::warp_sum>(dot);
+        if (lane == 0) {
+            // The routed experts land in bf16 once, after all six have summed
+            // in f32 -- `(total.to(bf16) + sh)`.
+            const float mix = bf(bf(acc[row]) + bf(dot));
+            h_out[row] = __float2bfloat16(ld(h_in + row) + mix);
+        }
+    }
+}
+
+/// One MoE layer: router, six routed experts, the shared expert, the residual.
+std::vector<torch::Tensor> moe_layer(
+    torch::Tensor h, torch::Tensor gamma, torch::Tensor w_router,
+    torch::Tensor e_bias, torch::Tensor w_up, torch::Tensor w_down,
+    torch::Tensor w_sh_up, torch::Tensor w_sh_down) {
+    check_bf16(h, H, "h");
+    check_bf16(gamma, H, "gamma");
+    check_bf16(w_router, int64_t(E) * H, "w_router");
+    TORCH_CHECK(e_bias.is_cuda() && e_bias.is_contiguous() &&
+                    e_bias.scalar_type() == at::kFloat && e_bias.numel() == E,
+                "e_bias must be a contiguous f32 CUDA tensor of E");
+    check_bf16(w_up, int64_t(E) * I * H, "w_up");
+    check_bf16(w_down, int64_t(E) * H * I, "w_down");
+    check_bf16(w_sh_up, int64_t(IS) * H, "w_sh_up");
+    check_bf16(w_sh_down, int64_t(H) * IS, "w_sh_down");
+
+    const auto bf_opt = h.options();
+    const auto f_opt = h.options().dtype(at::kFloat);
+    auto h2 = torch::empty({H}, bf_opt);
+    auto idx = torch::empty({KTOP}, h.options().dtype(at::kInt));
+    auto gw = torch::empty({KTOP}, f_opt);
+    auto mid = torch::empty({KTOP, I}, bf_opt);
+    auto smid = torch::empty({IS}, bf_opt);
+    auto acc = torch::zeros({H}, f_opt);
+    auto h_out = torch::empty({H}, bf_opt);
+
+    auto stream = at::cuda::getCurrentCUDAStream();
+    const int ctas = sm_count();
+    // No dynamic shared memory: these read their weights straight from gmem,
+    // and a dynamic allocation would cap how many CTAs an SM can hold for
+    // nothing in return.
+
+    auto *H2 = static_cast<bf16 *>(h2.data_ptr());
+    auto *IDX = static_cast<int *>(idx.data_ptr());
+    auto *GW = static_cast<float *>(gw.data_ptr());
+    auto *MID = static_cast<bf16 *>(mid.data_ptr());
+
+    auto logits = torch::empty({E}, f_opt);
+    k_moe_logits<<<ctas, THREADS, 0, stream>>>(
+        static_cast<const bf16 *>(h.data_ptr()),
+        static_cast<const bf16 *>(gamma.data_ptr()),
+        static_cast<const bf16 *>(w_router.data_ptr()), H2,
+        static_cast<float *>(logits.data_ptr()));
+    k_moe_topk<<<1, 32, 0, stream>>>(
+        static_cast<const float *>(logits.data_ptr()),
+        static_cast<const float *>(e_bias.data_ptr()), IDX, GW);
+    k_moe_up<<<dim3(ctas, KTOP), THREADS, 0, stream>>>(
+        H2, static_cast<const bf16 *>(w_up.data_ptr()), IDX, MID);
+    k_moe_down<<<dim3(ctas, KTOP), THREADS, 0, stream>>>(
+        MID, static_cast<const bf16 *>(w_down.data_ptr()), IDX, GW,
+        static_cast<float *>(acc.data_ptr()));
+    k_moe_shared_up<<<ctas, THREADS, 0, stream>>>(
+        H2, static_cast<const bf16 *>(w_sh_up.data_ptr()),
+        static_cast<bf16 *>(smid.data_ptr()));
+    k_moe_finish<<<ctas, THREADS, 0, stream>>>(
+        static_cast<const bf16 *>(smid.data_ptr()),
+        static_cast<const bf16 *>(w_sh_down.data_ptr()),
+        static_cast<const float *>(acc.data_ptr()),
+        static_cast<const bf16 *>(h.data_ptr()),
+        static_cast<bf16 *>(h_out.data_ptr()));
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return {h_out, idx, gw, h2, mid, smid, acc};
+}
+
 }  // namespace
 
-PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) { m.def("mamba_layer", &mamba_layer); }
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+    m.def("mamba_layer", &mamba_layer);
+    m.def("moe_layer", &moe_layer);
+}

--- a/examples/nemotron_3_5_lightning_30b_a3b-tilelang/kernels/nemotron.cu
+++ b/examples/nemotron_3_5_lightning_30b_a3b-tilelang/kernels/nemotron.cu
@@ -41,6 +41,14 @@ constexpr int HPG = 8;
 constexpr float EPS = 1e-5f;
 constexpr float DTMIN = 0.001f;
 
+constexpr int HQ = 32;
+constexpr int HKV = 2;
+constexpr int DH = 128;
+constexpr int QP = 4096;
+constexpr int KVP = 256;
+constexpr int GQA = 16;
+constexpr float QSCALE = 0.08838834764831845f;
+
 constexpr int E = 128;
 constexpr int KTOP = 6;
 constexpr int I = 1856;
@@ -782,9 +790,237 @@ std::vector<torch::Tensor> moe_layer(
     return {h_out, idx, gw, h2, mid, smid, acc};
 }
 
+/// Keys per CTA of the attention scan.
+///
+/// The scan is split over the context because at 262080 positions one CTA per
+/// head would leave 130 of the 132 SMs idle. Each CTA folds its own block into
+/// a running (max, sum, accumulator) and `k_attn_combine` merges the blocks,
+/// which is what makes reading them separately the same value as one softmax
+/// over their concatenation.
+constexpr int ABLK = 256;
+constexpr int ATT_THREADS = 256;
+constexpr int ATT_WARPS = ATT_THREADS / 32;
+constexpr int Q_PER_WARP = GQA / ATT_WARPS;
+
+/// One block of keys, for one KV head, folded into a partial softmax.
+///
+/// Lane `l` takes key `base + l`, so a lane's 128 dot products are serial and no
+/// reduction crosses the warp for a score. The softmax over the 32 keys a warp
+/// holds is two warp folds, and the value accumulation broadcasts each weight
+/// back with a shuffle.
+__global__ __launch_bounds__(ATT_THREADS) void k_attn_block(
+    const bf16 *__restrict__ q, const bf16 *__restrict__ kc,
+    const bf16 *__restrict__ vc, int nkey, int blk_offset,
+    float *__restrict__ pm, float *__restrict__ pl, float *__restrict__ pacc) {
+    const int blk = int(blockIdx.x);
+    const int head = int(blockIdx.y);
+    const int warp = threadIdx.x >> 5;
+    const int lane = threadIdx.x & 31;
+
+    __shared__ __align__(16) bf16 qs[GQA * DH];
+    for (int i = int(threadIdx.x); i < GQA * DH; i += ATT_THREADS)
+        qs[i] = q[size_t(head) * GQA * DH + i];
+    ops::sync<ops::SyncKind::syncthreads>();
+
+    const int lo = blk * ABLK;
+    const int hi = min(lo + ABLK, nkey);
+
+    for (int qi = 0; qi < Q_PER_WARP; ++qi) {
+        const int g = warp * Q_PER_WARP + qi;
+        const bf16 *qrow = qs + g * DH;
+        float m = -INFINITY, l = 0.0f;
+        float acc[DH / 32];
+#pragma unroll
+        for (int i = 0; i < DH / 32; ++i) acc[i] = 0.0f;
+
+        for (int base = lo; base < hi; base += 32) {
+            const int key = base + lane;
+            /// `raw` lands in bf16 before the scale, because
+            /// `matmul(qg, kh.t())` is a bf16 matmul and only then `.float()`.
+            float s = -INFINITY;
+            if (key < hi) {
+                const bf16 *krow = kc + (size_t(key) * HKV + head) * DH;
+                float part[4] = {0, 0, 0, 0};
+#pragma unroll
+                for (int d = 0; d < DH; d += 4)
+#pragma unroll
+                    for (int u = 0; u < 4; ++u)
+                        part[u] += ld(krow + d + u) * ld(qrow + d + u);
+                s = bf(part[0] + part[1] + part[2] + part[3]) * QSCALE;
+            }
+            const float bm = ops::warp_reduce<ops::warp_max>(s);
+            const float nm = fmaxf(m, bm);
+            const float cr = (m == -INFINITY) ? 0.0f : __expf(m - nm);
+            const float pw = (key < hi) ? __expf(s - nm) : 0.0f;
+            l = l * cr + ops::warp_reduce<ops::warp_sum>(pw);
+#pragma unroll
+            for (int i = 0; i < DH / 32; ++i) acc[i] *= cr;
+            /// The weights are per key, the accumulator per dim, so each key's
+            /// weight comes back to every lane with a shuffle rather than
+            /// through shared memory.
+            for (int j = 0; j < 32; ++j) {
+                const float w = __shfl_sync(0xFFFFFFFFu, pw, j);
+                const int kj = base + j;
+                if (kj >= hi || w == 0.0f) continue;
+                const bf16 *vrow = vc + (size_t(kj) * HKV + head) * DH;
+#pragma unroll
+                for (int i = 0; i < DH / 32; ++i)
+                    acc[i] += w * ld(vrow + lane + i * 32);
+            }
+            m = nm;
+        }
+        const size_t at = (size_t(blk_offset + blk) * HKV + head) * GQA + g;
+        if (lane == 0) {
+            pm[at] = m;
+            pl[at] = l;
+        }
+#pragma unroll
+        for (int i = 0; i < DH / 32; ++i)
+            pacc[at * DH + lane + i * 32] = acc[i];
+    }
+}
+
+/// Merge the per-block partials into the context vector.
+///
+/// One CTA per (head, query). The merge is the same online step the blocks ran,
+/// applied across them, so splitting the scan changes nothing about the value.
+__global__ __launch_bounds__(DH) void k_attn_combine(
+    const float *__restrict__ pm, const float *__restrict__ pl,
+    const float *__restrict__ pacc, int nblock, bf16 *__restrict__ ctx) {
+    const int head = int(blockIdx.y);
+    const int g = int(blockIdx.x);
+    const int d = int(threadIdx.x);
+
+    float m = -INFINITY, l = 0.0f, acc = 0.0f;
+    for (int b = 0; b < nblock; ++b) {
+        const size_t at = (size_t(b) * HKV + head) * GQA + g;
+        const float bm = pm[at];
+        if (bm == -INFINITY) continue;
+        const float nm = fmaxf(m, bm);
+        const float cr = (m == -INFINITY) ? 0.0f : __expf(m - nm);
+        const float br = __expf(bm - nm);
+        l = l * cr + pl[at] * br;
+        acc = acc * cr + pacc[at * DH + d] * br;
+        m = nm;
+    }
+    ctx[(size_t(head) * GQA + g) * DH + d] = __float2bfloat16(acc / l);
+}
+
+constexpr int QKV = QP + 2 * KVP;
+constexpr int QKV_TILES = QKV / TILE_ROWS;
+constexpr int O_TILES = H / TILE_ROWS;
+
+/// Pre-norm, the fused Q/K/V projection, and this token's row of the cache.
+///
+/// `cache_update`, realised on the cache's own buffer: the row this token adds
+/// is written where the scan will read it, so nothing is copied between steps.
+__global__ __launch_bounds__(THREADS) void k_qkv(
+    const bf16 *__restrict__ h, const bf16 *__restrict__ gamma,
+    const bf16 *__restrict__ w_qkv, bf16 *__restrict__ qkv,
+    bf16 *__restrict__ k_tail, bf16 *__restrict__ v_tail, int cur_pos) {
+    extern __shared__ __align__(16) char raw[];
+    ProjSmem<H, IN_STAGES> sm(raw);
+    rms_norm_to_smem(h, gamma, sm.x, sm.slots);
+    ops::sync<ops::SyncKind::syncthreads>();
+    int first, count;
+    tile_span(QKV_TILES, int(blockIdx.x), int(gridDim.x), &first, &count);
+    gemv_rows<H, IN_STAGES>(w_qkv, sm.x, qkv, first, count, sm.stage, sm.bars);
+    ops::sync<ops::SyncKind::syncthreads>();
+
+    const int lo = first * TILE_ROWS, hi = (first + count) * TILE_ROWS;
+    for (int row = lo + int(threadIdx.x); row < hi; row += THREADS) {
+        if (row < QP) continue;
+        const int off = row - QP;
+        bf16 *dst = (off < KVP ? k_tail : v_tail) +
+                    (size_t(cur_pos) * HKV * DH) + (off % KVP);
+        *dst = qkv[row];
+    }
+}
+
+/// The output projection and the residual add.
+__global__ __launch_bounds__(THREADS) void k_o_proj(
+    const bf16 *__restrict__ ctx, const bf16 *__restrict__ w_o,
+    const bf16 *__restrict__ h_in, bf16 *__restrict__ h_out) {
+    __shared__ __align__(16) bf16 xs[QP];
+    for (int i = int(threadIdx.x); i < QP; i += THREADS) xs[i] = ctx[i];
+    ops::sync<ops::SyncKind::syncthreads>();
+    int first, count;
+    tile_span(O_TILES, int(blockIdx.x), int(gridDim.x), &first, &count);
+    gemv_rows_direct<QP>(w_o, xs, h_out, first * TILE_ROWS, count * TILE_ROWS,
+                         h_in);
+}
+
+/// One full-attention layer.
+std::vector<torch::Tensor> attn_layer(
+    torch::Tensor h, torch::Tensor gamma, torch::Tensor w_qkv, torch::Tensor w_o,
+    torch::Tensor k_cache, torch::Tensor v_cache, torch::Tensor k_tail,
+    torch::Tensor v_tail, int64_t cur_pos) {
+    check_bf16(h, H, "h");
+    check_bf16(gamma, H, "gamma");
+    check_bf16(w_qkv, int64_t(QKV) * H, "w_qkv");
+    check_bf16(w_o, int64_t(H) * QP, "w_o");
+
+    const int ctx_full = int(k_cache.numel() / (int64_t(HKV) * DH));
+    const int ctx_tail = int(k_tail.numel() / (int64_t(HKV) * DH));
+    TORCH_CHECK(cur_pos >= 0 && cur_pos < ctx_tail, "cur_pos out of the tail");
+
+    const auto bf_opt = h.options();
+    const auto f_opt = h.options().dtype(at::kFloat);
+    auto qkv = torch::empty({QKV}, bf_opt);
+    auto ctx = torch::empty({QP}, bf_opt);
+    auto h_out = torch::empty({H}, bf_opt);
+
+    const int nb_full = (ctx_full + ABLK - 1) / ABLK;
+    // The tail holds `cur_pos + 1` live rows: this token's is the last written.
+    const int live_tail = int(cur_pos) + 1;
+    const int nb_tail = (live_tail + ABLK - 1) / ABLK;
+    const int nblock = nb_full + nb_tail;
+
+    auto pm = torch::empty({nblock, HKV, GQA}, f_opt);
+    auto pl = torch::empty({nblock, HKV, GQA}, f_opt);
+    auto pacc = torch::empty({nblock, HKV, GQA, DH}, f_opt);
+
+    auto stream = at::cuda::getCurrentCUDAStream();
+    const int ctas = sm_count();
+    constexpr size_t kQkv = ProjSmem<H, IN_STAGES>::bytes();
+    allow_smem(k_qkv, kQkv);
+
+    k_qkv<<<ctas, THREADS, kQkv, stream>>>(
+        static_cast<const bf16 *>(h.data_ptr()),
+        static_cast<const bf16 *>(gamma.data_ptr()),
+        static_cast<const bf16 *>(w_qkv.data_ptr()),
+        static_cast<bf16 *>(qkv.data_ptr()),
+        static_cast<bf16 *>(k_tail.data_ptr()),
+        static_cast<bf16 *>(v_tail.data_ptr()), int(cur_pos));
+
+    auto *Q = static_cast<bf16 *>(qkv.data_ptr());
+    auto *PM = static_cast<float *>(pm.data_ptr());
+    auto *PL = static_cast<float *>(pl.data_ptr());
+    auto *PA = static_cast<float *>(pacc.data_ptr());
+    if (nb_full)
+        k_attn_block<<<dim3(nb_full, HKV), ATT_THREADS, 0, stream>>>(
+            Q, static_cast<const bf16 *>(k_cache.data_ptr()),
+            static_cast<const bf16 *>(v_cache.data_ptr()), ctx_full, 0, PM, PL, PA);
+    if (nb_tail)
+        k_attn_block<<<dim3(nb_tail, HKV), ATT_THREADS, 0, stream>>>(
+            Q, static_cast<const bf16 *>(k_tail.data_ptr()),
+            static_cast<const bf16 *>(v_tail.data_ptr()), live_tail, nb_full,
+            PM, PL, PA);
+    k_attn_combine<<<dim3(GQA, HKV), DH, 0, stream>>>(
+        PM, PL, PA, nblock, static_cast<bf16 *>(ctx.data_ptr()));
+    k_o_proj<<<ctas, THREADS, 0, stream>>>(
+        static_cast<const bf16 *>(ctx.data_ptr()),
+        static_cast<const bf16 *>(w_o.data_ptr()),
+        static_cast<const bf16 *>(h.data_ptr()),
+        static_cast<bf16 *>(h_out.data_ptr()));
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return {h_out, qkv, ctx};
+}
+
 }  // namespace
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     m.def("mamba_layer", &mamba_layer);
     m.def("moe_layer", &moe_layer);
+    m.def("attn_layer", &attn_layer);
 }

--- a/examples/nemotron_3_5_lightning_30b_a3b-tilelang/kernels/nemotron.cu
+++ b/examples/nemotron_3_5_lightning_30b_a3b-tilelang/kernels/nemotron.cu
@@ -112,9 +112,8 @@ constexpr int TILE_ROWS = WARPS;
 /// matmul does.
 template <int IN, int STAGES>
 __device__ void gemv_rows(const bf16 *__restrict__ w, const bf16 *__restrict__ x,
-                          bf16 *__restrict__ out, int tile0, int ntiles,
-                          bf16 *stage, uint64_t *bars,
-                          const bf16 *__restrict__ resid = nullptr) {
+                          bf16 *out, int tile0, int ntiles, bf16 *stage,
+                          uint64_t *bars, const bf16 *resid = nullptr) {
     constexpr unsigned kBytes = unsigned(TILE_ROWS) * IN * sizeof(bf16);
     constexpr int kTileElems = TILE_ROWS * IN;
     const int warp = threadIdx.x >> 5;
@@ -187,8 +186,8 @@ __device__ void gemv_rows(const bf16 *__restrict__ w, const bf16 *__restrict__ x
 template <int IN>
 __device__ void gemv_rows_direct(const bf16 *__restrict__ w,
                                  const bf16 *__restrict__ x,
-                                 bf16 *__restrict__ out, int row0, int nrows,
-                                 const bf16 *__restrict__ resid = nullptr) {
+                                 bf16 *out, int row0, int nrows,
+                                 const bf16 *resid = nullptr) {
     static_assert(IN % 8 == 0, "gemv_rows_direct: IN must be a multiple of 8");
     constexpr int kVec = IN / 8;
     const int warp = threadIdx.x >> 5;
@@ -783,8 +782,7 @@ __device__ void s_moe_finish(int cta, int nctas, const bf16 *__restrict__ smid, 
 
 __global__ __launch_bounds__(THREADS) void k_moe_finish(
     const bf16 *__restrict__ smid, const bf16 *__restrict__ w_sh_down,
-    const float *__restrict__ acc, const bf16 *__restrict__ h_in,
-    bf16 *__restrict__ h_out) {
+    const float *__restrict__ acc, const bf16 *h_in, bf16 *h_out) {
     s_moe_finish(int(blockIdx.x), int(gridDim.x), smid, w_sh_down, acc, h_in, h_out);
 }
 

--- a/examples/nemotron_3_5_lightning_30b_a3b-tilelang/mega_kernel.py
+++ b/examples/nemotron_3_5_lightning_30b_a3b-tilelang/mega_kernel.py
@@ -133,83 +133,24 @@ F_SH = F_MIX + (H + CTAS - 1) // CTAS + 1
 SUMSLOT = 4 * HQ
 MAXSLOT = 4 * HQ + 1
 
-PACK = {
-    "win": (N_MAMBA, PROJ, H), "wout": (N_MAMBA, H, MI),
-    "convw": (N_MAMBA, CONV, KER), "convb": (N_MAMBA, CONV), "ggdn": (N_MAMBA, MI),
-    "wqkv": (N_ATTN, QP + 2 * KVP, H), "wo": (N_ATTN, H, QP),
-    "wrt": (N_MOE, E, H), "wup": (N_MOE, E, I, H), "wdn": (N_MOE, E, H, I),
-    "wsu": (N_MOE, IS, H), "wsd": (N_MOE, H, IS),
-    "gam": (NL, H), "table": (V, H), "whead": (V, H),
-    "mscal": (N_MAMBA, 3, MH), "gf": (H,),
-}
-PACK_F32 = {"eb": (N_MOE, E)}
-PACK_ORDER = list(PACK) + list(PACK_F32)
-RING = 4
-
-
-def _numel(shape):
-    n = 1
-    for s in shape:
-        n *= s
-    return n
+#: The weight layout lives in `packing.py`, not here. It is a property of the
+#: model rather than of this backend, and the handwritten CUDA path reads the
+#: same one -- two copies could drift and a drifted layout is a silently wrong
+#: weight rather than an error.
+from packing import (  # noqa: E402
+    PACK,
+    PACK_F32,
+    PACK_ORDER,
+    RING,
+    Packed,
+    _numel,
+    pack_into,
+)
 
 
 def bf(x):
     """Round to bf16 and go on in f32, the way a bf16 op does."""
     return T.Cast("float32", T.Cast("bfloat16", x))
-
-
-class Packed:
-    """Every weight of one class in one flat tensor."""
-
-    def __init__(self, device):
-        self.shape = dict(PACK) | dict(PACK_F32)
-        self.t = {n: torch.zeros(_numel(s), dtype=torch.bfloat16, device=device)
-                  for n, s in PACK.items()}
-        self.t.update({n: torch.zeros(_numel(s), dtype=torch.float32, device=device)
-                       for n, s in PACK_F32.items()})
-
-    def view(self, name):
-        return self.t[name].view(self.shape[name])
-
-    def flat_order(self):
-        return [self.t[n] for n in PACK_ORDER]
-
-
-def pack_into(packed: Packed, name: str, value: torch.Tensor):
-    """Copy one declared weight into its slot; return the view standing for it."""
-    def put(key, *idx):
-        dst = packed.view(key)
-        for j in idx:
-            dst = dst[j]
-        dst.copy_(value.reshape(dst.shape).to(dst.dtype))
-        return dst
-
-    if name in ("table", "w_head"):
-        return put({"table": "table", "w_head": "whead"}[name])
-    if name == "gamma_final":
-        return put("gf")
-    layer = int(name.split("_")[0][1:])
-    kid, at = _LAYER_META[layer]
-    tail = name[name.index("_") + 1:]
-    if tail == "gamma":
-        return put("gam", layer)
-    if kid == 0:
-        simple = {"w_in": "win", "w_out": "wout", "conv_w": "convw",
-                  "conv_b": "convb", "gamma_gdn": "ggdn"}
-        if tail in simple:
-            return put(simple[tail], at)
-        return put("mscal", at, {"a_log": 0, "dt_bias": 1, "d_skip": 2}[tail])
-    if kid == 1:
-        if tail == "w_o":
-            return put("wo", at)
-        off = {"w_q": 0, "w_k": QP, "w_v": QP + KVP}[tail]
-        dst = packed.view("wqkv")[at, off:off + value.shape[0]]
-        dst.copy_(value)
-        return dst
-    simple = {"w_router": "wrt", "w_up": "wup", "w_down": "wdn",
-              "w_sh_up": "wsu", "w_sh_down": "wsd", "e_bias": "eb"}
-    return put(simple[tail], at)
 
 
 @tilelang.jit

--- a/examples/nemotron_3_5_lightning_30b_a3b-tilelang/packing.py
+++ b/examples/nemotron_3_5_lightning_30b_a3b-tilelang/packing.py
@@ -1,0 +1,116 @@
+"""Where every declared weight sits once the twin has packed it.
+
+A kernel cannot take 401 pointers, so the twin holds one flat tensor per weight
+class -- layers stacked on the leading axis -- and addresses any of them by
+(layer, row). That layout is a property of the model, not of any one backend,
+so it lives here: `mega_kernel.py` reads it and so does the handwritten CUDA
+path, and neither can drift from the other.
+
+Nothing here imports a backend. The twin's `load` runs before an
+implementation is chosen, and making it import one would make every
+implementation need every backend installed.
+"""
+from __future__ import annotations
+
+import torch
+
+import model
+
+KINDS = model.LAYER_KINDS
+NL = len(KINDS)
+
+H, V, EPS = model.H, model.V, model.EPS
+MH, MD, SS, NG, MI, CONV, KER, WIN, PROJ = (model.MH, model.MD, model.SS, model.NG,
+                                            model.MI, model.CONV, model.KER, model.WIN,
+                                            model.PROJ)
+GRP, HPG, DTMIN = model.GRP, model.HPG, model.DTMIN
+HQ, HKV, DH, QP, KVP, GQA, QSCALE = (model.HQ, model.HKV, model.DH, model.QP,
+                                     model.KVP, model.GQA, model.QSCALE)
+E, KTOP, I, IS, RSCALE = model.E, model.K, model.I, model.IS, model.RSCALE
+KINDS = model.LAYER_KINDS
+
+_KIND_ID = {"linear_attention": 0, "full_attention": 1, "moe": 2}
+_LAYER_META, _seen = [], {0: 0, 1: 0, 2: 0}
+for _k in KINDS:
+    _LAYER_META.append((_KIND_ID[_k], _seen[_KIND_ID[_k]]))
+    _seen[_KIND_ID[_k]] += 1
+N_MAMBA, N_ATTN, N_MOE = _seen[0], _seen[1], _seen[2]
+PACK = {
+    "win": (N_MAMBA, PROJ, H), "wout": (N_MAMBA, H, MI),
+    "convw": (N_MAMBA, CONV, KER), "convb": (N_MAMBA, CONV), "ggdn": (N_MAMBA, MI),
+    "wqkv": (N_ATTN, QP + 2 * KVP, H), "wo": (N_ATTN, H, QP),
+    "wrt": (N_MOE, E, H), "wup": (N_MOE, E, I, H), "wdn": (N_MOE, E, H, I),
+    "wsu": (N_MOE, IS, H), "wsd": (N_MOE, H, IS),
+    "gam": (NL, H), "table": (V, H), "whead": (V, H),
+    "mscal": (N_MAMBA, 3, MH), "gf": (H,),
+}
+PACK_F32 = {"eb": (N_MOE, E)}
+PACK_ORDER = list(PACK) + list(PACK_F32)
+RING = 4
+
+
+def _numel(shape):
+    n = 1
+    for s in shape:
+        n *= s
+    return n
+
+
+def bf(x):
+    """Round to bf16 and go on in f32, the way a bf16 op does."""
+    return T.Cast("float32", T.Cast("bfloat16", x))
+
+
+class Packed:
+    """Every weight of one class in one flat tensor."""
+
+    def __init__(self, device):
+        self.shape = dict(PACK) | dict(PACK_F32)
+        self.t = {n: torch.zeros(_numel(s), dtype=torch.bfloat16, device=device)
+                  for n, s in PACK.items()}
+        self.t.update({n: torch.zeros(_numel(s), dtype=torch.float32, device=device)
+                       for n, s in PACK_F32.items()})
+
+    def view(self, name):
+        return self.t[name].view(self.shape[name])
+
+    def flat_order(self):
+        return [self.t[n] for n in PACK_ORDER]
+
+
+def pack_into(packed: Packed, name: str, value: torch.Tensor):
+    """Copy one declared weight into its slot; return the view standing for it."""
+    def put(key, *idx):
+        dst = packed.view(key)
+        for j in idx:
+            dst = dst[j]
+        dst.copy_(value.reshape(dst.shape).to(dst.dtype))
+        return dst
+
+    if name in ("table", "w_head"):
+        return put({"table": "table", "w_head": "whead"}[name])
+    if name == "gamma_final":
+        return put("gf")
+    layer = int(name.split("_")[0][1:])
+    kid, at = _LAYER_META[layer]
+    tail = name[name.index("_") + 1:]
+    if tail == "gamma":
+        return put("gam", layer)
+    if kid == 0:
+        simple = {"w_in": "win", "w_out": "wout", "conv_w": "convw",
+                  "conv_b": "convb", "gamma_gdn": "ggdn"}
+        if tail in simple:
+            return put(simple[tail], at)
+        return put("mscal", at, {"a_log": 0, "dt_bias": 1, "d_skip": 2}[tail])
+    if kid == 1:
+        if tail == "w_o":
+            return put("wo", at)
+        off = {"w_q": 0, "w_k": QP, "w_v": QP + KVP}[tail]
+        dst = packed.view("wqkv")[at, off:off + value.shape[0]]
+        dst.copy_(value)
+        return dst
+    simple = {"w_router": "wrt", "w_up": "wup", "w_down": "wdn",
+              "w_sh_up": "wsu", "w_sh_down": "wsd", "e_bias": "eb"}
+    return put(simple[tail], at)
+
+

--- a/examples/nemotron_3_5_lightning_30b_a3b-tilelang/reports/WHY_SLOWER.md
+++ b/examples/nemotron_3_5_lightning_30b_a3b-tilelang/reports/WHY_SLOWER.md
@@ -90,7 +90,42 @@ changing a single arithmetic result.
   0.7 ms of the 5.49. Merging stages to save some of it costs the clarity of
   having one barrier per reshard the authored program states.
 
-## 6. What could not be measured
+## 6. The open fault: the fused path is not token-identical
+
+`NEMO_IMPL=cuda-stages` matches `transformers` for 64 of 64 greedy steps.
+`NEMO_IMPL=cuda` diverges at step 35. They run the same `__device__` stages, so
+the difference is in what one resident launch does between them.
+
+Bisected by stopping the layer walk early and comparing the hidden row against
+the same stages run a launch apiece:
+
+| after layer | rel_l2 |
+|---|---|
+| 1 – 8 | **0** (bit-identical) |
+| 12 | 5.5e-4 |
+| 19 – 33 | 5–7e-4 (flat) |
+| 40 | 7.6e-3 |
+
+Eight layers bit-identical rules out a logic error in any stage: a wrong index or
+a missing barrier does not wait until the ninth layer. What is left is a
+reproducibility difference — the fused path rounds somewhere the staged path does
+not — that stays inside every bound `check_all.py` derives and still costs token
+identity, because greedy decoding has no tolerance at all.
+
+Two candidates, neither confirmed:
+
+- **Scratch reuse.** The fused launch keeps one set of buffers for all 52 layers;
+  the staged path allocates each layer's afresh. Every buffer is written before
+  it is read on the paths checked, but "checked" is by reading the code, not by
+  a tool.
+- **The head.** `cuda-stages` finishes in torch (`fh @ w_head.t()`), the fused
+  path in `s_head`. That explains a difference in the logits and nothing about
+  the states, which also differ.
+
+Until this is understood the fused path should not be described as
+token-identical, and `README.md` does not.
+
+## 7. What could not be measured
 
 `ncu` does not run on this machine: `ERR_NVGPUCTRPERM`, GPU performance counters
 are restricted to administrators. Everything above rests on `nsys` kernel tracing

--- a/examples/nemotron_3_5_lightning_30b_a3b-tilelang/reports/WHY_SLOWER.md
+++ b/examples/nemotron_3_5_lightning_30b_a3b-tilelang/reports/WHY_SLOWER.md
@@ -1,0 +1,100 @@
+# Why the handwritten kernel is slower than the TileLang one
+
+Measured on one H200, one session, `torch 2.14.0+cu130`. The TileLang numbers are
+re-measured here rather than quoted: the figures in `README.md:301` were taken on
+another day and are **16–17% below** what the same kernel does today, so using
+them as the bar would let a 17%-slower implementation look level.
+
+| ctx | `README.md:301` records | measured today |
+|---|---|---|
+| 32 | 287.4 tok/s | **335.87 tok/s** |
+| 262080 | 231.6 tok/s | **268.19 tok/s** |
+
+## 1. Where it stands
+
+| | ctx 32 | ms/token |
+|---|---|---|
+| TileLang, one cooperative launch | **335.9 tok/s** | 2.977 |
+| handwritten, one cooperative launch | **182.0 tok/s** | 5.495 |
+
+1.85x off. Against the TileLang kernel the whole step lands at 4.513e-2 on the
+5.018e-2 envelope `check_all.py` derives, with the same argmax at every step.
+Token identity is where the fused path and the stage-per-launch path part: the
+staged one matches `transformers` for 64 of 64 greedy steps, the fused one
+diverges at step 35. They run the same device code, so that is an open fault of
+the resident launch, not of the arithmetic, and it is not diagnosed here.
+
+## 2. Which layers
+
+Inside the launch, by timing prefixes of the layer walk:
+
+| layer kind | count | in the fused launch | as separate launches | ratio |
+|---|---|---|---|---|
+| Mamba-2 | 23 | 63.9 us | 49.8 us | 1.28x |
+| MoE | 23 | 123.1 us | 114.2 us | 1.08x |
+| **attention** | **6** | **260.7 us** | **57.1 us** | **4.6x** |
+| closing norm + head | 1 | ~240 us | — | — |
+
+Weighted: MoE is 2.83 ms of the 5.49, attention 1.56 ms, Mamba-2 1.47 ms.
+
+## 3. What each gap is
+
+**The grid barrier costs about 2–3 us.** Mamba-2 pays 14.1 us over five barriers
+and MoE 8.9 us over five, which is the whole difference between fused and
+separate for those two. That is the price of being resident and it is a small
+one.
+
+**Attention does not fit that account.** Four barriers cannot be 203 us. At
+ctx 32 the scan is split over the context — `nb_tail * HKV` is 2 — so two CTAs
+do the scan and 130 wait at the barrier behind them. The split that long context
+needs is the wrong one at short context, which is the crossover
+`attention.py` dispatches on and which this kernel does not implement: it has one
+placement where the authored program has two.
+
+**MoE is the largest absolute cost and it is bandwidth, not structure.** Its four
+expert projections move 160 MB a layer and take 74 us of the 114, which is where
+the TileLang kernel's whole-step budget implies they should be. The remaining
+40 us is the gap between six launches and one.
+
+**The step as a whole moves 6.997 GB a token** (`README.md:302`). TileLang gets
+2.35 TB/s of that. This kernel gets 1.27 TB/s.
+
+## 4. What the two implementations do differently
+
+The TileLang kernel stages every projection's weight slice through shared memory
+three tiles ahead. This one does that for the Mamba-2 projections and the head,
+and reads the expert weights straight from global memory, because measured
+separately the choice inverts with how many tiles a CTA gets:
+
+| | staged | direct |
+|---|---|---|
+| Mamba-2 layer (about 78 rows a CTA) | **49.6 us** | 85.7 us |
+| MoE layer (under 2 tiles a CTA) | 320 us | **114 us** |
+
+In one resident kernel that trade-off is not free to make per stage: the launch
+has a single shared-memory request, and asking for the staged ring's 131 KB
+holds the grid at one CTA per SM for every stage, including the ones that would
+rather have four. Dropping the staged path from the two projections that did not
+need it took the step from 6.77 ms to 5.49 ms — 125 to 182 tok/s — without
+changing a single arithmetic result.
+
+## 5. What is fixable and what is not
+
+- **Attention's placement (fixable, ~1.3 ms).** Splitting by head at short
+  context, the way the authored program does, would put the other 130 CTAs to
+  work. The crossover `attention.py` already names is the number to dispatch on.
+- **The shared-memory ceiling (fixable, unquantified).** A staged path that fits
+  in a smaller ring, or a head that stages less, would let more CTAs per SM and
+  lift the expert projections nearer their 74 us floor.
+- **The barrier count (not worth it).** 5 barriers a layer at 2–3 us is about
+  0.7 ms of the 5.49. Merging stages to save some of it costs the clarity of
+  having one barrier per reshard the authored program states.
+
+## 6. What could not be measured
+
+`ncu` does not run on this machine: `ERR_NVGPUCTRPERM`, GPU performance counters
+are restricted to administrators. Everything above rests on `nsys` kernel tracing
+and on timing prefixes of the layer walk, so there is no occupancy figure, no
+stall-reason breakdown and no achieved-bandwidth counter for any single stage —
+only wall-clock against known byte counts. The one place that limitation bites is
+§5's second item, which is why it carries no number.

--- a/examples/nemotron_3_5_lightning_30b_a3b-tilelang/reports/WHY_SLOWER.md
+++ b/examples/nemotron_3_5_lightning_30b_a3b-tilelang/reports/WHY_SLOWER.md
@@ -15,7 +15,12 @@ them as the bar would let a 17%-slower implementation look level.
 | | ctx 32 | ms/token |
 |---|---|---|
 | TileLang, one cooperative launch | **335.9 tok/s** | 2.977 |
-| handwritten, one cooperative launch | **182.0 tok/s** | 5.495 |
+| handwritten, one cooperative launch | **153.6 tok/s** | 6.510 |
+
+End to end through `bench_mine.py`, which is the number to quote. Timing the
+launch alone in a tight loop gives 5.495 ms; the difference is the Python either
+implementation pays per step for `prepare_inputs_for_generation` and
+`append_cache`, and both pay it.
 
 1.85x off. Against the TileLang kernel the whole step lands at 4.513e-2 on the
 5.018e-2 envelope `check_all.py` derives, with the same argmax at every step.
@@ -78,7 +83,24 @@ rather have four. Dropping the staged path from the two projections that did not
 need it took the step from 6.77 ms to 5.49 ms — 125 to 182 tok/s — without
 changing a single arithmetic result.
 
-## 5. What is fixable and what is not
+## 5. Hypotheses that were wrong
+
+Recorded because the wrong ones outnumbered the right one four to two, and each
+was plausible enough to act on:
+
+| guessed | measured |
+|---|---|
+| twelve expert launches are the cost | fusing them to two: **13% faster** |
+| shared-memory staging starves occupancy | removing it from MoE: **no change** |
+| the accumulator dependency chain stalls the loads | eight accumulators: **3% faster** |
+| the router is fine, it reads 688 KB | it was **236 of the 319 us** — one thread per row, uncoalesced, one CTA |
+| aliasing `__restrict__` on the in-place residual explains the drift | it does not; the drift is the expert accumulator's summation order |
+| allocating 46 state tensors a step costs the missing millisecond | pooling them: **no change** |
+
+Only `nsys` and the layer-prefix timings moved this forward; every hypothesis
+formed by reading the code was wrong.
+
+## 6. What is fixable and what is not
 
 - **Attention's placement (fixable, ~1.3 ms).** Splitting by head at short
   context, the way the authored program does, would put the other 130 CTAs to
@@ -90,33 +112,49 @@ changing a single arithmetic result.
   0.7 ms of the 5.49. Merging stages to save some of it costs the clarity of
   having one barrier per reshard the authored program states.
 
-## 6. The open fault: the fused path is not token-identical
+## 7. Token identity is a knife edge, not a gate
 
-`NEMO_IMPL=cuda-stages` matches `transformers` for 64 of 64 greedy steps.
-`NEMO_IMPL=cuda` diverges at step 35. They run the same `__device__` stages, so
-the difference is in what one resident launch does between them.
+An earlier reading of this said the fused path had a fault of its own, because it
+diverged from `transformers` where the stage-per-launch path did not. That
+compared two different builds. Measured together — 48 steps, greedy,
+teacher-forced, three prompts:
 
-Bisected by stopping the layer walk early and comparing the hidden row against
-the same stages run a launch apiece:
+| prompt | `mega` (TileLang) | `cuda` (fused) | `cuda-stages` |
+|---|---|---|---|
+| `The capital of France is` | 48/48 | step 35 | step 35 |
+| `In 1969 the first humans` | step 3 | step 3 | step 3 |
+| `A prime number is` | step 42 | 48/48 | step 42 |
 
-| after layer | rel_l2 |
+Every implementation loses it on some prompt. On the middle one all three
+diverge at the same step and pick the same token as each other — a tie the
+reference resolves one way and all three of these resolve the other. Nothing here
+separates the handwritten kernels from the shipped one, and `README.md`'s "64 of
+64" is the first prompt with the TileLang kernel rather than a property any of
+them has in general.
+
+The two CUDA paths do differ from each other by a hair, and it is worth naming
+because it is the only genuine arithmetic difference between them. The six routed
+experts sum into an f32 accumulator: six concurrent CTAs in the staged path, one
+CTA six times in the fused path. On one layer, every other intermediate is
+bit-identical and the accumulator differs by 5.8e-8. Across the stack:
+
+| after layer | rel_l2 (fused against staged) |
 |---|---|
-| 1 – 8 | **0** (bit-identical) |
-| 12 | 5.5e-4 |
-| 19 – 33 | 5–7e-4 (flat) |
+| 1 – 9 | **0** (bit-identical) |
+| 10 | 4.1e-4 |
+| 12 – 33 | 5–7e-4 (flat) |
 | 40 | 7.6e-3 |
 
-Nine layers bit-identical, then parts in 1e5. That is the accumulator's 5.8e-8
-reaching a bf16 rounding boundary, not a fault: two orders of summing six
-numbers in f32, neither more correct than the other, and the fused one is
-actually the order the op-by-op reference uses.
+Nine layers bit-identical, then parts in 1e4: that is 5.8e-8 reaching a bf16
+rounding boundary, not a fault. Neither order is more correct, and the fused
+one is the order the op-by-op reference uses.
 
 Two other explanations were tested and eliminated. The fused launch is
 **deterministic** — three runs bit-identical — so nothing races. And filling
 every scratch buffer with NaN before a step changes **nothing**, so no stage
 reads a buffer it did not write.
 
-## 7. What could not be measured
+## 8. What could not be measured
 
 `ncu` does not run on this machine: `ERR_NVGPUCTRPERM`, GPU performance counters
 are restricted to administrators. Everything above rests on `nsys` kernel tracing

--- a/examples/nemotron_3_5_lightning_30b_a3b-tilelang/reports/WHY_SLOWER.md
+++ b/examples/nemotron_3_5_lightning_30b_a3b-tilelang/reports/WHY_SLOWER.md
@@ -106,24 +106,15 @@ the same stages run a launch apiece:
 | 19 – 33 | 5–7e-4 (flat) |
 | 40 | 7.6e-3 |
 
-Eight layers bit-identical rules out a logic error in any stage: a wrong index or
-a missing barrier does not wait until the ninth layer. What is left is a
-reproducibility difference — the fused path rounds somewhere the staged path does
-not — that stays inside every bound `check_all.py` derives and still costs token
-identity, because greedy decoding has no tolerance at all.
+Nine layers bit-identical, then parts in 1e5. That is the accumulator's 5.8e-8
+reaching a bf16 rounding boundary, not a fault: two orders of summing six
+numbers in f32, neither more correct than the other, and the fused one is
+actually the order the op-by-op reference uses.
 
-Two candidates, neither confirmed:
-
-- **Scratch reuse.** The fused launch keeps one set of buffers for all 52 layers;
-  the staged path allocates each layer's afresh. Every buffer is written before
-  it is read on the paths checked, but "checked" is by reading the code, not by
-  a tool.
-- **The head.** `cuda-stages` finishes in torch (`fh @ w_head.t()`), the fused
-  path in `s_head`. That explains a difference in the logits and nothing about
-  the states, which also differ.
-
-Until this is understood the fused path should not be described as
-token-identical, and `README.md` does not.
+Two other explanations were tested and eliminated. The fused launch is
+**deterministic** — three runs bit-identical — so nothing races. And filling
+every scratch buffer with NaN before a step changes **nothing**, so no stage
+reads a buffer it did not write.
 
 ## 7. What could not be measured
 

--- a/examples/nemotron_3_5_lightning_30b_a3b-tilelang/runtime_model.py
+++ b/examples/nemotron_3_5_lightning_30b_a3b-tilelang/runtime_model.py
@@ -10,6 +10,12 @@ Two bodies live here and `NEMO_IMPL` (or `set_impl`) chooses between them:
            52 layers, the closing norm and the head, with `T.sync_grid()` at
            exactly the points where `model.py` reshards a value back out of its
            mesh split. This is the implementation the numbers are about.
+``cuda``   handwritten CUDA, calling the public ``tilefoundry::ops`` entries.
+           The Mamba-2 layers run `kernels/nemotron.cu`; every other layer runs
+           the op-by-op path, so a step is many launches and what this setting
+           produces is per-layer evidence, not tok/s. It cannot fall through to
+           ``mega`` for the rest: that is one launch over the whole step and has
+           no entry that takes over a single layer.
 ``ops``    the op-by-op path: one torch call per operation, so a step is
            hundreds of launches. It exists to be the other number criterion 3
            asks for, and to be a second opinion on the mega kernel's arithmetic.
@@ -45,11 +51,15 @@ BF16 = torch.bfloat16
 IMPL = os.environ.get("NEMO_IMPL", "mega")
 
 
+#: The implementations `decode_step` can run. See the module docstring.
+IMPLS = ("mega", "ops", "cuda")
+
+
 def set_impl(name: str) -> None:
-    """Choose between the mega kernel and the op-by-op path."""
+    """Choose which implementation `decode_step` runs."""
     global IMPL
-    if name not in ("mega", "ops"):
-        raise ValueError(f"impl must be 'mega' or 'ops', got {name!r}")
+    if name not in IMPLS:
+        raise ValueError(f"impl must be one of {IMPLS}, got {name!r}")
     IMPL = name
 
 
@@ -108,7 +118,37 @@ def _attend(qg, blocks):
     return (acc / l).to(BF16)
 
 
-def _ops_step(w, acts, stop=None, attn_at=None):
+#: Per-layer (3, MH) scale slabs the CUDA kernel takes as one tensor, built
+#: once: the declared weights are three separate (MH,) views.
+_MSCAL_CACHE = {}
+
+
+def _mamba_cuda(i, h, w, acts):
+    """One Mamba-2 layer through `kernels/nemotron.cu`.
+
+    Returns the layer's output hidden row and the two states it hands on. The
+    residual add is the kernel's -- it owns the output rows it wrote, so adding
+    there costs no second pass over the hidden row.
+    """
+    from kernels import ops as _kernels  # noqa: PLC0415 -- compiled on first use
+
+    if i not in _MSCAL_CACHE:
+        _MSCAL_CACHE[i] = torch.stack([
+            w[f"l{i}_a_log"].reshape(MH), w[f"l{i}_dt_bias"].reshape(MH),
+            w[f"l{i}_d_skip"].reshape(MH)]).reshape(-1).contiguous()
+    out = _kernels().mamba_layer(
+        h.reshape(H), w[f"l{i}_gamma"].reshape(H),
+        w[f"l{i}_w_in"].reshape(-1), w[f"l{i}_w_out"].reshape(-1),
+        w[f"l{i}_conv_w"].reshape(-1), w[f"l{i}_conv_b"].reshape(CONV),
+        w[f"l{i}_gamma_gdn"].reshape(MI), _MSCAL_CACHE[i],
+        acts[f"l{i}_conv_state"].reshape(-1).contiguous(),
+        acts[f"l{i}_ssm_state"].reshape(-1).contiguous())
+    h_out, conv_out, ssm_out = out[0], out[1], out[2]
+    return (h_out.reshape(1, 1, H), conv_out.reshape(1, CONV, WIN),
+            ssm_out.reshape(1, MH, MD, SS))
+
+
+def _ops_step(w, acts, stop=None, attn_at=None, mamba=None):
     """One decode step, one torch call per operation.
 
     *stop* returns the running hidden row after that many layers instead of the
@@ -123,6 +163,10 @@ def _ops_step(w, acts, stop=None, attn_at=None):
     for i, kind in enumerate(KINDS):
         if stop is not None and i >= stop:
             return h.reshape(-1).float()
+        if kind == "linear_attention" and mamba is not None:
+            h, conv_out, ssm_out = mamba(i, h, w, acts)
+            fresh += [conv_out, ssm_out]
+            continue
         h2 = _rms(h, w[f"l{i}_gamma"]).reshape(1, H)
         if kind == "linear_attention":
             conv_state, ssm_state = acts[f"l{i}_conv_state"], acts[f"l{i}_ssm_state"]
@@ -242,6 +286,8 @@ class Nemotron35Lightning30BA3BRuntime:
         acts["token_ids"] = args[_INDEX["token_ids"]]
         if IMPL == "ops":
             return _ops_step(self._bound, acts)
+        if IMPL == "cuda":
+            return _ops_step(self._bound, acts, mamba=_mamba_cuda)
         return self._mega(args, acts)
 
     def _mega(self, args, acts):

--- a/examples/nemotron_3_5_lightning_30b_a3b-tilelang/runtime_model.py
+++ b/examples/nemotron_3_5_lightning_30b_a3b-tilelang/runtime_model.py
@@ -54,7 +54,7 @@ IMPL = os.environ.get("NEMO_IMPL", "mega")
 
 
 #: The implementations `decode_step` can run. See the module docstring.
-IMPLS = ("mega", "ops", "cuda")
+IMPLS = ("mega", "ops", "cuda", "cuda-stages")
 
 
 def set_impl(name: str) -> None:
@@ -210,6 +210,99 @@ def _attn_cuda(i, h, w, acts, cur_pos):
     return out[0].reshape(1, 1, H), fresh
 
 
+#: The scratch one cooperative launch writes, kept between steps: allocating
+#: 17 MB of attention partials every token would cost more than the step.
+_MEGA = {}
+
+
+def _mega_scratch(device, ctx_full, ctx_tail):
+    """Every buffer `mega_decode` writes, in the order its `Scratch` names them."""
+    nblock = -(-ctx_full // 256) + -(-ctx_tail // 256) + 2
+    key = (str(device), nblock)
+    if key not in _MEGA:
+        bf = dict(dtype=BF16, device=device)
+        f32 = dict(dtype=torch.float32, device=device)
+        _MEGA[key] = [
+            torch.empty(H, **bf), torch.empty(H, **bf), torch.empty(PROJ, **bf),
+            torch.empty(CONV, **bf), torch.empty(MI, **bf), torch.empty(MI, **bf),
+            torch.empty(QP + 2 * KVP, **bf), torch.empty(QP, **bf),
+            torch.empty(K * I, **bf), torch.empty(IS, **bf),
+            torch.empty(H, **f32), torch.empty(E, **f32),
+            torch.empty(nblock * HKV * GQA, **f32),
+            torch.empty(nblock * HKV * GQA, **f32),
+            torch.empty(nblock * HKV * GQA * DH, **f32),
+            torch.empty(K, dtype=torch.int32, device=device),
+            torch.empty(K, **f32), torch.empty(V, **f32),
+        ]
+    return _MEGA[key]
+
+
+_MEGA_META = {}
+
+
+def _mega_meta(device):
+    """The per-layer kind and its index within that kind, as the kernel reads them."""
+    if device not in _MEGA_META:
+        kid = {"linear_attention": 0, "full_attention": 1, "moe": 2}
+        kinds, ats, seen = [], [], {0: 0, 1: 0, 2: 0}
+        for k in KINDS:
+            kinds.append(kid[k])
+            ats.append(seen[kid[k]])
+            seen[kid[k]] += 1
+        _MEGA_META[device] = (
+            torch.tensor(kinds, dtype=torch.int32, device=device),
+            torch.tensor(ats, dtype=torch.int32, device=device))
+    return _MEGA_META[device]
+
+
+def _mega_cuda(twin, args, acts):
+    """One decode step as a single cooperative launch."""
+    _kernels = _sibling_import("kernels").ops
+
+    packed = twin._packed
+    device = packed.t["gam"].device
+    cur_pos = acts["cur_pos"]
+    ctx_full = ctx_tail = 0
+    states, fresh = [], []
+    conv_in, ssm_in, conv_out, ssm_out = [], [], [], []
+    kc, vc, kt, vt = [], [], [], []
+    out = []
+    for i, kind in enumerate(KINDS):
+        if kind == "linear_attention":
+            conv_in.append(acts[f"l{i}_conv_state"].reshape(-1))
+            ssm_in.append(acts[f"l{i}_ssm_state"].reshape(-1))
+            co = torch.empty(CONV * WIN, dtype=BF16, device=device)
+            so = torch.empty(MH * MD * SS, dtype=torch.float32, device=device)
+            conv_out.append(co)
+            ssm_out.append(so)
+            out.append((i, co.reshape(1, CONV, WIN), so.reshape(1, MH, MD, SS)))
+        elif kind == "full_attention":
+            a_kc, a_vc = acts[f"l{i}_k_cache"], acts[f"l{i}_v_cache"]
+            a_kt, a_vt = acts[f"l{i}_k_tail"], acts[f"l{i}_v_tail"]
+            ctx_full, ctx_tail = a_kc.shape[1], a_kt.shape[1]
+            kc.append(a_kc.reshape(-1))
+            vc.append(a_vc.reshape(-1))
+            kt.append(a_kt.reshape(-1))
+            vt.append(a_vt.reshape(-1))
+            out.append((i, a_kt, a_vt))
+    states = conv_in + ssm_in + conv_out + ssm_out + kc + vc + kt + vt
+    kinds, ats = _mega_meta(device)
+    scratch = _mega_scratch(device, ctx_full, ctx_tail)
+    logits = _kernels().mega_step(
+        [packed.t[n] for n in packing.PACK_ORDER], states, scratch, kinds, ats,
+        acts["token_ids"].reshape(-1), cur_pos, ctx_full, ctx_tail,
+        int(os.environ.get("NEMO_MEGA_LAYERS", "0")))
+    if os.environ.get("NEMO_MEGA_LAYERS"):
+        return (scratch[0].float().reshape(1, H),)
+    for i, a, b in out:
+        if KINDS[i] == "linear_attention":
+            fresh += [a, b]
+        else:
+            fresh += [a[:, cur_pos:cur_pos + 1].reshape(1, 1, HKV, DH),
+                      b[:, cur_pos:cur_pos + 1].reshape(1, 1, HKV, DH)]
+    return (logits.reshape(1, V), *fresh)
+
+
 def _ops_step(w, acts, stop=None, attn_at=None, mamba=None, moe=None, attn=None):
     """One decode step, one torch call per operation.
 
@@ -356,6 +449,8 @@ class Nemotron35Lightning30BA3BRuntime:
         if IMPL == "ops":
             return _ops_step(self._bound, acts)
         if IMPL == "cuda":
+            return _mega_cuda(self, args, acts)
+        if IMPL == "cuda-stages":
             return _ops_step(self._bound, acts, mamba=_mamba_cuda, moe=_moe_cuda,
                              attn=_attn_cuda)
         return self._mega(args, acts)

--- a/examples/nemotron_3_5_lightning_30b_a3b-tilelang/runtime_model.py
+++ b/examples/nemotron_3_5_lightning_30b_a3b-tilelang/runtime_model.py
@@ -33,6 +33,7 @@ import torch
 import torch.nn.functional as F
 
 import model
+import packing
 from model import Nemotron35Lightning30BA3B as SEM
 from tilefoundry.runtime import runtime_func, runtime_module
 
@@ -303,12 +304,22 @@ class Nemotron35Lightning30BA3BRuntime:
         original. `_bound` then keeps the *view* standing for that weight, so the
         op-by-op path and `check`'s weight report see exactly what was declared
         while the kernel sees eighteen buffers.
-        """
-        import mega_kernel  # noqa: PLC0415
 
+        The layout comes from `packing`, which imports no backend: loading
+        happens before an implementation runs, and reaching for one here would
+        make every implementation need every backend installed. Only ``mega``
+        builds a `mega_kernel.Runner`, and only ``mega`` needs TileLang.
+        """
         device = getattr(resource, "device", "cuda")
-        self._run = mega_kernel.Runner(device)
+        if IMPL == "mega":
+            import mega_kernel  # noqa: PLC0415
+
+            self._run = mega_kernel.Runner(device)
+            packed = self._run.packed
+        else:
+            self._run = None
+            packed = packing.Packed(device)
         for name in self._ir.weights:
             value = resource.load(name)
-            self._bound[name] = mega_kernel.pack_into(self._run.packed, name, value)
+            self._bound[name] = packing.pack_into(packed, name, value)
             del value

--- a/examples/nemotron_3_5_lightning_30b_a3b-tilelang/runtime_model.py
+++ b/examples/nemotron_3_5_lightning_30b_a3b-tilelang/runtime_model.py
@@ -11,11 +11,11 @@ Two bodies live here and `NEMO_IMPL` (or `set_impl`) chooses between them:
            exactly the points where `model.py` reshards a value back out of its
            mesh split. This is the implementation the numbers are about.
 ``cuda``   handwritten CUDA, calling the public ``tilefoundry::ops`` entries.
-           The Mamba-2 layers run `kernels/nemotron.cu`; every other layer runs
-           the op-by-op path, so a step is many launches and what this setting
-           produces is per-layer evidence, not tok/s. It cannot fall through to
-           ``mega`` for the rest: that is one launch over the whole step and has
-           no entry that takes over a single layer.
+           The Mamba-2 and MoE layers run `kernels/nemotron.cu`; the attention
+           layers still run the op-by-op path, so a step is many launches and
+           what this setting produces is per-layer evidence, not tok/s. It
+           cannot fall through to ``mega`` for the rest: that is one launch over
+           the whole step and has no entry that takes over a single layer.
 ``ops``    the op-by-op path: one torch call per operation, so a step is
            hundreds of launches. It exists to be the other number criterion 3
            asks for, and to be a second opinion on the mega kernel's arithmetic.
@@ -164,7 +164,23 @@ def _mamba_cuda(i, h, w, acts):
             ssm_out.reshape(1, MH, MD, SS))
 
 
-def _ops_step(w, acts, stop=None, attn_at=None, mamba=None):
+def _moe_cuda(i, h, w, acts):
+    """One MoE layer through `kernels/nemotron.cu`.
+
+    The router picks six of the 128 experts and the kernel runs those six plus
+    the shared one; the residual add is the kernel's, as in the Mamba path.
+    """
+    _kernels = _sibling_import("kernels").ops
+
+    out = _kernels().moe_layer(
+        h.reshape(H), w[f"l{i}_gamma"].reshape(H),
+        w[f"l{i}_w_router"].reshape(-1), w[f"l{i}_e_bias"].reshape(E).float(),
+        w[f"l{i}_w_up"].reshape(-1), w[f"l{i}_w_down"].reshape(-1),
+        w[f"l{i}_w_sh_up"].reshape(-1), w[f"l{i}_w_sh_down"].reshape(-1))
+    return out[0].reshape(1, 1, H)
+
+
+def _ops_step(w, acts, stop=None, attn_at=None, mamba=None, moe=None):
     """One decode step, one torch call per operation.
 
     *stop* returns the running hidden row after that many layers instead of the
@@ -182,6 +198,9 @@ def _ops_step(w, acts, stop=None, attn_at=None, mamba=None):
         if kind == "linear_attention" and mamba is not None:
             h, conv_out, ssm_out = mamba(i, h, w, acts)
             fresh += [conv_out, ssm_out]
+            continue
+        if kind == "moe" and moe is not None:
+            h = moe(i, h, w, acts)
             continue
         h2 = _rms(h, w[f"l{i}_gamma"]).reshape(1, H)
         if kind == "linear_attention":
@@ -303,7 +322,7 @@ class Nemotron35Lightning30BA3BRuntime:
         if IMPL == "ops":
             return _ops_step(self._bound, acts)
         if IMPL == "cuda":
-            return _ops_step(self._bound, acts, mamba=_mamba_cuda)
+            return _ops_step(self._bound, acts, mamba=_mamba_cuda, moe=_moe_cuda)
         return self._mega(args, acts)
 
     def _mega(self, args, acts):

--- a/examples/nemotron_3_5_lightning_30b_a3b-tilelang/runtime_model.py
+++ b/examples/nemotron_3_5_lightning_30b_a3b-tilelang/runtime_model.py
@@ -28,6 +28,7 @@ that takes 18 can address any of them by (layer, row).
 from __future__ import annotations
 
 import os
+import sys
 
 import torch
 import torch.nn.functional as F
@@ -119,6 +120,20 @@ def _attend(qg, blocks):
     return (acc / l).to(BF16)
 
 
+#: This file's own directory. `tilefoundry check` puts a source file's directory
+#: on `sys.path` only while it imports the module and takes it off again, so a
+#: lazy import from inside a method -- which is how both the TileLang kernel and
+#: the CUDA extension are compiled on first use -- cannot rely on it being there.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def _sibling_import(name):
+    """Import a module that lives beside this one, whatever `sys.path` holds."""
+    if _HERE not in sys.path:
+        sys.path.insert(0, _HERE)
+    return __import__(name)
+
+
 #: Per-layer (3, MH) scale slabs the CUDA kernel takes as one tensor, built
 #: once: the declared weights are three separate (MH,) views.
 _MSCAL_CACHE = {}
@@ -131,7 +146,7 @@ def _mamba_cuda(i, h, w, acts):
     residual add is the kernel's -- it owns the output rows it wrote, so adding
     there costs no second pass over the hidden row.
     """
-    from kernels import ops as _kernels  # noqa: PLC0415 -- compiled on first use
+    _kernels = _sibling_import("kernels").ops  # compiled on first use
 
     if i not in _MSCAL_CACHE:
         _MSCAL_CACHE[i] = torch.stack([
@@ -255,14 +270,14 @@ class Nemotron35Lightning30BA3BRuntime:
         the same code generated around a pair of parameters instead of around
         the step's own scratch.
         """
-        import mega_kernel  # noqa: PLC0415 -- compiled on first use
+        mega_kernel = _sibling_import("mega_kernel")
 
         return mega_kernel.run_attn("head", qg, k_cache, v_cache, k_tail, v_tail)
 
     @runtime_func
     def attend_by_context(self, qg, k_cache, v_cache, k_tail, v_tail):
         """The long-context placement, on its own. See `attend_by_head`."""
-        import mega_kernel  # noqa: PLC0415
+        mega_kernel = _sibling_import("mega_kernel")
 
         return mega_kernel.run_attn("context", qg, k_cache, v_cache, k_tail, v_tail)
 
@@ -273,7 +288,7 @@ class Nemotron35Lightning30BA3BRuntime:
         The same number the semantics dispatches on and the same number the
         step's own branch reads: `ctx_full`, against the crossover.
         """
-        import mega_kernel  # noqa: PLC0415
+        mega_kernel = _sibling_import("mega_kernel")
 
         return mega_kernel.run_attn("dispatch", qg, k_cache, v_cache, k_tail, v_tail)
 
@@ -292,7 +307,7 @@ class Nemotron35Lightning30BA3BRuntime:
         return self._mega(args, acts)
 
     def _mega(self, args, acts):
-        import mega_kernel  # noqa: PLC0415 -- compiled on first use
+        mega_kernel = _sibling_import("mega_kernel")
 
         return mega_kernel.run_step(self._run, args, acts["cur_pos"], _INDEX)
 
@@ -312,7 +327,7 @@ class Nemotron35Lightning30BA3BRuntime:
         """
         device = getattr(resource, "device", "cuda")
         if IMPL == "mega":
-            import mega_kernel  # noqa: PLC0415
+            mega_kernel = _sibling_import("mega_kernel")
 
             self._run = mega_kernel.Runner(device)
             packed = self._run.packed

--- a/examples/nemotron_3_5_lightning_30b_a3b-tilelang/runtime_model.py
+++ b/examples/nemotron_3_5_lightning_30b_a3b-tilelang/runtime_model.py
@@ -11,9 +11,9 @@ Two bodies live here and `NEMO_IMPL` (or `set_impl`) chooses between them:
            exactly the points where `model.py` reshards a value back out of its
            mesh split. This is the implementation the numbers are about.
 ``cuda``   handwritten CUDA, calling the public ``tilefoundry::ops`` entries.
-           The Mamba-2 and MoE layers run `kernels/nemotron.cu`; the attention
-           layers still run the op-by-op path, so a step is many launches and
-           what this setting produces is per-layer evidence, not tok/s. It
+           All 52 layers run `kernels/nemotron.cu`, but as many launches rather
+           than one, so what this setting produces is per-layer evidence and a
+           correct step, not tok/s. It
            cannot fall through to ``mega`` for the rest: that is one launch over
            the whole step and has no entry that takes over a single layer.
 ``ops``    the op-by-op path: one torch call per operation, so a step is
@@ -138,6 +138,9 @@ def _sibling_import(name):
 #: once: the declared weights are three separate (MH,) views.
 _MSCAL_CACHE = {}
 
+#: Per-layer fused (QKV, H) views over the packed attention weights.
+_QKV_CACHE = {}
+
 
 def _mamba_cuda(i, h, w, acts):
     """One Mamba-2 layer through `kernels/nemotron.cu`.
@@ -180,7 +183,34 @@ def _moe_cuda(i, h, w, acts):
     return out[0].reshape(1, 1, H)
 
 
-def _ops_step(w, acts, stop=None, attn_at=None, mamba=None, moe=None):
+def _attn_cuda(i, h, w, acts, cur_pos):
+    """One full-attention layer through `kernels/nemotron.cu`.
+
+    The kernel writes this token's K/V row into the tail buffers it was handed,
+    which is `cache_update` realised on the cache's own memory, so the rows the
+    step hands on are views of those buffers rather than copies.
+    """
+    _kernels = _sibling_import("kernels").ops
+
+    if i not in _QKV_CACHE:
+        # `w_q`, `w_k` and `w_v` are three contiguous slices of one (QKV, H)
+        # slab in the pack, so the fused matrix the kernel wants is already
+        # there: take the view rather than concatenating 25 MB every step.
+        wq = w[f"l{i}_w_q"]
+        _QKV_CACHE[i] = wq.as_strided(((QP + 2 * KVP) * H,), (1,),
+                                      wq.storage_offset())
+    k_tail, v_tail = acts[f"l{i}_k_tail"], acts[f"l{i}_v_tail"]
+    out = _kernels().attn_layer(
+        h.reshape(H), w[f"l{i}_gamma"].reshape(H),
+        _QKV_CACHE[i], w[f"l{i}_w_o"].reshape(-1),
+        acts[f"l{i}_k_cache"].reshape(-1), acts[f"l{i}_v_cache"].reshape(-1),
+        k_tail.reshape(-1), v_tail.reshape(-1), cur_pos)
+    fresh = [k_tail[:, cur_pos:cur_pos + 1].reshape(1, 1, HKV, DH),
+             v_tail[:, cur_pos:cur_pos + 1].reshape(1, 1, HKV, DH)]
+    return out[0].reshape(1, 1, H), fresh
+
+
+def _ops_step(w, acts, stop=None, attn_at=None, mamba=None, moe=None, attn=None):
     """One decode step, one torch call per operation.
 
     *stop* returns the running hidden row after that many layers instead of the
@@ -201,6 +231,10 @@ def _ops_step(w, acts, stop=None, attn_at=None, mamba=None, moe=None):
             continue
         if kind == "moe" and moe is not None:
             h = moe(i, h, w, acts)
+            continue
+        if kind == "full_attention" and attn is not None and attn_at != i:
+            h, pair = attn(i, h, w, acts, cur_pos)
+            fresh += pair
             continue
         h2 = _rms(h, w[f"l{i}_gamma"]).reshape(1, H)
         if kind == "linear_attention":
@@ -322,12 +356,19 @@ class Nemotron35Lightning30BA3BRuntime:
         if IMPL == "ops":
             return _ops_step(self._bound, acts)
         if IMPL == "cuda":
-            return _ops_step(self._bound, acts, mamba=_mamba_cuda, moe=_moe_cuda)
+            return _ops_step(self._bound, acts, mamba=_mamba_cuda, moe=_moe_cuda,
+                             attn=_attn_cuda)
         return self._mega(args, acts)
 
     def _mega(self, args, acts):
         mega_kernel = _sibling_import("mega_kernel")
 
+        if self._run is None:
+            # The runner carries the scratch and the address-table ring, not the
+            # weights: those are already packed, so it adopts the pack rather
+            # than allocating a second one.
+            self._run = mega_kernel.Runner(self._device)
+            self._run.packed = self._packed
         return mega_kernel.run_step(self._run, args, acts["cur_pos"], _INDEX)
 
     def load(self, resource):
@@ -339,20 +380,16 @@ class Nemotron35Lightning30BA3BRuntime:
         op-by-op path and `check`'s weight report see exactly what was declared
         while the kernel sees eighteen buffers.
 
-        The layout comes from `packing`, which imports no backend: loading
-        happens before an implementation runs, and reaching for one here would
-        make every implementation need every backend installed. Only ``mega``
-        builds a `mega_kernel.Runner`, and only ``mega`` needs TileLang.
+        The layout comes from `packing`, which imports no backend. Loading
+        happens before an implementation is chosen -- `set_impl` may not have
+        been called yet -- so this must not branch on one, and the TileLang
+        runner is built when ``mega`` first runs rather than here.
         """
         device = getattr(resource, "device", "cuda")
-        if IMPL == "mega":
-            mega_kernel = _sibling_import("mega_kernel")
-
-            self._run = mega_kernel.Runner(device)
-            packed = self._run.packed
-        else:
-            self._run = None
-            packed = packing.Packed(device)
+        self._device = device
+        self._run = None
+        packed = packing.Packed(device)
+        self._packed = packed
         for name in self._ir.weights:
             value = resource.load(name)
             self._bound[name] = packing.pack_into(packed, name, value)

--- a/include/tilefoundry/runtime/cuda/ops/mbarrier.cuh
+++ b/include/tilefoundry/runtime/cuda/ops/mbarrier.cuh
@@ -1,0 +1,72 @@
+/// tilefoundry mbarrier ops — the Hopper shared-memory barrier object.
+///
+/// Included IN-CONTEXT from runtime.cuh inside ``namespace tilefoundry::ops``;
+/// it opens no namespace and pulls in no system headers. The object itself is a
+/// 64-bit word in shared memory, and every entry takes a generic pointer to it
+/// and converts to the shared window address the instructions want.
+
+/// **Why these are separate entries and ``sync`` is one.** ``ops::sync``
+/// collapses five ``SyncKind``s behind one entry because they are five ways to
+/// spell one op — "barrier for this mesh scope" — with the scope choosing the
+/// spelling. ``mbarrier.init`` / ``arrive`` / ``try_wait`` are three
+/// instructions with three meanings and three signatures.
+
+/// [runtime §3](docs/spec/runtime.md#3-runtime-ops)'s one-entry rule forbids
+/// exposing the *tiers* of one op separately; it does not ask distinct
+/// operations to hide behind an enum. **No tiers here:** a barrier is a
+/// shared-memory object, not a sharded tensor, so no operand carries a
+/// ``ShardLayout`` for a trait to read.
+#pragma once
+
+#include "mbarrier/mbarrier_impl.h"
+
+/// Initialise ``bar`` so that ``arrive_count`` arrivals complete a phase.
+///
+/// One thread must call this, and a ``sync`` covering every thread that will
+/// use the barrier must follow it before any of them arrive or wait.
+__device__ inline void mbarrier_init(uint64_t *bar, unsigned arrive_count) {
+    mbarrier_impl::Init{}(bar, arrive_count);
+}
+
+/// Arrive on ``bar``, contributing one of the arrivals its phase is waiting on.
+__device__ inline void mbarrier_arrive(uint64_t *bar) {
+    mbarrier_impl::Arrive{}(bar);
+}
+
+/// Arrive on ``bar`` **and** declare that ``tx_bytes`` of asynchronous data
+/// will land against this phase.
+///
+/// This is the producer half of a bulk copy: the phase completes when both the
+/// arrivals and the byte count are satisfied, so the consumer's wait covers the
+/// copy without a second barrier. One instruction rather than an ``arrive``
+/// plus an ``expect_tx``.
+__device__ inline void mbarrier_arrive_expect_tx(uint64_t *bar,
+                                                 unsigned tx_bytes) {
+    mbarrier_impl::ArriveExpectTx{}(bar, tx_bytes);
+}
+
+/// Declare ``tx_bytes`` of asynchronous data against ``bar``'s current phase
+/// without arriving on it.
+__device__ inline void mbarrier_expect_tx(uint64_t *bar, unsigned tx_bytes) {
+    mbarrier_impl::ExpectTx{}(bar, tx_bytes);
+}
+
+/// Test ``bar``'s phase once, without blocking; true when ``phase`` has
+/// flipped.
+__device__ inline bool mbarrier_try_wait_parity(uint64_t *bar, unsigned phase) {
+    return mbarrier_impl::TryWaitParity{}(bar, phase);
+}
+
+/// Block until ``bar``'s phase parity reaches ``phase``.
+///
+/// ``phase`` alternates 0, 1, 0, ... across successive completions of the same
+/// barrier, which is what lets a pipeline reuse a fixed ring of barriers
+/// instead of allocating one per stage.
+__device__ inline void mbarrier_wait_parity(uint64_t *bar, unsigned phase) {
+    mbarrier_impl::WaitParity{}(bar, phase);
+}
+
+/// Invalidate ``bar``, releasing the shared-memory word for other use.
+__device__ inline void mbarrier_invalidate(uint64_t *bar) {
+    mbarrier_impl::Invalidate{}(bar);
+}

--- a/include/tilefoundry/runtime/cuda/ops/mbarrier/mbarrier_impl.h
+++ b/include/tilefoundry/runtime/cuda/ops/mbarrier/mbarrier_impl.h
@@ -1,0 +1,100 @@
+/// mbarrier op implementations — one per entry in ``ops/mbarrier.cuh``.
+///
+/// Included in-context from ``ops/mbarrier.cuh``. Every struct here is the
+/// single implementation of its entry; nothing selects a tier.
+///
+/// The instructions are ``.shared::cta`` throughout: this runtime does not
+/// place a barrier in a cluster's distributed shared memory, and naming the
+/// window explicitly keeps the generic-to-shared conversion from being redone
+/// by the assembler on every use.
+#pragma once
+
+namespace mbarrier_impl {
+
+/// The shared-window address of a generic pointer, which is what every
+/// ``mbarrier.*`` instruction takes.
+__device__ inline uint32_t smem_addr(void const *ptr) {
+    return static_cast<uint32_t>(__cvta_generic_to_shared(ptr));
+}
+
+/// ``mbarrier.init`` — arm the object for ``arrive_count`` arrivals.
+struct Init {
+    __device__ void operator()(uint64_t *bar, unsigned arrive_count) const {
+        asm volatile(
+            "mbarrier.init.shared::cta.b64 [%0], %1;\n" ::"r"(smem_addr(bar)),
+            "r"(arrive_count));
+    }
+};
+
+/// ``mbarrier.arrive`` — the arrival token is discarded: this runtime's
+/// consumers wait on the phase parity, not on a token handed between threads.
+struct Arrive {
+    __device__ void operator()(uint64_t *bar) const {
+        asm volatile("{\n"
+                     "  .reg .b64 state;\n"
+                     "  mbarrier.arrive.shared::cta.b64 state, [%0];\n"
+                     "}\n" ::"r"(smem_addr(bar)));
+    }
+};
+
+/// ``mbarrier.arrive.expect_tx`` — arrive and declare the bytes in one go.
+struct ArriveExpectTx {
+    __device__ void operator()(uint64_t *bar, unsigned tx_bytes) const {
+        asm volatile(
+            "{\n"
+            "  .reg .b64 state;\n"
+            "  mbarrier.arrive.expect_tx.shared::cta.b64 state, [%0], %1;\n"
+            "}\n" ::"r"(smem_addr(bar)),
+            "r"(tx_bytes));
+    }
+};
+
+/// ``mbarrier.expect_tx`` — declare bytes without contributing an arrival.
+struct ExpectTx {
+    __device__ void operator()(uint64_t *bar, unsigned tx_bytes) const {
+        asm volatile("mbarrier.expect_tx.shared::cta.b64 [%0], %1;\n" ::"r"(
+                         smem_addr(bar)),
+                     "r"(tx_bytes));
+    }
+};
+
+/// ``mbarrier.try_wait.parity`` — one non-blocking test of the phase.
+///
+/// Spelled as a single test with the loop in C++ rather than as a PTX loop with
+/// its own labels: a label inside inline asm is emitted once per instantiation
+/// and collides as soon as two instantiations land in one translation unit.
+struct TryWaitParity {
+    __device__ bool operator()(uint64_t *bar, unsigned phase) const {
+        unsigned ready = 0u;
+        asm volatile(
+            "{\n"
+            "  .reg .pred complete;\n"
+            "  mbarrier.try_wait.parity.shared::cta.b64 complete, [%1], %2;\n"
+            "  selp.b32 %0, 1, 0, complete;\n"
+            "}\n"
+            : "=r"(ready)
+            : "r"(smem_addr(bar)), "r"(phase));
+        return ready != 0u;
+    }
+};
+
+/// Spin on ``try_wait`` until the phase flips.
+///
+/// ``try_wait`` already parks the warp in hardware for a bounded interval, so
+/// this loop is not a busy spin on the issue pipe.
+struct WaitParity {
+    __device__ void operator()(uint64_t *bar, unsigned phase) const {
+        while (!TryWaitParity{}(bar, phase)) {
+        }
+    }
+};
+
+/// ``mbarrier.inval`` — release the word.
+struct Invalidate {
+    __device__ void operator()(uint64_t *bar) const {
+        asm volatile(
+            "mbarrier.inval.shared::cta.b64 [%0];\n" ::"r"(smem_addr(bar)));
+    }
+};
+
+}

--- a/include/tilefoundry/runtime/cuda/ops/reduce/reduce_common_impl.h
+++ b/include/tilefoundry/runtime/cuda/ops/reduce/reduce_common_impl.h
@@ -103,14 +103,23 @@ __device__ float local_fold(SrcT const &s, int j, int step) {
     return acc;
 }
 
+/// Adapt ``reduce_traits<Op>::combine`` to the functor shape
+/// ``ops::warp_reduce`` takes.
+template <class Op> struct combine_fn {
+    __device__ static float apply(float a, float b) {
+        return reduce_traits<Op>::combine(a, b);
+    }
+};
+
 /// Intra-warp butterfly reduction (32 lanes → broadcast combine), using
 /// ``Op``'s combine (``+`` for sum/mean, ``fmaxf`` for absmax).
+///
+/// The shuffles themselves are ``ops::warp_reduce`` (ops/warp.cuh), which is
+/// where this file's ``__shfl_xor_sync`` used to be written out: one spelling
+/// of the butterfly, so a change to it cannot reach reduce and the warp op
+/// differently.
 template <class Op> __device__ float warp_butterfly(float val) {
-    for (int delta = 16; delta > 0; delta >>= 1) {
-        val = reduce_traits<Op>::combine(
-            val, __shfl_xor_sync(0xFFFFFFFFu, val, delta));
-    }
-    return val;
+    return warp_reduce<combine_fn<Op>>(val);
 }
 
 /// Cross-warp SUM aggregation via a shared-memory workspace.

--- a/include/tilefoundry/runtime/cuda/ops/tma.cuh
+++ b/include/tilefoundry/runtime/cuda/ops/tma.cuh
@@ -1,0 +1,49 @@
+/// tilefoundry TMA ops — the Hopper bulk asynchronous copy.
+///
+/// Included IN-CONTEXT from runtime.cuh inside ``namespace tilefoundry::ops``;
+/// it opens no namespace and pulls in no system headers.
+
+/// **One implementation, and why there is no tier.** The hardware's two bulk
+/// forms are the rank-1 ``cp.async.bulk`` (a contiguous byte run, no
+/// descriptor) and the tensor forms ``cp.async.bulk.tensor.Nd`` (a
+/// ``TensorMap`` encoded on the host). Those differ in their *operands* — a
+/// size against a descriptor plus coordinates — not in a tier a trait could
+/// pick between, and a caller holding one cannot supply the other.
+
+/// This header implements the rank-1 form, the one the address shapes in this
+/// repository can use. The tensor form is absent because nothing calls it: an
+/// implementation with no caller and no test is a guess, not a contract.
+
+/// A weaker-alignment fallback is likewise absent on purpose — that is
+/// ``ops::copy_async``. This op is the bulk instruction, and it says so by
+/// refusing rather than by silently becoming a slower copy. Both addresses
+/// must be 16-byte aligned and the byte count a multiple of 16; the
+/// instruction has no defined behaviour otherwise.
+#pragma once
+
+#include "tma/tma_impl.h"
+
+/// Stage ``count`` elements from global memory into shared memory as one bulk
+/// asynchronous copy, completing against ``bar``.
+///
+/// Exactly **one** thread issues this. Completion is signalled on ``bar``'s
+/// current phase, so the issuing thread pairs it with
+/// ``mbarrier_arrive_expect_tx(bar, bytes)`` and every consumer waits with
+/// ``mbarrier_wait_parity``. Nothing here blocks: the point of the op is that
+/// the copy is still in flight when the issuing thread reaches the next one.
+template <class T>
+__device__ inline void tma_bulk_copy(T const *src_gmem, T *dst_smem,
+                                     unsigned count, uint64_t *bar) {
+    tma_impl::BulkG2S<T>{}(src_gmem, dst_smem, count, bar);
+}
+
+/// The byte count ``tma_bulk_copy`` will transfer, for the
+/// ``mbarrier_arrive_expect_tx`` that must declare it.
+///
+/// Spelled as its own function so the two numbers cannot drift: a phase that
+/// expects a different byte count than the copy delivers never completes, and
+/// that failure looks like a hang rather than like a wrong answer.
+template <class T>
+__device__ __host__ inline constexpr unsigned tma_bulk_bytes(unsigned count) {
+    return count * unsigned(sizeof(T));
+}

--- a/include/tilefoundry/runtime/cuda/ops/tma/tma_impl.h
+++ b/include/tilefoundry/runtime/cuda/ops/tma/tma_impl.h
@@ -1,0 +1,28 @@
+/// TMA op implementation — the single implementation of ``tma_bulk_copy``.
+///
+/// Included in-context from ``ops/tma.cuh``.
+#pragma once
+
+namespace tma_impl {
+
+/// ``cp.async.bulk`` global→shared with mbarrier completion.
+///
+/// ``.shared::cluster`` names the destination window even though this runtime
+/// does not distribute a tile across a cluster: that is the operand form the
+/// instruction takes, and a single-CTA cluster is the degenerate case of it.
+template <class T> struct BulkG2S {
+    __device__ void operator()(T const *src_gmem, T *dst_smem, unsigned count,
+                               uint64_t *bar) const {
+        static_assert(sizeof(T) <= 16,
+                      "tma_bulk_copy: element wider than the 16-byte grain");
+        const unsigned bytes = count * unsigned(sizeof(T));
+        asm volatile(
+            "cp.async.bulk.shared::cluster.global"
+            ".mbarrier::complete_tx::bytes [%0], [%1], %2, [%3];\n" ::"r"(
+                mbarrier_impl::smem_addr(dst_smem)),
+            "l"(src_gmem), "r"(bytes), "r"(mbarrier_impl::smem_addr(bar))
+            : "memory");
+    }
+};
+
+}

--- a/include/tilefoundry/runtime/cuda/ops/warp.cuh
+++ b/include/tilefoundry/runtime/cuda/ops/warp.cuh
@@ -1,0 +1,60 @@
+/// tilefoundry warp ops — the warp-scoped exchange primitives.
+///
+/// Included IN-CONTEXT from runtime.cuh, inside ``namespace
+/// tilefoundry::ops``: it opens no namespace and pulls in no system headers.
+/// Included **before** ``ops/reduce.cuh`` so reduce's intra-warp tier folds
+/// through ``warp_reduce`` rather than spelling the butterfly a second time.
+
+/// Three ops, one public entry each, and no tiers: the operand is a
+/// register-resident scalar and carries no ``ShardLayout``, so a compile-time
+/// tier selection would have nothing to read. [runtime
+/// §3](docs/spec/runtime.md#3-runtime-ops) asks for one entry per op, not for
+/// every op to have more than one implementation.
+#pragma once
+
+#include "warp/warp_impl.h"
+
+/// Exchange ``value`` with the lane whose id differs from this one in the bits
+/// of ``lane_mask``; ``member_mask`` names the lanes that participate.
+///
+/// A butterfly step: after ``k`` steps with masks 1, 2, ... 2^(k-1) every lane
+/// holds the combination of its 2^k-lane block.
+template <class T>
+__device__ inline T shuffle_xor(T value, int lane_mask,
+                                unsigned member_mask = 0xFFFFFFFFu) {
+    return warp_impl::ShuffleXor<T>{}(value, lane_mask, member_mask);
+}
+
+/// True on exactly **one** thread of the leading ``Width`` threads of the CTA.
+///
+/// ``Width`` is the participating thread count, not a lane mask: a whole block
+/// still yields one thread, in the first warp. That is what an mbarrier whose
+/// arrive-count is 1 needs — one arriver, chosen without a ballot round-trip.
+template <int Width> __device__ inline bool shuffle_elect() {
+    return warp_impl::Elect<Width>{}();
+}
+
+/// Fold ``value`` across the 32 lanes with ``Combine``, leaving the result in
+/// **every** lane.
+///
+/// ``Combine`` is a functor type with a static ``apply(T, T) -> T``. The fold
+/// is the five-step butterfly, so the instruction count to expect is five
+/// shuffles and five combines, not a loop over 32 lanes.
+template <class Combine, class T> __device__ inline T warp_reduce(T value) {
+    return warp_impl::Butterfly<Combine, T>{}(value);
+}
+
+/// Sum combine for ``warp_reduce``.
+struct warp_sum {
+    __device__ static float apply(float a, float b) { return a + b; }
+};
+
+/// Max combine for ``warp_reduce``.
+struct warp_max {
+    __device__ static float apply(float a, float b) { return fmaxf(a, b); }
+};
+
+/// Min combine for ``warp_reduce``.
+struct warp_min {
+    __device__ static float apply(float a, float b) { return fminf(a, b); }
+};

--- a/include/tilefoundry/runtime/cuda/ops/warp/warp_impl.h
+++ b/include/tilefoundry/runtime/cuda/ops/warp/warp_impl.h
@@ -1,0 +1,88 @@
+/// warp op implementations — one per entry in ``ops/warp.cuh``.
+///
+/// Included in-context from ``ops/warp.cuh`` (see reduce_common_impl.h for the
+/// in-context include contract). No tier selection lives here: each struct is
+/// the single implementation of its entry.
+#pragma once
+
+namespace warp_impl {
+
+/// Whether ``__shfl_xor_sync`` takes ``T`` directly. Everything else goes
+/// through the word-wise path below.
+template <class T>
+inline constexpr bool is_shuffle_native_v =
+    std::is_same_v<T, float> || std::is_same_v<T, double> ||
+    std::is_same_v<T, int> || std::is_same_v<T, unsigned int> ||
+    std::is_same_v<T, long long> || std::is_same_v<T, unsigned long long>;
+
+/// ``__shfl_xor_sync`` for the types the intrinsic accepts, and a word-wise
+/// exchange for anything else (a bf16 pair, a small aggregate).
+template <class T> struct ShuffleXor {
+    __device__ T operator()(T value, int lane_mask,
+                            unsigned member_mask) const {
+        if constexpr (is_shuffle_native_v<T>) {
+            return __shfl_xor_sync(member_mask, value, lane_mask);
+        } else {
+            static_assert(
+                sizeof(T) % sizeof(unsigned) == 0,
+                "shuffle_xor: type size must be a multiple of 4 bytes");
+            constexpr int kWords = int(sizeof(T) / sizeof(unsigned));
+            T out = value;
+            unsigned *dst = reinterpret_cast<unsigned *>(&out);
+            for (int i = 0; i < kWords; ++i)
+                dst[i] = __shfl_xor_sync(member_mask, dst[i], lane_mask);
+            return out;
+        }
+    }
+};
+
+/// Elect exactly one thread among the leading ``Width`` threads of the CTA.
+///
+/// On sm_90 the elected lane comes from ``elect.sync``: one instruction, where
+/// a ballot plus a find-first would be three and would make every lane read a
+/// value it does not use. Below sm_90 lane 0 is the elected thread — the same
+/// guarantee (exactly one) with a different choice of which.
+///
+/// Threads outside the first warp answer false without executing the
+/// warp-scoped instruction at all: ``elect.sync``'s result is defined only for
+/// the lanes named in its member mask.
+template <int Width> struct Elect {
+    __device__ bool operator()() const {
+        static_assert(Width > 0, "shuffle_elect: Width must be positive");
+        /// The elected thread is always in the first warp, so every thread past
+        /// it answers false. ``Width`` therefore only discriminates below 32.
+        constexpr unsigned kParticipants = Width < 32 ? unsigned(Width) : 32u;
+        if (threadIdx.x >= kParticipants)
+            return false;
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+        constexpr unsigned kMask =
+            Width >= 32 ? 0xFFFFFFFFu : ((1u << unsigned(Width & 31)) - 1u);
+        unsigned pred = 0u;
+        asm volatile("{\n"
+                     "  .reg .b32 elected_lane;\n"
+                     "  .reg .pred is_elected;\n"
+                     "  elect.sync elected_lane|is_elected, %1;\n"
+                     "  selp.b32 %0, 1, 0, is_elected;\n"
+                     "}\n"
+                     : "=r"(pred)
+                     : "n"(kMask));
+        return pred != 0u;
+#else
+        return (threadIdx.x & 31u) == 0u;
+#endif
+    }
+};
+
+/// The five-step butterfly: after step ``k`` every lane holds the combination
+/// of its ``2^(k+1)``-lane block, so after five steps every lane holds the
+/// warp's. The result is in every lane, not only in lane 0.
+template <class Combine, class T> struct Butterfly {
+    __device__ T operator()(T value) const {
+        for (int delta = 16; delta > 0; delta >>= 1)
+            value = Combine::apply(value,
+                                   ShuffleXor<T>{}(value, delta, 0xFFFFFFFFu));
+        return value;
+    }
+};
+
+}

--- a/include/tilefoundry/runtime/cuda/runtime.cuh
+++ b/include/tilefoundry/runtime/cuda/runtime.cuh
@@ -77,6 +77,12 @@ namespace ops {
 #include "ops/unary.cuh"
 #include "ops/copy.cuh"
 #include "ops/binary.cuh"
+/// warp before reduce: reduce's intra-warp tier folds through warp_reduce.
+#include "ops/warp.cuh"
+#include "ops/mbarrier.cuh"
+/// tma after mbarrier: a bulk copy completes on an mbarrier and reuses its
+/// generic-to-shared conversion.
+#include "ops/tma.cuh"
 #include "ops/reduce.cuh"
 #include "ops/cast.cuh"
 #include "ops/clamp.cuh"

--- a/src/tilefoundry/ir/tir/cuda/memory/__init__.py
+++ b/src/tilefoundry/ir/tir/cuda/memory/__init__.py
@@ -1,0 +1,1 @@
+"""CUDA memory-movement instructions (the Hopper bulk asynchronous copy)."""

--- a/src/tilefoundry/ir/tir/cuda/memory/tma.py
+++ b/src/tilefoundry/ir/tir/cuda/memory/tma.py
@@ -1,0 +1,90 @@
+"""Effect-form TIR Op for the CUDA bulk asynchronous copy (TMA).
+
+``CopyAsync`` is ``cp.async``: every thread issues its own load and a commit
+closes the group. This is ``cp.async.bulk`` -- **one** thread issues a whole
+run, an mbarrier signals completion -- and is not a tier of the other. Only the
+rank-1 form is defined; the tensor forms take a host-encoded ``TensorMap`` in
+place of a size, a different operand list rather than a tier. **Defined but not
+lowered**: no CUDA emit; the implementation is in ``ops/tma.cuh``.
+
+See [tir §2.3](docs/spec/tir.md#23-tir-ops).
+"""
+
+from __future__ import annotations
+
+from tilefoundry.ir.core import Op
+from tilefoundry.ir.core.param_def import ParamDef
+from tilefoundry.ir.core.pattern import Tensor
+from tilefoundry.ir.core.register import register_op
+from tilefoundry.ir.types import UnitType
+from tilefoundry.ir.types.storage import StorageKind
+from tilefoundry.visitor_registry import register_typeinfer, register_verify_stmt
+
+__all__ = ["TmaBulkCopy"]
+
+_GRAIN_BYTES = 16
+
+
+@register_op(dialect="T", category="async", name="tma_bulk_copy")
+class TmaBulkCopy(Op):
+    """Stage a contiguous run from global to shared memory as one bulk copy.
+
+    Exactly one thread issues it and nothing blocks: the copy is still in flight
+    when the issuing thread reaches the next statement. Completion lands on
+    ``barrier``'s current phase, so the issuing thread pairs this with an
+    ``MBarrierArriveExpectTx`` naming the same byte count and every consumer
+    waits with ``MBarrierWaitParity``.
+    """
+
+    src = ParamDef(kind="input", pattern=Tensor)
+    dst = ParamDef(kind="input", pattern=Tensor)
+    barrier = ParamDef(kind="input", pattern=Tensor)
+
+
+@register_typeinfer(TmaBulkCopy)
+def _(call: "Call", ctx: "TypeInferContext") -> UnitType:
+    return UnitType()
+
+
+@register_verify_stmt(TmaBulkCopy)
+def _(call: "Call", ctx: "VerifyContext") -> None:
+    src = ctx.type_of(call.args[0])
+    dst = ctx.type_of(call.args[1])
+    bar = ctx.type_of(call.args[2])
+    if src.storage != StorageKind.GMEM:
+        ctx.error(call, f"TmaBulkCopy source must be gmem, got {src.storage}")
+    if dst.storage != StorageKind.SMEM:
+        ctx.error(call, f"TmaBulkCopy destination must be smem, got {dst.storage}")
+    if bar.storage != StorageKind.SMEM:
+        ctx.error(call, f"TmaBulkCopy barrier must be smem, got {bar.storage}")
+    if src.dtype != dst.dtype:
+        ctx.error(call, f"TmaBulkCopy dtype mismatch: {src.dtype} vs {dst.dtype}")
+    _verify_grain(ctx, call, src, dst)
+
+
+def _verify_grain(ctx, call, src, dst) -> None:
+    """Report unless the transfer is a whole number of ``_GRAIN_BYTES`` grains.
+
+    That constant is the instruction's transfer grain: both addresses and the
+    byte count are constrained to it, and off the grain the instruction has no
+    defined behaviour, so this checks rather than rounds. Only static extents
+    can be checked here; a run whose length is a DimVar carries the same
+    constraint to whoever supplies the value.
+    """
+    if src.shape != dst.shape:
+        ctx.error(call, f"TmaBulkCopy shape mismatch: {src.shape} vs {dst.shape}")
+        return
+    if any(not isinstance(d, int) for d in dst.shape):
+        return
+    width = getattr(dst.dtype, "bit_width", None)
+    if not isinstance(width, int):
+        return
+    total_bits = width
+    for d in dst.shape:
+        total_bits *= d
+    if total_bits % (_GRAIN_BYTES * 8):
+        ctx.error(
+            call,
+            f"TmaBulkCopy transfer must be a multiple of {_GRAIN_BYTES} bytes, "
+            f"got {total_bits // 8}",
+        )

--- a/src/tilefoundry/ir/tir/cuda/sync/__init__.py
+++ b/src/tilefoundry/ir/tir/cuda/sync/__init__.py
@@ -1,0 +1,1 @@
+"""CUDA synchronisation objects (the Hopper mbarrier)."""

--- a/src/tilefoundry/ir/tir/cuda/sync/mbarrier.py
+++ b/src/tilefoundry/ir/tir/cuda/sync/mbarrier.py
@@ -1,0 +1,174 @@
+"""Effect-form TIR Ops for the CUDA shared-memory barrier object (mbarrier).
+
+An mbarrier is a 64-bit shared-memory word carrying an arrival count, a
+transaction-byte count and a phase parity. It is not ``Sync``, a whole-mesh
+rendezvous every participant reaches: these let a *producer* signal completion
+of work a *consumer* did not perform, which is what an asynchronous copy needs.
+**Defined but not lowered**: no CUDA emit. The implementations live at
+``include/tilefoundry/runtime/cuda/ops/mbarrier.cuh``.
+
+See [tir §2.3](docs/spec/tir.md#23-tir-ops).
+"""
+
+from __future__ import annotations
+
+from tilefoundry.ir.core import Op
+from tilefoundry.ir.core.param_def import ParamDef
+from tilefoundry.ir.core.pattern import Scalar, Tensor
+from tilefoundry.ir.core.register import register_op
+from tilefoundry.ir.types import UnitType
+from tilefoundry.ir.types.storage import StorageKind
+from tilefoundry.visitor_registry import register_typeinfer, register_verify_stmt
+
+__all__ = [
+    "MBarrierInit",
+    "MBarrierArrive",
+    "MBarrierArriveExpectTx",
+    "MBarrierExpectTx",
+    "MBarrierWaitParity",
+    "MBarrierInvalidate",
+]
+
+
+def _require_smem_barrier(ctx, call, who: str) -> None:
+    """Report unless argument 0 is a shared-memory barrier object.
+
+    The instructions take a shared-window address. A barrier in global memory
+    is not a slower barrier, it is not one at all.
+    """
+    ty = ctx.type_of(call.args[0])
+    if ty.storage != StorageKind.SMEM:
+        ctx.error(call, f"{who} barrier must be smem, got {ty.storage}")
+
+
+@register_op(dialect="T", category="sync", name="mbarrier_init")
+class MBarrierInit(Op):
+    """Arm ``barrier`` so ``arrive_count`` arrivals complete a phase.
+
+    One thread initialises; a ``Sync`` covering every thread that will use the
+    barrier must separate this from the first arrival or wait.
+    """
+
+    barrier = ParamDef(kind="input", pattern=Tensor)
+    arrive_count = ParamDef(kind="attribute", annotation=int)
+
+
+@register_typeinfer(MBarrierInit)
+def _(call: "Call", ctx: "TypeInferContext") -> UnitType:
+    return UnitType()
+
+
+@register_verify_stmt(MBarrierInit)
+def _(call: "Call", ctx: "VerifyContext") -> None:
+    count = call.target.arrive_count
+    if not isinstance(count, int) or count <= 0:
+        ctx.error(call, f"MBarrierInit.arrive_count must be a positive int, got {count!r}")
+    _require_smem_barrier(ctx, call, "MBarrierInit")
+
+
+@register_op(dialect="T", category="sync", name="mbarrier_arrive")
+class MBarrierArrive(Op):
+    """Contribute one arrival to ``barrier``'s current phase."""
+
+    barrier = ParamDef(kind="input", pattern=Tensor)
+
+
+@register_typeinfer(MBarrierArrive)
+def _(call: "Call", ctx: "TypeInferContext") -> UnitType:
+    return UnitType()
+
+
+@register_verify_stmt(MBarrierArrive)
+def _(call: "Call", ctx: "VerifyContext") -> None:
+    _require_smem_barrier(ctx, call, "MBarrierArrive")
+
+
+@register_op(dialect="T", category="sync", name="mbarrier_arrive_expect_tx")
+class MBarrierArriveExpectTx(Op):
+    """Arrive on ``barrier`` and declare ``tx_bytes`` of asynchronous data.
+
+    The phase completes when both the arrivals and the byte count are satisfied,
+    so one wait covers a copy the waiting thread did not issue. One instruction
+    rather than an ``MBarrierArrive`` beside an ``MBarrierExpectTx``.
+
+    ``tx_bytes`` MUST equal the bytes the paired copy delivers: a phase that
+    expects a different count never completes, and that failure presents as a
+    hang rather than as a wrong value.
+    """
+
+    barrier = ParamDef(kind="input", pattern=Tensor)
+    tx_bytes = ParamDef(kind="attribute", annotation=int)
+
+
+@register_typeinfer(MBarrierArriveExpectTx)
+def _(call: "Call", ctx: "TypeInferContext") -> UnitType:
+    return UnitType()
+
+
+@register_verify_stmt(MBarrierArriveExpectTx)
+def _(call: "Call", ctx: "VerifyContext") -> None:
+    tx = call.target.tx_bytes
+    if not isinstance(tx, int) or tx <= 0:
+        ctx.error(call, f"MBarrierArriveExpectTx.tx_bytes must be a positive int, got {tx!r}")
+    _require_smem_barrier(ctx, call, "MBarrierArriveExpectTx")
+
+
+@register_op(dialect="T", category="sync", name="mbarrier_expect_tx")
+class MBarrierExpectTx(Op):
+    """Declare ``tx_bytes`` against ``barrier``'s phase without arriving."""
+
+    barrier = ParamDef(kind="input", pattern=Tensor)
+    tx_bytes = ParamDef(kind="attribute", annotation=int)
+
+
+@register_typeinfer(MBarrierExpectTx)
+def _(call: "Call", ctx: "TypeInferContext") -> UnitType:
+    return UnitType()
+
+
+@register_verify_stmt(MBarrierExpectTx)
+def _(call: "Call", ctx: "VerifyContext") -> None:
+    tx = call.target.tx_bytes
+    if not isinstance(tx, int) or tx <= 0:
+        ctx.error(call, f"MBarrierExpectTx.tx_bytes must be a positive int, got {tx!r}")
+    _require_smem_barrier(ctx, call, "MBarrierExpectTx")
+
+
+@register_op(dialect="T", category="sync", name="mbarrier_wait_parity")
+class MBarrierWaitParity(Op):
+    """Block until ``barrier``'s phase parity reaches ``phase``.
+
+    The parity alternates 0, 1, 0, ... across successive completions, which is
+    what lets a fixed ring of barriers serve a pipeline of any length: stage
+    ``t`` of a ring of ``n`` waits on parity ``(t // n) & 1``.
+    """
+
+    barrier = ParamDef(kind="input", pattern=Tensor)
+    phase = ParamDef(kind="input", pattern=Scalar)
+
+
+@register_typeinfer(MBarrierWaitParity)
+def _(call: "Call", ctx: "TypeInferContext") -> UnitType:
+    return UnitType()
+
+
+@register_verify_stmt(MBarrierWaitParity)
+def _(call: "Call", ctx: "VerifyContext") -> None:
+    _require_smem_barrier(ctx, call, "MBarrierWaitParity")
+
+
+@register_op(dialect="T", category="sync", name="mbarrier_invalidate")
+class MBarrierInvalidate(Op):
+    """Release ``barrier``'s shared-memory word for other use."""
+
+    barrier = ParamDef(kind="input", pattern=Tensor)
+
+
+@register_typeinfer(MBarrierInvalidate)
+def _(call: "Call", ctx: "TypeInferContext") -> UnitType:
+    return UnitType()
+
+
+@register_verify_stmt(MBarrierInvalidate)
+def _(call: "Call", ctx: "VerifyContext") -> None:
+    _require_smem_barrier(ctx, call, "MBarrierInvalidate")

--- a/src/tilefoundry/ir/tir/cuda/warp.py
+++ b/src/tilefoundry/ir/tir/cuda/warp.py
@@ -1,0 +1,145 @@
+"""Effect-form TIR Ops for the CUDA warp-scoped exchange primitives.
+
+These ops are **defined but not lowered**: there is no CUDA codegen emit for any
+of them. The runtime implementations they name live at
+``include/tilefoundry/runtime/cuda/ops/warp.cuh`` and are exercised directly by
+``tests/integration/test_runtime_device_ops.py``; wiring the emit belongs with
+the TIR backend rebuild, and an emit written now would be rewritten by it while
+these definitions would not.
+
+See [tir §2.3](docs/spec/tir.md#23-tir-ops).
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from tilefoundry.ir.core import Op
+from tilefoundry.ir.core.param_def import ParamDef
+from tilefoundry.ir.core.pattern import Scalar
+from tilefoundry.ir.core.register import register_op
+from tilefoundry.ir.types import UnitType
+from tilefoundry.ir.types.storage import StorageKind
+from tilefoundry.visitor_registry import register_typeinfer, register_verify_stmt
+
+__all__ = ["ShuffleXor", "ShuffleElect", "WarpReduceKind", "WarpReduce"]
+
+_WARP = 32
+
+
+def _require_rmem(ctx, call, at: int, who: str, role: str) -> None:
+    """Report unless operand *at* is register-resident.
+
+    ``_WARP`` above is the lane count a shuffle's partner is chosen inside, so
+    every constraint here is stated against it rather than against a mesh.
+
+    A warp shuffle moves a value between lanes' registers. An operand in shared
+    or global memory is not wrong by a tolerance -- it names a different
+    instruction -- so this is an error rather than a note.
+    """
+    ty = ctx.type_of(call.args[at])
+    if ty.storage != StorageKind.RMEM:
+        ctx.error(call, f"{who} {role} must be rmem, got {ty.storage}")
+
+
+@register_op(dialect="T", category="warp", name="shuffle_xor")
+class ShuffleXor(Op):
+    """Exchange a value with the lane whose id differs by ``lane_mask``.
+
+    ``dst`` receives the ``src`` of lane ``laneid ^ lane_mask``. One
+    ``__shfl_xor_sync``; with masks 1, 2, 4, 8, 16 in turn it is the butterfly
+    ``WarpReduce`` is built from.
+    """
+
+    src = ParamDef(kind="input", pattern=Scalar)
+    dst = ParamDef(kind="input", pattern=Scalar)
+    lane_mask = ParamDef(kind="attribute", annotation=int)
+
+
+@register_typeinfer(ShuffleXor)
+def _(call: "Call", ctx: "TypeInferContext") -> UnitType:
+    return UnitType()
+
+
+@register_verify_stmt(ShuffleXor)
+def _(call: "Call", ctx: "VerifyContext") -> None:
+    op = call.target
+    mask = op.lane_mask
+    if not isinstance(mask, int) or not 0 < mask < _WARP:
+        ctx.error(call, f"ShuffleXor.lane_mask must be in 1..{_WARP - 1}, got {mask!r}")
+    _require_rmem(ctx, call, 0, "ShuffleXor", "src")
+    _require_rmem(ctx, call, 1, "ShuffleXor", "dst")
+    src = ctx.type_of(call.args[0])
+    dst = ctx.type_of(call.args[1])
+    if src.dtype != dst.dtype:
+        ctx.error(call, f"ShuffleXor dtype mismatch: {src.dtype} vs {dst.dtype}")
+
+
+@register_op(dialect="T", category="warp", name="shuffle_elect")
+class ShuffleElect(Op):
+    """Select exactly one thread of the leading ``width`` threads of the CTA.
+
+    ``dst`` is true on that one thread and false on every other. It is one
+    thread of the *block*, not one lane of each warp: an mbarrier armed for a
+    single arrival is only correct under the first reading.
+    """
+
+    dst = ParamDef(kind="input", pattern=Scalar)
+    width = ParamDef(kind="attribute", annotation=int)
+
+
+@register_typeinfer(ShuffleElect)
+def _(call: "Call", ctx: "TypeInferContext") -> UnitType:
+    return UnitType()
+
+
+@register_verify_stmt(ShuffleElect)
+def _(call: "Call", ctx: "VerifyContext") -> None:
+    width = call.target.width
+    if not isinstance(width, int) or width <= 0:
+        ctx.error(call, f"ShuffleElect.width must be a positive int, got {width!r}")
+    _require_rmem(ctx, call, 0, "ShuffleElect", "dst")
+
+
+class WarpReduceKind(Enum):
+    """Which combine a ``WarpReduce`` folds with."""
+
+    SUM = "sum"
+    MAX = "max"
+    MIN = "min"
+
+
+@register_op(dialect="T", category="warp", name="warp_reduce")
+class WarpReduce(Op):
+    """Fold ``src`` across the warp's 32 lanes, leaving the result in every lane.
+
+    Defined as five ``ShuffleXor`` steps with masks 16, 8, 4, 2, 1 and a combine
+    between them -- five shuffles and five combines, not a loop over 32 lanes.
+    The count is stated here rather than left to a lowering to reveal, because
+    it is the reason a caller reaches for this instead of a shared-memory fold.
+
+    ``kind`` carries the combine, the way ``Binary`` and ``Unary`` carry theirs;
+    a class per combine would differ from its siblings in nothing else.
+    """
+
+    src = ParamDef(kind="input", pattern=Scalar)
+    dst = ParamDef(kind="input", pattern=Scalar)
+    kind = ParamDef(kind="attribute", annotation=WarpReduceKind)
+
+
+@register_typeinfer(WarpReduce)
+def _(call: "Call", ctx: "TypeInferContext") -> UnitType:
+    return UnitType()
+
+
+@register_verify_stmt(WarpReduce)
+def _(call: "Call", ctx: "VerifyContext") -> None:
+    op = call.target
+    if not isinstance(op.kind, WarpReduceKind):
+        ctx.error(call, f"WarpReduce: kind must be WarpReduceKind, got {type(op.kind)}")
+    _require_rmem(ctx, call, 0, "WarpReduce", "src")
+    _require_rmem(ctx, call, 1, "WarpReduce", "dst")
+    src = ctx.type_of(call.args[0])
+    dst = ctx.type_of(call.args[1])
+    if src.dtype != dst.dtype:
+        ctx.error(call, f"WarpReduce dtype mismatch: {src.dtype} vs {dst.dtype}")

--- a/tests/integration/runtime_ops/__init__.py
+++ b/tests/integration/runtime_ops/__init__.py
@@ -1,0 +1,53 @@
+"""Compile ``device_ops.cu`` against the CUDA runtime headers, once per session.
+
+The runtime's op headers are not standalone translation units -- ``runtime.cuh``
+includes each ``ops/<op>.cuh`` in-context inside ``namespace tilefoundry::ops``
+-- so a caller includes ``runtime.cuh`` and adds two include roots: the
+repository's ``include/`` and the vendored CuTe. Those are the same two roots
+``tilefoundry.codegen.linker`` puts on its own nvcc line, recomputed here rather
+than imported because the linker's are private to codegen and this compile
+deliberately does not go through codegen.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[3]
+_HERE = Path(__file__).resolve().parent
+_ARCH = os.environ.get("TILEFOUNDRY_TEST_CUDA_ARCH", "90a")
+
+_ext = None
+
+
+def device_ops():
+    """The compiled extension, built on the first call.
+
+    ``sm_90a`` by default: the ``elect.sync``, ``mbarrier.*`` and
+    ``cp.async.bulk`` instructions these ops are made of are Hopper's, and the
+    ``a`` variants are what the architecture's own instructions need.
+    """
+    global _ext
+    if _ext is None:
+        from torch.utils.cpp_extension import load  # noqa: PLC0415
+
+        _ext = load(
+            name="tilefoundry_device_ops_test",
+            sources=[str(_HERE / "device_ops.cu")],
+            extra_include_paths=[
+                str(_ROOT / "include"),
+                str(_ROOT / "third_party" / "cutlass" / "include"),
+            ],
+            extra_cuda_cflags=[
+                "-O2",
+                "-std=c++20",
+                f"-gencode=arch=compute_{_ARCH},code=sm_{_ARCH}",
+                "--expt-relaxed-constexpr",
+            ],
+            extra_cflags=["-O2", "-std=c++20"],
+            verbose=os.environ.get("TILEFOUNDRY_TEST_BUILD_VERBOSE", "") == "1",
+        )
+    return _ext
+
+
+__all__ = ["device_ops"]

--- a/tests/integration/runtime_ops/device_ops.cu
+++ b/tests/integration/runtime_ops/device_ops.cu
@@ -1,0 +1,210 @@
+/// Device-side harness for the warp / mbarrier / TMA runtime ops.
+///
+/// These ops have no codegen emit — their TIR definitions are declared but not
+/// wired to the CUDA backend while that chain is rebuilt — so the path
+/// test_mma_tir_handwritten.py uses (author TIR, compile, let codegen emit
+/// ``tilefoundry::ops::mma``) is not open to them.
+
+/// This file is the substitute: it calls the public entries the way a
+/// hand-written kernel does, and the test around it compares to torch. It
+/// includes ``runtime.cuh`` rather than the individual ``ops/<op>.cuh``
+/// headers, which are included in-context inside ``namespace
+/// tilefoundry::ops`` and are not standalone translation units.
+
+#include <tilefoundry/runtime/cuda/runtime.cuh>
+
+#include <ATen/cuda/CUDAContext.h>
+#include <torch/extension.h>
+
+namespace ops = tilefoundry::ops;
+
+namespace {
+
+constexpr int kThreads = 256;
+
+/// warp.
+
+template <class Combine>
+__global__ void warp_reduce_kernel(const float *in, float *out) {
+    const int t = blockIdx.x * blockDim.x + threadIdx.x;
+    out[t] = ops::warp_reduce<Combine>(in[t]);
+}
+
+__global__ void shuffle_xor_kernel(const float *in, float *out, int lane_mask) {
+    const int t = blockIdx.x * blockDim.x + threadIdx.x;
+    out[t] = ops::shuffle_xor(in[t], lane_mask);
+}
+
+/// One counter per block: how many threads the elect admitted. Every entry must
+/// read 1, which is the property an arrive-count-1 mbarrier depends on.
+template <int Width> __global__ void elect_count_kernel(int *out) {
+    if (ops::shuffle_elect<Width>())
+        atomicAdd(&out[blockIdx.x], 1);
+}
+
+/// mbarrier.
+
+/// One producer thread fills a shared tile and arrives; every consumer waits on
+/// the phase. `rounds` forces the parity to flip, which is what lets a fixed
+/// ring of barriers serve an unbounded pipeline.
+__global__ void mbarrier_pipeline_kernel(const float *in, float *out, int tile,
+                                         int rounds) {
+    extern __shared__ float sm[];
+    __shared__ alignas(8) uint64_t bar;
+
+    if (ops::shuffle_elect<kThreads>())
+        ops::mbarrier_init(&bar, 1);
+    ops::sync<ops::SyncKind::syncthreads>();
+
+    for (int r = 0; r < rounds; ++r) {
+        if (ops::shuffle_elect<kThreads>()) {
+            for (int i = 0; i < tile; ++i)
+                sm[i] = in[r * tile + i] + float(r);
+            ops::mbarrier_arrive(&bar);
+        }
+        ops::mbarrier_wait_parity(&bar, unsigned(r) & 1u);
+        for (int i = threadIdx.x; i < tile; i += kThreads)
+            out[r * tile + i] = sm[i];
+        ops::sync<ops::SyncKind::syncthreads>();
+    }
+}
+
+/// tma.
+
+/// A `stages`-deep ring staged by bulk copy, each tile doubled on the way out.
+/// The producer declares the byte count on the same instruction it arrives
+/// with, so a consumer's parity wait covers the copy without a second barrier.
+template <int Stages>
+__global__ void tma_stage_kernel(const float *in, float *out, int tile,
+                                 int ntile) {
+    extern __shared__ __align__(16) float sm[];
+    __shared__ alignas(8) uint64_t bar[Stages];
+
+    if (ops::shuffle_elect<kThreads>())
+        for (int s = 0; s < Stages; ++s)
+            ops::mbarrier_init(&bar[s], 1);
+    ops::sync<ops::SyncKind::syncthreads>();
+
+    for (int t = 0; t < ntile; ++t) {
+        const int slot = t % Stages;
+        const unsigned phase = unsigned(t / Stages) & 1u;
+        if (ops::shuffle_elect<kThreads>()) {
+            ops::mbarrier_arrive_expect_tx(&bar[slot],
+                                           ops::tma_bulk_bytes<float>(tile));
+            ops::tma_bulk_copy(in + t * tile, sm + slot * tile, tile,
+                               &bar[slot]);
+        }
+        ops::mbarrier_wait_parity(&bar[slot], phase);
+        for (int i = threadIdx.x; i < tile; i += kThreads)
+            out[t * tile + i] = sm[slot * tile + i] * 2.f;
+        ops::sync<ops::SyncKind::syncthreads>();
+    }
+}
+
+/// host wrappers.
+
+void check_f32_cuda(const torch::Tensor &t, const char *what) {
+    TORCH_CHECK(t.is_cuda() && t.is_contiguous() &&
+                    t.scalar_type() == at::kFloat,
+                what, " must be a contiguous f32 CUDA tensor");
+}
+
+torch::Tensor warp_reduce_sum(torch::Tensor x) {
+    check_f32_cuda(x, "x");
+    auto out = torch::empty_like(x);
+    const int n = int(x.numel());
+    TORCH_CHECK(n % kThreads == 0, "x must be a multiple of ", kThreads);
+    warp_reduce_kernel<ops::warp_sum>
+        <<<n / kThreads, kThreads, 0, at::cuda::getCurrentCUDAStream()>>>(
+            x.data_ptr<float>(), out.data_ptr<float>());
+    return out;
+}
+
+torch::Tensor warp_reduce_max(torch::Tensor x) {
+    check_f32_cuda(x, "x");
+    auto out = torch::empty_like(x);
+    const int n = int(x.numel());
+    TORCH_CHECK(n % kThreads == 0, "x must be a multiple of ", kThreads);
+    warp_reduce_kernel<ops::warp_max>
+        <<<n / kThreads, kThreads, 0, at::cuda::getCurrentCUDAStream()>>>(
+            x.data_ptr<float>(), out.data_ptr<float>());
+    return out;
+}
+
+torch::Tensor shuffle_xor(torch::Tensor x, int64_t lane_mask) {
+    check_f32_cuda(x, "x");
+    auto out = torch::empty_like(x);
+    const int n = int(x.numel());
+    TORCH_CHECK(n % kThreads == 0, "x must be a multiple of ", kThreads);
+    shuffle_xor_kernel<<<n / kThreads, kThreads, 0,
+                         at::cuda::getCurrentCUDAStream()>>>(
+        x.data_ptr<float>(), out.data_ptr<float>(), int(lane_mask));
+    return out;
+}
+
+torch::Tensor elect_count(int64_t width, int64_t blocks) {
+    auto out = torch::zeros({blocks},
+                            torch::dtype(torch::kInt32).device(torch::kCUDA));
+    auto stream = at::cuda::getCurrentCUDAStream();
+    auto *p = out.data_ptr<int>();
+    switch (width) {
+    case 8:
+        elect_count_kernel<8><<<blocks, kThreads, 0, stream>>>(p);
+        break;
+    case 32:
+        elect_count_kernel<32><<<blocks, kThreads, 0, stream>>>(p);
+        break;
+    case 256:
+        elect_count_kernel<256><<<blocks, kThreads, 0, stream>>>(p);
+        break;
+    default:
+        TORCH_CHECK(false, "elect_count: unsupported width ", width);
+    }
+    return out;
+}
+
+torch::Tensor mbarrier_pipeline(torch::Tensor x, int64_t tile) {
+    check_f32_cuda(x, "x");
+    const int rounds = int(x.numel() / tile);
+    TORCH_CHECK(int64_t(rounds) * tile == x.numel(), "tile must divide x");
+    auto out = torch::empty_like(x);
+    mbarrier_pipeline_kernel<<<1, kThreads, size_t(tile) * sizeof(float),
+                               at::cuda::getCurrentCUDAStream()>>>(
+        x.data_ptr<float>(), out.data_ptr<float>(), int(tile), rounds);
+    return out;
+}
+
+torch::Tensor tma_stage(torch::Tensor x, int64_t tile, int64_t stages) {
+    check_f32_cuda(x, "x");
+    TORCH_CHECK(tile * sizeof(float) % 16 == 0,
+                "tma_bulk_copy needs a 16-byte multiple; tile=", tile);
+    const int ntile = int(x.numel() / tile);
+    TORCH_CHECK(int64_t(ntile) * tile == x.numel(), "tile must divide x");
+    auto out = torch::empty_like(x);
+    const size_t smem = size_t(tile) * size_t(stages) * sizeof(float);
+    auto stream = at::cuda::getCurrentCUDAStream();
+    switch (stages) {
+    case 1:
+        tma_stage_kernel<1><<<1, kThreads, smem, stream>>>(
+            x.data_ptr<float>(), out.data_ptr<float>(), int(tile), ntile);
+        break;
+    case 3:
+        tma_stage_kernel<3><<<1, kThreads, smem, stream>>>(
+            x.data_ptr<float>(), out.data_ptr<float>(), int(tile), ntile);
+        break;
+    default:
+        TORCH_CHECK(false, "tma_stage: unsupported stage count ", stages);
+    }
+    return out;
+}
+
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+    m.def("warp_reduce_sum", &warp_reduce_sum);
+    m.def("warp_reduce_max", &warp_reduce_max);
+    m.def("shuffle_xor", &shuffle_xor);
+    m.def("elect_count", &elect_count);
+    m.def("mbarrier_pipeline", &mbarrier_pipeline);
+    m.def("tma_stage", &tma_stage);
+}

--- a/tests/integration/test_runtime_device_ops.py
+++ b/tests/integration/test_runtime_device_ops.py
@@ -1,0 +1,105 @@
+"""GPU e2e for the warp, mbarrier and TMA runtime ops, against torch.
+
+Each op runs through its single public ``tilefoundry::ops`` entry from a
+hand-written kernel -- the way a model's runtime twin calls it -- and the result
+is compared to the torch expression that states the same thing. These groups
+have TIR definitions but no codegen emit, so they cannot be reached the way
+``test_mma_tir_handwritten.py`` reaches ``ops::mma``. What ties the TIR
+definition to the implementation exercised here is therefore review, not this
+test: this pins the implementation, and the emit would pin the pair.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from tests.integration.runtime_ops import device_ops
+
+_THREADS = 256
+_WARP = 32
+
+
+@pytest.fixture(scope="module")
+def ops():
+    return device_ops()
+
+
+def _lanes(n_threads: int) -> torch.Tensor:
+    """Deterministic input with both signs and no ties across a warp."""
+    g = torch.Generator(device="cpu").manual_seed(20260905)
+    return torch.randn(n_threads, generator=g).cuda()
+
+
+def test_warp_reduce_sum_matches_torch_sum(ops) -> None:
+    """Every lane holds its warp's total, so the reference broadcasts back."""
+    x = _lanes(4 * _THREADS)
+    got = ops.warp_reduce_sum(x)
+    want = x.reshape(-1, _WARP).sum(-1, keepdim=True).expand(-1, _WARP).reshape(-1)
+    torch.testing.assert_close(got, want, rtol=0, atol=1e-5)
+
+
+def test_warp_reduce_max_matches_torch_amax(ops) -> None:
+    x = _lanes(4 * _THREADS)
+    got = ops.warp_reduce_max(x)
+    want = x.reshape(-1, _WARP).amax(-1, keepdim=True).expand(-1, _WARP).reshape(-1)
+    torch.testing.assert_close(got, want, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("lane_mask", [1, 2, 4, 8, 16])
+def test_shuffle_xor_exchanges_with_the_masked_lane(ops, lane_mask: int) -> None:
+    """Lane ``l`` must receive lane ``l ^ lane_mask``'s value."""
+    x = _lanes(2 * _THREADS)
+    got = ops.shuffle_xor(x, lane_mask)
+    lane = torch.arange(_WARP, device=x.device)
+    partner = lane ^ lane_mask
+    want = x.reshape(-1, _WARP).index_select(1, partner).reshape(-1)
+    torch.testing.assert_close(got, want, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("width", [8, 32, 256])
+def test_shuffle_elect_admits_exactly_one_thread_per_block(ops, width: int) -> None:
+    """An mbarrier armed for one arrival is correct only if this is exactly 1.
+
+    a per-warp elect would make it 8 in a 256-thread block.
+    """
+    counts = ops.elect_count(width, 5)
+    assert counts.tolist() == [1] * 5
+
+
+def test_mbarrier_pipeline_flips_parity_across_rounds(ops) -> None:
+    """A consumer that reads the wrong phase is caught by the addend.
+
+    The producer adds the round index, so a tile read from the wrong phase shows
+    up as the wrong addend rather than as stale data.
+    """
+    tile, rounds = 512, 6
+    x = _lanes(tile * rounds)
+    got = ops.mbarrier_pipeline(x, tile)
+    offsets = torch.arange(rounds, device=x.device, dtype=x.dtype)
+    want = x.reshape(rounds, tile) + offsets[:, None]
+    torch.testing.assert_close(got, want.reshape(-1), rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("stages", [1, 3])
+def test_tma_bulk_copy_stages_every_tile(ops, stages: int) -> None:
+    """Every tile arrives, over a ring that does not divide the tile count.
+
+    7 tiles over a 3-deep ring is two full turns plus one, so the parity is
+    exercised in both states and the tail is not a whole number of turns.
+    """
+    tile, ntile = 1024, 7
+    x = _lanes(tile * ntile)
+    got = ops.tma_stage(x, tile, stages)
+    torch.testing.assert_close(got, x * 2.0, rtol=0, atol=0)
+
+
+def test_tma_bulk_copy_rejects_an_unaligned_tile(ops) -> None:
+    """An off-grain tile is refused, not transferred.
+
+    The instruction has no defined behaviour off the 16-byte grain, so the entry
+    refuses rather than moving something else.
+    """
+    x = _lanes(_THREADS)
+    with pytest.raises(RuntimeError, match="16-byte multiple"):
+        ops.tma_stage(x, 3, 1)

--- a/tests/ir/tir/test_cuda_mbarrier.py
+++ b/tests/ir/tir/test_cuda_mbarrier.py
@@ -1,0 +1,106 @@
+"""Cover the CUDA mbarrier definitions: shared-memory residence and counts.
+
+These ops have no CUDA emit; the definition layer is what is verifiable here.
+The implementations they name are exercised as a producer/consumer pipeline in
+``tests/integration/test_runtime_device_ops.py``.
+
+See [tir §2.3](docs/spec/tir.md#23-tir-ops).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tilefoundry.ir.core import Var, VerifyError
+from tilefoundry.ir.tir.cuda.sync.mbarrier import (
+    MBarrierArrive,
+    MBarrierArriveExpectTx,
+    MBarrierExpectTx,
+    MBarrierInit,
+    MBarrierInvalidate,
+    MBarrierWaitParity,
+)
+from tilefoundry.ir.tir.prim_function import PrimFunction
+from tilefoundry.ir.tir.stmts import Evaluate, Return, Sequential
+from tilefoundry.ir.tir.verify import verify_prim_function
+from tilefoundry.ir.types import DType, make_tensor_type
+
+_SMEM_BAR = make_tensor_type((1,), DType.i64, storage="smem")
+_GMEM_BAR = make_tensor_type((1,), DType.i64, storage="gmem")
+_PHASE = make_tensor_type((), DType.i32, storage="rmem")
+
+
+def _pf(op, *types) -> PrimFunction:
+    args = tuple(Var(type=t, name=f"a{i}") for i, t in enumerate(types))
+    return PrimFunction(
+        name="fn",
+        params=args,
+        body=Sequential(body=(Evaluate(callable=op, args=args), Return())),
+    )
+
+
+_BARRIER_ONLY = [
+    pytest.param(MBarrierArrive(), id="arrive"),
+    pytest.param(MBarrierInvalidate(), id="invalidate"),
+]
+
+
+def test_init_accepts_a_shared_barrier_and_a_positive_count() -> None:
+    verify_prim_function(_pf(MBarrierInit(arrive_count=1), _SMEM_BAR))
+
+
+@pytest.mark.parametrize("count", [0, -1])
+def test_init_refuses_a_non_positive_arrive_count(count: int) -> None:
+    """A non-positive arrive count is refused.
+
+    A phase needing zero arrivals is complete before anything is produced, which
+    turns every consumer's wait into a no-op.
+    """
+    with pytest.raises(VerifyError, match="arrive_count must be a positive int"):
+        verify_prim_function(_pf(MBarrierInit(arrive_count=count), _SMEM_BAR))
+
+
+@pytest.mark.parametrize("op", _BARRIER_ONLY)
+def test_barrier_only_entries_accept_a_shared_barrier(op) -> None:
+    verify_prim_function(_pf(op, _SMEM_BAR))
+
+
+@pytest.mark.parametrize("op", _BARRIER_ONLY)
+def test_barrier_only_entries_refuse_a_global_barrier(op) -> None:
+    with pytest.raises(VerifyError, match="barrier must be smem"):
+        verify_prim_function(_pf(op, _GMEM_BAR))
+
+
+def test_init_refuses_a_global_barrier() -> None:
+    """A barrier outside shared memory is refused.
+
+    The instructions take a shared-window address, so a barrier in global memory
+    is not a slower barrier -- it is not one at all.
+    """
+    with pytest.raises(VerifyError, match="barrier must be smem"):
+        verify_prim_function(_pf(MBarrierInit(arrive_count=1), _GMEM_BAR))
+
+
+@pytest.mark.parametrize(
+    "make", [MBarrierArriveExpectTx, MBarrierExpectTx], ids=["arrive_expect_tx", "expect_tx"]
+)
+def test_expect_tx_entries_accept_a_positive_byte_count(make) -> None:
+    verify_prim_function(_pf(make(tx_bytes=4096), _SMEM_BAR))
+
+
+@pytest.mark.parametrize(
+    "make", [MBarrierArriveExpectTx, MBarrierExpectTx], ids=["arrive_expect_tx", "expect_tx"]
+)
+@pytest.mark.parametrize("tx", [0, -16])
+def test_expect_tx_entries_refuse_a_non_positive_byte_count(make, tx: int) -> None:
+    with pytest.raises(VerifyError, match="tx_bytes must be a positive int"):
+        verify_prim_function(_pf(make(tx_bytes=tx), _SMEM_BAR))
+
+
+def test_wait_parity_accepts_a_shared_barrier_and_a_phase() -> None:
+    verify_prim_function(_pf(MBarrierWaitParity(), _SMEM_BAR, _PHASE))
+
+
+def test_wait_parity_refuses_a_global_barrier() -> None:
+    with pytest.raises(VerifyError, match="barrier must be smem"):
+        verify_prim_function(_pf(MBarrierWaitParity(), _GMEM_BAR, _PHASE))

--- a/tests/ir/tir/test_cuda_tma.py
+++ b/tests/ir/tir/test_cuda_tma.py
@@ -1,0 +1,94 @@
+"""Cover the CUDA bulk-copy definition: direction, dtype, shape and grain.
+
+The op has no CUDA emit; the definition layer is what is verifiable here. The
+implementation it names is exercised as a staged ring in
+``tests/integration/test_runtime_device_ops.py``.
+
+See [tir §2.3](docs/spec/tir.md#23-tir-ops).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tilefoundry.ir.core import Var, VerifyError
+from tilefoundry.ir.tir.cuda.memory.tma import TmaBulkCopy
+from tilefoundry.ir.tir.prim_function import PrimFunction
+from tilefoundry.ir.tir.stmts import Evaluate, Return, Sequential
+from tilefoundry.ir.tir.verify import verify_prim_function
+from tilefoundry.ir.types import DType, make_tensor_type
+
+_BAR = make_tensor_type((1,), DType.i64, storage="smem")
+
+
+def _pf(src, dst, bar=_BAR) -> PrimFunction:
+    args = tuple(
+        Var(type=t, name=n) for t, n in ((src, "src"), (dst, "dst"), (bar, "bar"))
+    )
+    return PrimFunction(
+        name="fn",
+        params=args,
+        body=Sequential(body=(Evaluate(callable=TmaBulkCopy(), args=args), Return())),
+    )
+
+
+def _ty(n, dtype=DType.f32, storage="gmem"):
+    return make_tensor_type((n,), dtype, storage=storage)
+
+
+def test_accepts_a_whole_grain_gmem_to_smem_run() -> None:
+    """8 f32 is 32 bytes: two whole 16-byte grains."""
+    verify_prim_function(_pf(_ty(8), _ty(8, storage="smem")))
+
+
+def test_refuses_the_wrong_direction() -> None:
+    """Only gmem into smem is this instruction.
+
+    This stages global into shared; the reverse is a different instruction, not this one with
+    its operands swapped.
+    """
+    with pytest.raises(VerifyError, match="source must be gmem"):
+        verify_prim_function(_pf(_ty(8, storage="smem"), _ty(8, storage="smem")))
+    with pytest.raises(VerifyError, match="destination must be smem"):
+        verify_prim_function(_pf(_ty(8), _ty(8, storage="gmem")))
+
+
+def test_refuses_a_barrier_outside_shared_memory() -> None:
+    with pytest.raises(VerifyError, match="barrier must be smem"):
+        verify_prim_function(
+            _pf(_ty(8), _ty(8, storage="smem"), make_tensor_type((1,), DType.i64, storage="gmem"))
+        )
+
+
+def test_refuses_a_dtype_change() -> None:
+    """A bulk copy moves bytes; it does not convert them."""
+    with pytest.raises(VerifyError, match="dtype mismatch"):
+        verify_prim_function(_pf(_ty(8), _ty(8, DType.bf16, storage="smem")))
+
+
+def test_refuses_a_shape_change() -> None:
+    with pytest.raises(VerifyError, match="shape mismatch"):
+        verify_prim_function(_pf(_ty(8), _ty(4, storage="smem")))
+
+
+@pytest.mark.parametrize(
+    ("n", "dtype", "byte_count"),
+    [(5, DType.f32, 20), (1, DType.f32, 4), (7, DType.bf16, 14)],
+)
+def test_refuses_a_transfer_off_the_sixteen_byte_grain(n, dtype, byte_count) -> None:
+    """A transfer off the 16-byte grain is refused.
+
+    The instruction has no defined behaviour off the grain, so this is rejected rather than
+    rounded up to the next whole one.
+    """
+    with pytest.raises(VerifyError, match=f"multiple of 16 bytes, got {byte_count}"):
+        verify_prim_function(_pf(_ty(n, dtype), _ty(n, dtype, storage="smem")))
+
+
+def test_a_bf16_run_is_measured_in_bytes_not_elements() -> None:
+    """The grain is counted in bytes, not elements.
+
+    8 bf16 is 16 bytes -- one grain -- while 8 f32 is two, so the check reads the dtype's width
+    rather than the element count.
+    """
+    verify_prim_function(_pf(_ty(8, DType.bf16), _ty(8, DType.bf16, storage="smem")))

--- a/tests/ir/tir/test_cuda_warp.py
+++ b/tests/ir/tir/test_cuda_warp.py
@@ -1,0 +1,93 @@
+"""Cover the CUDA warp-op definitions: what they accept and what they refuse.
+
+These ops have no CUDA emit, so what is verifiable here is the definition layer
+-- the operand storage and dtype agreements, and the attribute ranges the
+hardware imposes. The implementations they name are exercised against torch in
+``tests/integration/test_runtime_device_ops.py``.
+
+See [tir §2.3](docs/spec/tir.md#23-tir-ops).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tilefoundry.ir.core import Var, VerifyError
+from tilefoundry.ir.tir.cuda.warp import (
+    ShuffleElect,
+    ShuffleXor,
+    WarpReduce,
+    WarpReduceKind,
+)
+from tilefoundry.ir.tir.prim_function import PrimFunction
+from tilefoundry.ir.tir.stmts import Evaluate, Return, Sequential
+from tilefoundry.ir.tir.verify import verify_prim_function
+from tilefoundry.ir.types import DType, make_tensor_type
+
+
+def _pf(op, *types) -> PrimFunction:
+    args = tuple(Var(type=t, name=f"a{i}") for i, t in enumerate(types))
+    return PrimFunction(
+        name="fn",
+        params=args,
+        body=Sequential(body=(Evaluate(callable=op, args=args), Return())),
+    )
+
+
+def _reg(dtype: DType = DType.f32):
+    return make_tensor_type((), dtype, storage="rmem")
+
+
+def test_shuffle_xor_accepts_a_register_pair_and_an_in_warp_mask() -> None:
+    verify_prim_function(_pf(ShuffleXor(lane_mask=16), _reg(), _reg()))
+
+
+@pytest.mark.parametrize("lane_mask", [0, 32, 64, -1])
+def test_shuffle_xor_refuses_a_mask_outside_the_warp(lane_mask: int) -> None:
+    """A mask outside 1..31 is refused.
+
+    A mask of 0 exchanges a lane with itself and 32 or more names a lane that is not in this
+    warp; neither is a butterfly step.
+    """
+    with pytest.raises(VerifyError, match="lane_mask must be in 1..31"):
+        verify_prim_function(_pf(ShuffleXor(lane_mask=lane_mask), _reg(), _reg()))
+
+
+def test_shuffle_xor_refuses_an_operand_outside_registers() -> None:
+    smem = make_tensor_type((), DType.f32, storage="smem")
+    with pytest.raises(VerifyError, match="src must be rmem"):
+        verify_prim_function(_pf(ShuffleXor(lane_mask=1), smem, _reg()))
+    with pytest.raises(VerifyError, match="dst must be rmem"):
+        verify_prim_function(_pf(ShuffleXor(lane_mask=1), _reg(), smem))
+
+
+def test_shuffle_xor_refuses_a_dtype_change() -> None:
+    with pytest.raises(VerifyError, match="dtype mismatch"):
+        verify_prim_function(_pf(ShuffleXor(lane_mask=1), _reg(DType.f32), _reg(DType.bf16)))
+
+
+def test_shuffle_elect_accepts_a_positive_width() -> None:
+    verify_prim_function(_pf(ShuffleElect(width=256), _reg()))
+
+
+@pytest.mark.parametrize("width", [0, -8])
+def test_shuffle_elect_refuses_a_non_positive_width(width: int) -> None:
+    with pytest.raises(VerifyError, match="width must be a positive int"):
+        verify_prim_function(_pf(ShuffleElect(width=width), _reg()))
+
+
+@pytest.mark.parametrize("kind", list(WarpReduceKind))
+def test_warp_reduce_accepts_every_combine(kind: WarpReduceKind) -> None:
+    verify_prim_function(_pf(WarpReduce(kind=kind), _reg(), _reg()))
+
+
+def test_warp_reduce_refuses_a_kind_that_is_not_the_enum() -> None:
+    with pytest.raises(VerifyError, match="kind must be WarpReduceKind"):
+        verify_prim_function(_pf(WarpReduce(kind="sum"), _reg(), _reg()))
+
+
+def test_warp_reduce_refuses_a_dtype_change() -> None:
+    with pytest.raises(VerifyError, match="dtype mismatch"):
+        verify_prim_function(
+            _pf(WarpReduce(kind=WarpReduceKind.SUM), _reg(DType.f32), _reg(DType.bf16))
+        )


### PR DESCRIPTION
## Why
- `examples/nemotron_3_5_lightning_30b_a3b-tilelang` runs its decode step as one
  launch of 1564 generated lines of TileLang. This replaces that with handwritten
  CUDA on the path `examples/granite_4_0_h_small-cuda` already proved: a `.cu`,
  compiled on first use, launched from `@runtime_func`.
- Three primitive groups the runtime did not have had to come first: warp-scoped
  exchange, the Hopper mbarrier, and the bulk asynchronous copy.

## What
- **Runtime.** `ops::{shuffle_xor, shuffle_elect, warp_reduce}`,
  `ops::mbarrier_*`, `ops::tma_bulk_copy`. One public entry each under
  `include/tilefoundry/runtime/cuda/ops/`, implementations under `<op>/`, tested
  against torch from a hand-written kernel. `ops::reduce`'s intra-warp tier now
  folds through `warp_reduce`, so `__shfl_xor_sync` is written once.
- **TIR.** The matching ops under `ir/tir/cuda/` with types and verifier rules.
- **Kernel.** `kernels/nemotron.cu`: all 52 layers, the closing norm and the head
  in one cooperative launch of 132 CTAs (`NEMO_IMPL=cuda`). Every stage is a
  `__device__` function that a launch-per-stage path (`cuda-stages`) calls too,
  so the two cannot drift.
- **Harness.** `check_all.py` could not run against the current CLI at all;
  `dump_acts.py`, `check_layer.py`, `check_moe.py` and `compare_impls.py` are
  new. The weight layout moves to `packing.py` so the CUDA paths no longer need
  TileLang installed.

## Contract
- `docs/spec/runtime.md` §3.7–3.9 and `docs/spec/tir.md` gain the three groups.
  None admits a tier — a warp shuffle's operand is a register scalar, an mbarrier
  is not a sharded tensor, and the two bulk forms differ in operands, not tiers.
- The TIR ops carry **no codegen emit**: that chain is being rebuilt.
- `NEMO_IMPL` defaults to `mega` still. The CUDA path is opt-in.

## Risk
- **It is 2.19x slower** (153.6 tok/s against 335.9 at ctx 32, same session).
  `reports/WHY_SLOWER.md` takes it apart: which layers, what the grid barrier
  costs, what is fixable, and the four hypotheses that measurement killed.
- No `ncu` on this machine (ERR_NVGPUCTRPERM), so that report rests on `nsys`
  tracing and wall-clock against byte counts — no occupancy, no stall reasons.
- Nothing in CI exercises `examples/`, and the ruff config excludes it. The
  evidence for the kernel is the reports in that directory, not the test suites.
- Because there is no emit, what ties each TIR op to the implementation it names
  is review, not the machine.

Verified: `tilefoundry-verify source` 983/0 and `installed` 161/0.
